### PR TITLE
Allocated Types, Array Lengths, Array LowerBounds are global for cfa-construction

### DIFF
--- a/VSharp.SILI.Core/Database.fs
+++ b/VSharp.SILI.Core/Database.fs
@@ -110,18 +110,17 @@ type Lemmas(m : MethodBase, offset : int) =
 type Paths(m : MethodBase, offset : int) =
     let id = Database.idOfVertex m offset
     let parsed = new Dictionary<level, HashSet<path>>()
-    let used = HashSet<path>()
+    let used = HashSet<path>() // TODO: ``used'' set should be moved to Analyzer
     member x.Add (path : path) =
+        if used.Contains path then used.Remove path |> ignore
         Database.addPath id path
         let paths = Dict.getValueOrUpdate parsed path.lvl (fun () -> new HashSet<_>())
         paths.Add path |> ignore
-    member x.OfLevel all lvl =
+    member x.OfLevel lvl =
         let paths  = Dict.tryGetValue2 parsed lvl (fun () -> new HashSet<_>()) |> List.ofSeq
-        if all then paths
-        else
-            let paths = List.filter (used.Contains >> not) paths
-            List.iter (fun (path : path) -> Prelude.releaseAssert(used.Add(path))) paths
-            paths
+        let paths = List.filter (used.Contains >> not) paths
+        List.iter (fun (path : path) -> Prelude.releaseAssert(used.Add(path))) paths
+        paths
 
 
 type Queries(m : MethodBase, offset : int) =

--- a/VSharp.SILI.Core/InterpreterBase.fs
+++ b/VSharp.SILI.Core/InterpreterBase.fs
@@ -257,7 +257,11 @@ type public ExplorerBase() =
 
     member x.ExploreAndCompose codeLoc state k =
         x.Explore codeLoc (Seq.map (fun summary ->
+            Logger.trace "ExploreAndCompose: got summary state = %s" (Memory.Dump summary.state)
+            Logger.trace "ExploreAndCompose: Left state = %s" (Memory.Dump state)
             let newStates = Memory.composeStates state summary.state
+            List.iter (Memory.Dump >> (Logger.trace "ExploreAndCompose: Result after composition %s")) newStates
+
             let result = Memory.fillHoles state summary.result
             List.map (withFst result) newStates) >> List.ofSeq >> List.concat >> k)
 

--- a/VSharp.SILI.Core/InterpreterBase.fs
+++ b/VSharp.SILI.Core/InterpreterBase.fs
@@ -188,7 +188,7 @@ type public ExplorerBase() =
                         x.ReduceFunctionSignature state cctor None (Specified []) false (fun state ->
                         x.ReduceConcreteCall cctor state  (List.map (snd >> removeCallSiteResultAndPopStack)))
                     | None -> state |> List.singleton
-                k (states |> List.map (fun state -> Memory.withPathCondition state (!!typeInitialized)))
+                k states // TODO: make assumption ``Memory.withPathCondition state (!!typeInitialized)''
 
     member x.CallAbstractMethod (funcId : IFunctionIdentifier) state k =
         __insufficientInformation__ "Can't call abstract method %O, need more information about the object type" funcId

--- a/VSharp.SILI.Core/Memory.fs
+++ b/VSharp.SILI.Core/Memory.fs
@@ -907,8 +907,10 @@ module internal Memory =
     let private composeConcreteDictionaries state dict dict' mapValue =
         dict' |> PersistentDict.fold (fun acc k v ->
                         let k = composeTime state k
-                        assert (not <| PersistentDict.contains k dict)
-                        PersistentDict.add k (mapValue v) acc
+                        if (PersistentDict.contains k dict) then
+                            assert (PersistentDict.find dict k = mapValue v)
+                            acc
+                        else PersistentDict.add k (mapValue v) acc
                  ) dict
 
     let private composeArrayCopyInfo state (addr, reg) =

