### PR TITLE
WIP: Preallocated objects

### DIFF
--- a/LoanExam/EmploymentHandler.cs
+++ b/LoanExam/EmploymentHandler.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace LoanExam.ActionPointsHandler;
+
+public enum Employment
+{
+    EmploymentContract=0,
+    IndividualEntrepreneur=1,
+    Freelancer =2,
+    Retired=3,
+    Unemployed=4
+}
+
+public class EmploymentHandler
+{
+    private readonly ILogger _logger;
+
+    public EmploymentHandler(ILogger logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+    
+    public int EmploymentActionPoint(Employment personalInfoEmployment, int personalInfoAge)
+    {
+        int points = 0;
+        switch (personalInfoEmployment)
+        {
+            case Employment.EmploymentContract:
+                points += 14;
+                break;
+            case Employment.IndividualEntrepreneur:
+                points += 12;
+                break;
+            case Employment.Freelancer:
+                points += 8;
+                break;
+            case Employment.Retired:
+                points += personalInfoAge switch
+                {
+                    < 70 => 5,
+                    _ => 0
+                };
+                break;
+        }
+
+        return points;
+    }
+}

--- a/LoanExam/LoanExam.csproj
+++ b/LoanExam/LoanExam.csproj
@@ -9,9 +9,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <Reference Include="Microsoft.Extensions.Logging.Abstractions">
-        <HintPath>..\..\..\..\..\usr\local\share\dotnet\shared\Microsoft.AspNetCore.App\6.0.6\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
-      </Reference>
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     </ItemGroup>
-
 </Project>

--- a/LoanExam/LoanExam.csproj
+++ b/LoanExam/LoanExam.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <Reference Include="Microsoft.Extensions.Logging.Abstractions">
+        <HintPath>..\..\..\..\..\usr\local\share\dotnet\shared\Microsoft.AspNetCore.App\6.0.6\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+      </Reference>
+    </ItemGroup>
+
+</Project>

--- a/LoanExamTests/LoanExamTests.csproj
+++ b/LoanExamTests/LoanExamTests.csproj
@@ -27,9 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Reference Include="Microsoft.Extensions.Logging.Abstractions">
-        <HintPath>..\..\..\..\..\usr\local\share\dotnet\shared\Microsoft.AspNetCore.App\6.0.6\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
-      </Reference>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     </ItemGroup>
 
 </Project>

--- a/LoanExamTests/LoanExamTests.csproj
+++ b/LoanExamTests/LoanExamTests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\LoanExam\LoanExam.csproj" />
+      <ProjectReference Include="..\VSharp.API\VSharp.API.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Reference Include="Microsoft.Extensions.Logging.Abstractions">
+        <HintPath>..\..\..\..\..\usr\local\share\dotnet\shared\Microsoft.AspNetCore.App\6.0.6\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+      </Reference>
+    </ItemGroup>
+
+</Project>

--- a/LoanExamTests/UnitTest1.cs
+++ b/LoanExamTests/UnitTest1.cs
@@ -1,0 +1,45 @@
+using LoanExam.ActionPointsHandler;
+using Microsoft.Extensions.Logging;
+using VSharp;
+
+namespace LoanExamTests;
+
+
+public class Logger : ILogger
+{
+    public string A { get; }
+
+    public Logger(string a)
+    {
+        A = a;
+    }
+    
+    public IDisposable BeginScope<TState>(TState state)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+        var map = new Dictionary<Type, object>()
+        {
+            { typeof(ILogger), new Logger("AAA") }
+        };
+        
+        TestGenerator.CoverAndRun<EmploymentHandler>(map);
+    }
+}

--- a/LoanExamTests/Usings.cs
+++ b/LoanExamTests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/LoanExamTests/issues.md
+++ b/LoanExamTests/issues.md
@@ -1,0 +1,6 @@
+## ```testInfo/memoryRepr/typeRepr``` types
+I update testInfo.memory.types before serializing test information to files.
+While strings are OK-ish in terms of the ability to obtain type information, it still concerns me that
+```Type -> String```, ```String -> Type``` have to happen twice.
+Any objections against changing the structure of the source code in a way that strings appear only on app boundaries:
+just before and right after serialization/deserialization?

