### PR TITLE
[fix] Suspended states are infinitely picked in guided mode with weighted searcher

### DIFF
--- a/VSharp.SILI/TargetedSearcher.fs
+++ b/VSharp.SILI/TargetedSearcher.fs
@@ -84,10 +84,6 @@ type GuidedSearcher(maxBound, threshold : uint, baseSearcher : IForwardSearcher,
     let calculateTarget (state : cilState): codeLocation option =
         targetCalculator.CalculateTarget state
 
-    let suspend (state : cilState) : unit =
-        state.suspended <- true
-    let resume (state : cilState) : unit =
-        state.suspended <- false
     let violatesRecursionLevel s =
         let optCurrLoc = tryCurrentLoc s
         match optCurrLoc with
@@ -175,6 +171,10 @@ type GuidedSearcher(maxBound, threshold : uint, baseSearcher : IForwardSearcher,
     let update parent newStates =
         baseSearcher.Update (parent, newStates)
         updateTargetedSearchers parent newStates
+
+    let suspend (state : cilState) : unit =
+        state.suspended <- true
+        update state Seq.empty
 
     let setTargetOrSuspend state =
         match calculateTarget state with


### PR DESCRIPTION
Weighted searcher cannot add suspended a stated to storage, but the state is mutable, and it can be made suspended when it is already in storage. When guided searcher picks a state from its base searcher (and it is a weighted searcher), it can make it suspended, but the state remains in storage and is picked again and again infinitely. As a result, some tests fall into infinite recursion.

How to reproduce: run test `ForSimple` with `SearchStrategy.ShortestDistance`