--- a/VSharp.SILI.Core/Memory.fs
+++ b/VSharp.SILI.Core/Memory.fs
@@ -41,6 +41,9 @@ type callSite = { sourceMethod : System.Reflection.MethodBase; offset : offset
             | :? callSite as other when x.sourceMethod.Equals(other.sourceMethod) -> x.offset.CompareTo(other.offset)
             | :? callSite as other -> x.sourceMethod.MetadataToken.CompareTo(other.sourceMethod.MetadataToken)
             | _ -> -1
+    override x.ToString() =
+        sprintf "sourceMethod = %s\noffset=%x\nopcode=%O\ncalledMethod = %s"
+            (Reflection.GetFullMethodName x.sourceMethod) x.offset x.opCode (Reflection.GetFullMethodName x.calledMethod)
 
 type exceptionRegister =
     | Unhandled of term

--- a/VSharp.SILI.Core/Terms.fs
+++ b/VSharp.SILI.Core/Terms.fs
@@ -21,7 +21,7 @@ type stackKey =
             match x with
             | ThisKey m -> sprintf "%s##this" (Reflection.GetFullMethodName m)
             | ParameterKey pi -> sprintf "%O##%O" pi.Member pi
-            | LocalVariableKey (lvi, m) -> sprintf "%O##%O" m (lvi.ToString())
+            | LocalVariableKey (lvi, m) -> sprintf "%O##%s" (Reflection.GetFullMethodName m) (lvi.ToString())
         fullname.GetDeterministicHashCode()
     interface IComparable with
         override x.CompareTo(other: obj) =

--- a/VSharp.SILI/CFA.fs
+++ b/VSharp.SILI/CFA.fs
@@ -99,7 +99,9 @@ module public CFA =
                 true
             else false
         override x.ToString() = x.commonToString()
-        member x.commonToString() = sprintf "%s ID:[%d --> %d] Offset:[%x --> %x] Method:%O" x.Type x.Src.Id x.Dst.Id x.Src.Offset x.Dst.Offset x.Method
+        member x.commonToString() =
+            sprintf "%s ID:[%d --> %d] Offset:[%x --> %x] Method:%s"
+                x.Type x.Src.Id x.Dst.Id x.Src.Offset x.Dst.Offset (Reflection.GetFullMethodName x.Method)
 
 
     type 'a unitBlock =
@@ -201,9 +203,7 @@ module public CFA =
                 else callSiteResults
             let k states =
                 let propagateStateAfterCall acc state =
-                    let state = Memory.PopStack state
                     assert(path.state.frames = state.frames) // TODO: assert fails in ClassesSimple.Test1
-                    assert(path.state.stack = state.stack)
                     x.PrintLog "propagation through callEdge" callSite
                     x.PrintLog "call edge: composition left" (Memory.Dump path.state)
                     x.PrintLog "call edge: composition result" (Memory.Dump state)

--- a/VSharp.SILI/Instruction.fs
+++ b/VSharp.SILI/Instruction.fs
@@ -22,7 +22,7 @@ type ip =
         match x with
         | Instruction _ -> true
         | _ -> false
-    member x.Vertex () =
+    member x.Offset () =
         match x with
         | Instruction i -> i
         | _              -> internalfail "Could not get vertex from destination"
@@ -175,7 +175,8 @@ module internal Instruction =
         isCallOpCode opCode || isNewObjOpCode opCode
     let isFinallyClause (ehc : ExceptionHandlingClause) =
         ehc.Flags = ExceptionHandlingClauseOptions.Finally
-    let shouldExecuteFinallyClause srcOffset dstOffset (ehc : ExceptionHandlingClause) =
+    let shouldExecuteFinallyClause (src : ip) (dst : ip) (ehc : ExceptionHandlingClause) =
+        let srcOffset, dstOffset = src.Offset(), dst.Offset()
         let isInside offset = ehc.TryOffset <= offset && offset < ehc.TryOffset + ehc.TryLength
         isInside srcOffset && not <| isInside dstOffset
 

--- a/VSharp.SILI/Interpreter.fs
+++ b/VSharp.SILI/Interpreter.fs
@@ -249,6 +249,7 @@ and public ILInterpreter() as this =
             k results) k) id
         | _ -> internalfail "unexpected number of arguments"
     member private x.ReduceMethodBaseCall (methodBase : MethodBase) (state : state) (k : state list -> 'a) =
+        let k = List.map Memory.PopStack >> k
         let dealWithResult (term : term, state : state) =
             if term <> Nop then {state with returnRegister = Some term}
             else {state with returnRegister = None}

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/DoubleInitializeObjects.-51226744.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/DoubleInitializeObjects.-51226744.gold
@@ -1,0 +1,8 @@
+METHOD: System.Void VSharp.Test.Tests.PDR.DoubleInitializeObjects()
+RESULT: Totally 1 state:
+<VOID>
+MEMORY DUMP:
+--------------- Types tokens: ---------------
+1 ==> System.Object
+2 ==> System.Object
+Initialized types = { VSharp.Test.Tests.PDR, System.Object }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/MultipleInitializeStaticFieldsInCfa.-202758858.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/MultipleInitializeStaticFieldsInCfa.-202758858.gold
@@ -1,0 +1,17 @@
+METHOD: System.Int32 VSharp.Test.Tests.PDR.MultipleInitializeStaticFieldsInCfa(System.Int32)
+RESULT: Totally 2 states:
+a
+MEMORY DUMP:
+Path condition: a <= 10
+--------------- Static fields: ---------------
+x ==> {VSharp.Test.Tests.PDR+ClassWithOneStaticField <- a}
+Initialized types = { VSharp.Test.Tests.PDR+ClassWithOneStaticField, VSharp.Test.Tests.PDR }
+
+20
+MEMORY DUMP:
+Path condition: !(a <= 10)
+--------------- Static fields: ---------------
+x ==> {
+        VSharp.Test.Tests.PDR+ClassWithOneStaticField <- 20
+    }
+Initialized types = { VSharp.Test.Tests.PDR+ClassWithOneStaticField, VSharp.Test.Tests.PDR }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/NewObjInLoop.-51226744.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/NewObjInLoop.-51226744.gold
@@ -1,0 +1,11 @@
+METHOD: System.Void VSharp.Test.Tests.PDR.NewObjInLoop()
+RESULT: Totally 1 state:
+<VOID>
+MEMORY DUMP:
+--------------- Types tokens: ---------------
+2 ==> System.Object
+2.2 ==> System.Object
+2.2.2 ==> System.Object
+2.2.2.2 ==> System.Object
+2.2.2.2.2 ==> System.Object
+Initialized types = { VSharp.Test.Tests.PDR, System.Object }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/NewObjInLoop1.-51226744.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/NewObjInLoop1.-51226744.gold
@@ -1,0 +1,12 @@
+METHOD: System.Void VSharp.Test.Tests.PDR.NewObjInLoop1()
+RESULT: Totally 1 state:
+<VOID>
+MEMORY DUMP:
+--------------- Types tokens: ---------------
+2 ==> VSharp.Test.Tests.PDR+ClassWithOneField
+4 ==> System.Object
+4.4 ==> System.Object
+4.4.4 ==> System.Object
+4.4.4.4 ==> System.Object
+4.4.4.4.4 ==> System.Object
+Initialized types = { VSharp.Test.Tests.PDR, System.Object, VSharp.Test.Tests.PDR+ClassWithOneField }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/SameN.383462754.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/SameN.383462754.gold
@@ -1,0 +1,10 @@
+METHOD: System.Boolean VSharp.Test.Tests.PDR.SameN(System.Int32)
+RESULT: Totally 1 state:
+True
+MEMORY DUMP:
+--------------- Fields: ---------------
+_a ==> {2 <- VSharp.Test.Tests.PDR+A STRUCT [
+	| x ~> n]}
+--------------- Types tokens: ---------------
+2 ==> VSharp.Test.Tests.PDR+ClassWithStructInside
+Initialized types = { VSharp.Test.Tests.PDR+A, VSharp.Test.Tests.PDR, System.Object, VSharp.Test.Tests.PDR+ClassWithStructInside }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestAllocatedType_1.-2039345157.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestAllocatedType_1.-2039345157.gold
@@ -1,0 +1,7 @@
+METHOD: System.Int32 VSharp.Test.Tests.PDR.TestAllocatedType_1()
+RESULT: Totally 1 state:
+1
+MEMORY DUMP:
+--------------- Types tokens: ---------------
+2 ==> VSharp.Test.Tests.Methods.VirtualC
+Initialized types = { VSharp.Test.Tests.Methods.VirtualC, VSharp.Test.Tests.Methods.VirtualB, VSharp.Test.Tests.PDR, System.Object }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestAllocatedType_2.-2039345157.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestAllocatedType_2.-2039345157.gold
@@ -1,0 +1,7 @@
+METHOD: System.Int32 VSharp.Test.Tests.PDR.TestAllocatedType_2()
+RESULT: Totally 1 state:
+1
+MEMORY DUMP:
+--------------- Types tokens: ---------------
+2 ==> VSharp.Test.Tests.Methods.VirtualC
+Initialized types = { VSharp.Test.Tests.Methods.VirtualC, VSharp.Test.Tests.Methods.VirtualB, VSharp.Test.Tests.PDR, System.Object }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestAllocatedType_3.-2039345157.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestAllocatedType_3.-2039345157.gold
@@ -1,0 +1,7 @@
+METHOD: System.Int32 VSharp.Test.Tests.PDR.TestAllocatedType_3()
+RESULT: Totally 1 state:
+1
+MEMORY DUMP:
+--------------- Types tokens: ---------------
+2 ==> VSharp.Test.Tests.Methods.VirtualC
+Initialized types = { VSharp.Test.Tests.Methods.VirtualC, VSharp.Test.Tests.Methods.VirtualB, VSharp.Test.Tests.PDR, System.Object }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestAllocatedType_4.-1339916414.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestAllocatedType_4.-1339916414.gold
@@ -1,0 +1,15 @@
+METHOD: System.Int32 VSharp.Test.Tests.PDR.TestAllocatedType_4(System.Boolean)
+RESULT: Totally 2 states:
+42
+MEMORY DUMP:
+Path condition: !f
+Initialized types = { VSharp.Test.Tests.PDR }
+
+100
+MEMORY DUMP:
+Path condition: f
+--------------- Fields: ---------------
+x ==> {2 <- 100}
+--------------- Types tokens: ---------------
+2 ==> VSharp.Test.Tests.PDR+ClassWithOneField
+Initialized types = { VSharp.Test.Tests.PDR, System.Object, VSharp.Test.Tests.PDR+ClassWithOneField }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestConcreteArray.-202758858.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestConcreteArray.-202758858.gold
@@ -1,0 +1,11 @@
+METHOD: System.Int32 VSharp.Test.Tests.PDR.TestConcreteArray(System.Int32)
+RESULT: Totally 1 state:
+1
+MEMORY DUMP:
+--------------- Array contents: ---------------
+System.Int32[] ==> {2[0] <- 1; 2[1] <- 2; 2[2] <- x}
+--------------- Array lengths: ---------------
+System.Int32[] ==> {2[0] <- 3}
+--------------- Types tokens: ---------------
+2 ==> System.Int32[]
+Initialized types = { System.Array, VSharp.Test.Tests.PDR, System.Runtime.CompilerServices.RuntimeHelpers }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestForCycle_5x.-202758858.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestForCycle_5x.-202758858.gold
@@ -1,0 +1,5 @@
+METHOD: System.Int32 VSharp.Test.Tests.PDR.TestForCycle_5x(System.Int32)
+RESULT: Totally 1 state:
+x + x + x + x + x
+MEMORY DUMP:
+Initialized types = { VSharp.Test.Tests.PDR }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestLengths_1.-2039345157.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestLengths_1.-2039345157.gold
@@ -1,0 +1,9 @@
+METHOD: System.Int32 VSharp.Test.Tests.PDR.TestLengths_1()
+RESULT: Totally 1 state:
+20
+MEMORY DUMP:
+--------------- Array lengths: ---------------
+System.Int32[,] ==> {2[0] <- 4; 2[1] <- 5}
+--------------- Types tokens: ---------------
+2 ==> System.Int32[,]
+Initialized types = { System.Array, VSharp.Test.Tests.PDR, System.Int32[,] }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestLengths_2.-2039345157.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestLengths_2.-2039345157.gold
@@ -1,0 +1,9 @@
+METHOD: System.Int32 VSharp.Test.Tests.PDR.TestLengths_2()
+RESULT: Totally 1 state:
+20
+MEMORY DUMP:
+--------------- Array lengths: ---------------
+System.Int32[,] ==> {2[0] <- 4; 2[1] <- 5}
+--------------- Types tokens: ---------------
+2 ==> System.Int32[,]
+Initialized types = { System.Array, VSharp.Test.Tests.PDR, System.Int32[,] }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestLengths_3.-2039345157.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestLengths_3.-2039345157.gold
@@ -1,0 +1,10 @@
+METHOD: System.Int32 VSharp.Test.Tests.PDR.TestLengths_3()
+RESULT: Totally 1 state:
+15
+MEMORY DUMP:
+--------------- Array lengths: ---------------
+System.Int32[,] ==> {2[0] <- 4; 2[1] <- 5; 3[0] <- 15; 3[1] <- 1}
+--------------- Types tokens: ---------------
+2 ==> System.Int32[,]
+3 ==> System.Int32[,]
+Initialized types = { System.Array, VSharp.Test.Tests.PDR, System.Int32[,] }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestLengths_4.-2039345157.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestLengths_4.-2039345157.gold
@@ -1,0 +1,10 @@
+METHOD: System.Int32 VSharp.Test.Tests.PDR.TestLengths_4()
+RESULT: Totally 1 state:
+15
+MEMORY DUMP:
+--------------- Array lengths: ---------------
+System.Int32[,] ==> {2[0] <- 4; 2[1] <- 5; 3[0] <- 15; 3[1] <- 1}
+--------------- Types tokens: ---------------
+2 ==> System.Int32[,]
+3 ==> System.Int32[,]
+Initialized types = { System.Array, VSharp.Test.Tests.PDR, System.Int32[,] }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestLengths_5.-2039345157.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestLengths_5.-2039345157.gold
@@ -1,0 +1,11 @@
+METHOD: System.Int32 VSharp.Test.Tests.PDR.TestLengths_5()
+RESULT: Totally 1 state:
+100
+MEMORY DUMP:
+--------------- Array lengths: ---------------
+System.Int32[] ==> {3[0] <- 100}
+System.Int32[,] ==> {2[0] <- 4; 2[1] <- 5}
+--------------- Types tokens: ---------------
+2 ==> System.Int32[,]
+3 ==> System.Int32[]
+Initialized types = { System.Array, VSharp.Test.Tests.PDR, System.Int32[,] }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestLowerBound_1.-2039345157.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestLowerBound_1.-2039345157.gold
@@ -1,0 +1,11 @@
+METHOD: System.Int32 VSharp.Test.Tests.PDR.TestLowerBound_1()
+RESULT: Totally 1 state:
+0
+MEMORY DUMP:
+--------------- Array lengths: ---------------
+System.Int32[] ==> {3[0] <- 100}
+System.Int32[,] ==> {2[0] <- 4; 2[1] <- 5}
+--------------- Types tokens: ---------------
+2 ==> System.Int32[,]
+3 ==> System.Int32[]
+Initialized types = { System.Array, VSharp.Test.Tests.PDR, System.Int32[,] }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestLowerBound_2.-1339916414.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestLowerBound_2.-1339916414.gold
@@ -1,0 +1,21 @@
+METHOD: System.Int32 VSharp.Test.Tests.PDR.TestLowerBound_2(System.Boolean)
+RESULT: Totally 2 states:
+0
+MEMORY DUMP:
+Path condition: !f
+--------------- Array lengths: ---------------
+System.Int32[] ==> {2[0] <- 100}
+--------------- Types tokens: ---------------
+2 ==> System.Int32[]
+Initialized types = { System.Array, VSharp.Test.Tests.PDR }
+
+0
+MEMORY DUMP:
+Path condition: f
+--------------- Array lengths: ---------------
+System.Int32[] ==> {2[0] <- 100}
+System.Int32[,] ==> {3[0] <- 4; 3[1] <- 5}
+--------------- Types tokens: ---------------
+2 ==> System.Int32[]
+3 ==> System.Int32[,]
+Initialized types = { System.Array, VSharp.Test.Tests.PDR, System.Int32[,] }

--- a/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestPopStackWithReservedVariable.-2039345157.gold
+++ b/VSharp.Test/Golds/VSharp/Test/Tests/PDR/TestPopStackWithReservedVariable.-2039345157.gold
@@ -1,0 +1,5 @@
+METHOD: System.Int32 VSharp.Test.Tests.PDR.TestPopStackWithReservedVariable()
+RESULT: Totally 1 state:
+100
+MEMORY DUMP:
+Initialized types = { VSharp.Test.Tests.PDR }

--- a/VSharp.Utils/MappedStack.fs
+++ b/VSharp.Utils/MappedStack.fs
@@ -35,15 +35,23 @@ module public MappedStack =
         let idx = Dict.tryGetValue peaks key 1ul
         addToStack key value stack idx
 
+    let containsKey key (contents, peaks) = Map.containsKey key peaks && Map.containsKey (makeExtendedKey key peaks.[key]) contents
+
     let remove (contents, peaks) key =
         let idx = peakIdx peaks key
-        assert (idx > defaultPeak)
-        let key' = makeExtendedKey key idx
-        let contents' = Map.remove key' contents
-        let peaks' =
-            if idx = 1ul then Map.remove key peaks
-            else Map.add key (idx - 1ul) peaks
-        contents', peaks'
+        match containsKey key (contents, peaks) with
+        | false ->
+            // this is a case when variable was reserved but never assigned
+            assert (idx = 0u)
+            (contents, peaks)
+        | _ ->
+            assert (idx > defaultPeak)
+            let key' = makeExtendedKey key idx
+            let contents' = Map.remove key' contents
+            let peaks' =
+                if idx = 1ul then Map.remove key peaks
+                else Map.add key (idx - 1ul) peaks
+            contents', peaks'
 
     let tryFind key (contents, peaks) =
         let idx = peakIdx peaks key
@@ -56,7 +64,6 @@ module public MappedStack =
         | Some term -> term
         | None -> failwith "Attempt get value by key which is not presented in stack"
 
-    let containsKey key (contents, peaks) = Map.containsKey key peaks && Map.containsKey (makeExtendedKey key peaks.[key]) contents
 
     let map f (contents, peaks) =
         Map.fold

--- a/VSharp.Utils/MappedStack.fs
+++ b/VSharp.Utils/MappedStack.fs
@@ -39,12 +39,7 @@ module public MappedStack =
 
     let remove (contents, peaks) key =
         let idx = peakIdx peaks key
-        match containsKey key (contents, peaks) with
-        | false ->
-            // this is a case when variable was reserved but never assigned
-            assert (idx = 0u)
-            (contents, peaks)
-        | _ ->
+        if containsKey key (contents, peaks) then
             assert (idx > defaultPeak)
             let key' = makeExtendedKey key idx
             let contents' = Map.remove key' contents
@@ -52,6 +47,10 @@ module public MappedStack =
                 if idx = 1ul then Map.remove key peaks
                 else Map.add key (idx - 1ul) peaks
             contents', peaks'
+        else
+            // this is a case when variable was reserved but never assigned
+            assert (idx = 0u)
+            contents, peaks
 
     let tryFind key (contents, peaks) =
         let idx = peakIdx peaks key


### PR DESCRIPTION
Future improvements: dominators should calculcated for gaining right sets of Allocated Types, Array Lengths and ArrayLowerBounds (named **Sets**). Currently, when execution goes to vertex with different **Sets** new vertex is created. Exception is vertices inside cycle (Such vertices are hacked to be visited only once with unique operationalStack for cfa-construction termination). 