--- a/VSharp.Runner/RunnerProgram.cs
+++ b/VSharp.Runner/RunnerProgram.cs
@@ -175,7 +175,7 @@ namespace VSharp.Runner
                     var type = ResolveType(assembly, className);
                     if (type != null)
                     {
-                        PostProcess(TestGenerator.Cover(type, output.FullName));
+                        PostProcess(TestGenerator.Cover(type, null, output.FullName));
                     }
                 }
             });

--- a/VSharp.SILI.Core/State.fs
+++ b/VSharp.SILI.Core/State.fs
@@ -87,8 +87,12 @@ type arrayCopyInfo =
         override x.ToString() =
             sprintf "    source address: %O, from %O ranging %O elements into %O index with cast to %O;\n\r    updates: %O" x.srcAddress x.srcIndex x.length x.dstIndex x.dstSightType (MemoryRegion.toString "        " x.contents)
 
-type model =
-    { state : state; subst : IDictionary<ISymbolicConstantSource, term>; complete : bool }
+type model = {
+    state : state
+    subst : IDictionary<ISymbolicConstantSource, term>
+    complete : bool
+}
+    
 with
     member x.Complete value =
         if x.complete then

--- a/VSharp.SILI/Options.fs
+++ b/VSharp.SILI/Options.fs
@@ -1,5 +1,7 @@
 ﻿namespace VSharp.Interpreter.IL
 
+open System
+open System.Collections.Generic
 open System.Diagnostics
 
 type searchMode =
@@ -20,5 +22,9 @@ type executionMode =
     | ConcolicMode
     | SymbolicMode
 
-type SiliOptions =
-    {explorationMode : explorationMode; executionMode : executionMode; recThreshold : uint32}
+type SiliOptions = {
+    explorationMode : explorationMode
+    executionMode : executionMode
+    recThreshold : uint32
+    preallocatedMap: Option<IDictionary<Type, Object>>
+}

--- a/VSharp.SILI/SILI.fs
+++ b/VSharp.SILI/SILI.fs
@@ -11,8 +11,7 @@ open VSharp.Core
 open CilStateOperations
 open VSharp.Solver
 
-type public SILI(options : SiliOptions) =
-
+type public SILI(options : SiliOptions) =    
     let statistics = SILIStatistics()
     let infty = UInt32.MaxValue
     let emptyState = Memory.EmptyState()
@@ -57,7 +56,7 @@ type public SILI(options : SiliOptions) =
 
     let reportState reporter isError method cmdArgs state =
         try
-            match TestGenerator.state2test isError method cmdArgs state with
+            match TestGenerator.state2test isError method cmdArgs state options.preallocatedMap with
             | Some test -> reporter test
             | None -> ()
         with :? InsufficientInformationException as e ->

--- a/VSharp.SILI/TestGenerator.fs
+++ b/VSharp.SILI/TestGenerator.fs
@@ -120,9 +120,12 @@ module TestGenerator =
                 test.Expected <- term2obj model cilState.state indices test retVal
             Some test
 
-    let state2test isError (m : MethodBase) cmdArgs (cilState : cilState) =
+    let state2test isError (m : MethodBase) cmdArgs (cilState : cilState) preallocatedMap =
         let indices = Dictionary<concreteHeapAddress, int>()
-        let test = UnitTest m
+        let test = match preallocatedMap with
+            | Some map -> UnitTest(m, map)
+            | None -> UnitTest(m)
+            
         let hasException =
             match cilState.state.exceptionsRegister with
             | Unhandled e ->

--- a/VSharp.Test/IntegrationTests.cs
+++ b/VSharp.Test/IntegrationTests.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using Microsoft.FSharp.Core;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -98,11 +99,11 @@ namespace VSharp.Test
                 var methodInfo = innerCommand.Test.Method.MethodInfo;
                 try
                 {
-                    _options = new SiliOptions
-                        (
+                    _options = new SiliOptions(
                             explorationMode.NewTestCoverageMode(coverageZone.MethodZone, searchMode.GuidedMode),
                             _executionMode,
-                            _recThresholdForTest
+                            _recThresholdForTest,
+                            new FSharpOption<IDictionary<Type, object>>(null)
                         );
                     SILI explorer = new SILI(_options);
                     UnitTests unitTests = new UnitTests(Directory.GetCurrentDirectory());

--- a/VSharp.Utils/UnitTest.fs
+++ b/VSharp.Utils/UnitTest.fs
@@ -140,7 +140,9 @@ type UnitTest private (m : MethodBase, info : testInfo, preallocatedObjectMap: I
                 fullName = loggerType.FullName
             }
             r
-            
+        
+        // TODO: this is for Logger implementation only
+        // needs to be implemented in a generic form    
         let updInfo info: testInfo =
             let types = info.memory.types |> Array.map(fun x ->
                 if x.fullName.Contains "Logger"

--- a/VSharp.Utils/VSharp.Utils.fsproj
+++ b/VSharp.Utils/VSharp.Utils.fsproj
@@ -50,5 +50,4 @@
     <ItemGroup>
       <ProjectReference Include="..\VSharp.CSharpUtils\VSharp.CSharpUtils.csproj" />
     </ItemGroup>
-
 </Project>

--- a/VSharp.sln
+++ b/VSharp.sln
@@ -20,6 +20,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VSharp.Runner", "VSharp.Run
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VSharp.API", "VSharp.API\VSharp.API.csproj", "{C908A11C-B910-4283-A718-DA6A69E19D7F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoanExamTests", "LoanExamTests\LoanExamTests.csproj", "{77B22F3A-EE2F-4B42-ABEA-FDABE31EAE7E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LoanExam", "LoanExam\LoanExam.csproj", "{E2821F93-ED10-4835-B73A-A986B4D73E71}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -93,5 +97,17 @@ Global
 		{C908A11C-B910-4283-A718-DA6A69E19D7F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C908A11C-B910-4283-A718-DA6A69E19D7F}.DebugTailRec|Any CPU.ActiveCfg = Debug|Any CPU
 		{C908A11C-B910-4283-A718-DA6A69E19D7F}.DebugTailRec|Any CPU.Build.0 = Debug|Any CPU
+		{77B22F3A-EE2F-4B42-ABEA-FDABE31EAE7E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{77B22F3A-EE2F-4B42-ABEA-FDABE31EAE7E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{77B22F3A-EE2F-4B42-ABEA-FDABE31EAE7E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{77B22F3A-EE2F-4B42-ABEA-FDABE31EAE7E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{77B22F3A-EE2F-4B42-ABEA-FDABE31EAE7E}.DebugTailRec|Any CPU.ActiveCfg = Debug|Any CPU
+		{77B22F3A-EE2F-4B42-ABEA-FDABE31EAE7E}.DebugTailRec|Any CPU.Build.0 = Debug|Any CPU
+		{E2821F93-ED10-4835-B73A-A986B4D73E71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2821F93-ED10-4835-B73A-A986B4D73E71}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2821F93-ED10-4835-B73A-A986B4D73E71}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2821F93-ED10-4835-B73A-A986B4D73E71}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2821F93-ED10-4835-B73A-A986B4D73E71}.DebugTailRec|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2821F93-ED10-4835-B73A-A986B4D73E71}.DebugTailRec|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
# PLEASE DON'T MERGE THIS PR. THIS IS FOR THE DISCUSSION
Please consider LoanExamTests/UnitTest1.cs Test1

```
        var map = new Dictionary<Type, object>()
        {
            { typeof(ILogger), new Logger("AAA") }
        };
        
        TestGenerator.CoverAndRun<EmploymentHandler>(map);
```

Automatic dependency creation was insufficient because in my case it's quite common that classes and their dependencies are located in different assemblies. This scenario is not supported in the "constructors" branch. Also, I believe that Mocks are required very often, so there should be a way to define mocks for the tests.

## ```testInfo/memoryRepr/typeRepr``` types
I update testInfo.memory.types before serializing test information to files.
While strings are OK-ish in terms of the ability to obtain type information, it still concerns me that
```Type -> String```, ```String -> Type``` have to happen twice.
Any objections against changing the structure of the source code in a way that strings appear only on app boundaries:
just before and right after serialization/deserialization or against the proposed public API?