### PR TITLE
Fixes for concrete memory

### DIFF
--- a/VSharp.InternalCalls/String.fs
+++ b/VSharp.InternalCalls/String.fs
@@ -12,13 +12,17 @@ module internal String =
     let CtorOfCharArray state args =
         assert (List.length args = 2)
         let this, arrayRef = List.item 0 args, List.item 1 args
+        let ctor state arrayRef k =
+            let states = Memory.StringCtorOfCharArray state arrayRef this
+            match states with
+            | [state] -> k (Nop, state)
+            | _ -> __notImplemented__()
         BranchStatementsOnNull state arrayRef
-            (fun state k -> k (Nop, state))
+            // TODO: if array is 'null', constructor should return String.Empty, which is interned #bug
             (fun state k ->
-                let states = Memory.StringCtorOfCharArray state arrayRef this
-                match states with
-                | [state] -> k (Nop, state)
-                | _ -> __notImplemented__())
+                let arrayRef = TypeOf arrayRef |> NullRef
+                ctor state arrayRef k)
+            (fun state k -> ctor state arrayRef k)
             id
 
     let CtorFromReplicatedChar state args =

--- a/VSharp.SILI.Core/API.fs
+++ b/VSharp.SILI.Core/API.fs
@@ -398,7 +398,10 @@ module API =
             ref
 
         let AllocateDefaultClass state typ =
-            if typ = typeof<string> then Memory.allocateString state ""
+            if typ = typeof<string> then
+                // Allocating not empty string, because it should not be interned
+                // Constructor will mutate whole string
+                Memory.allocateString state (String('\000', 1))
             else Memory.allocateClass state typ
 
         let AllocateDefaultArray state lengths typ =
@@ -452,14 +455,31 @@ module API =
             | _ -> internalfailf "Clearing array: expected heapRef, but got %O" array
 
         let StringFromReplicatedChar state string char length =
-            match string.term with
-            | HeapRef(address, sightType) ->
-                assert(Memory.mostConcreteTypeOfHeapRef state address sightType = typeof<string>)
+            let cm = state.concreteMemory
+            let concreteChar = Memory.tryTermToObj state char
+            let concreteLen = Memory.tryTermToObj state length
+            let symbolicCase address =
                 let arrayType = typeof<char>, 1, true
                 Copying.fillArray state address arrayType (makeNumber 0) length char
                 Memory.writeLengthSymbolic state address (makeNumber 0) arrayType (add length (makeNumber 1))
                 Memory.writeArrayIndex state address [length] arrayType (Concrete '\000' typeof<char>)
                 Memory.writeClassField state address Reflection.stringLengthField length
+            match string.term, concreteChar, concreteLen with
+            | HeapRef({term = ConcreteHeapAddress a} as address, sightType), Some (:? char as c), Some (:? int as len)
+                when cm.Contains a ->
+                    assert(Memory.mostConcreteTypeOfHeapRef state address sightType = typeof<string>)
+                    let string = String(c, len)
+                    cm.Remove a
+                    cm.Allocate a string
+            | HeapRef({term = ConcreteHeapAddress a} as address, sightType), _, None
+            | HeapRef({term = ConcreteHeapAddress a} as address, sightType), None, _
+                when cm.Contains a ->
+                    assert(Memory.mostConcreteTypeOfHeapRef state address sightType = typeof<string>)
+                    Memory.unmarshall state a
+                    symbolicCase address
+            | HeapRef(address, sightType), _, _ ->
+                assert(Memory.mostConcreteTypeOfHeapRef state address sightType = typeof<string>)
+                symbolicCase address
             | _ -> internalfailf "Creating string from replicated char: expected heapRef, but got %O" string
 
         let IsTypeInitialized state typ = Memory.isTypeInitialized state typ
@@ -493,8 +513,8 @@ module API =
             | _ -> internalfailf "counting array elements: expected heap reference, but got %O" arrayRef
 
         let StringLength state strRef = Memory.lengthOfString state strRef
-        let StringCtorOfCharArray state arrayRef dstRef =
-            match dstRef.term with
+        let StringCtorOfCharArray state arrayRef stringRef =
+            match stringRef.term with
             | HeapRef({term = ConcreteHeapAddress dstAddr} as address, typ) ->
                 assert(Memory.mostConcreteTypeOfHeapRef state address typ = typeof<string>)
                 Branching.guardedStatedMap (fun state arrayRef ->
@@ -507,7 +527,7 @@ module API =
                     state arrayRef
             | HeapRef _
             | Union _ -> __notImplemented__()
-            | _ -> internalfailf "constructing string from char array: expected string reference, but got %O" dstRef
+            | _ -> internalfailf "constructing string from char array: expected string reference, but got %O" stringRef
 
         let ComposeStates state state' = Memory.composeStates state state'
         let WLP state pc' = PC.mapPC (Memory.fillHoles state) pc' |> PC.union state.pc

--- a/VSharp.SILI.Core/ConcreteMemory.fs
+++ b/VSharp.SILI.Core/ConcreteMemory.fs
@@ -1,133 +1,223 @@
 namespace VSharp.Core
 
+open System
+open System.Collections.Generic
+open System.Runtime.Serialization
+open System.Runtime.CompilerServices
 open VSharp
+open VSharp.Utils
 
-module internal PhysToVirt =
+[<CustomEquality;NoComparison>]
+type physicalAddress = {object : obj}
+    with
+    override x.GetHashCode() = RuntimeHelpers.GetHashCode(x.object)
+    override x.Equals(o : obj) =
+        match o with
+        | :? physicalAddress as other ->
+            Object.ReferenceEquals(x.object, other.object)
+        | _ -> false
+    override x.ToString() = PrettyPrinting.printConcrete x.object
 
-    let find (state : state) obj = PersistentDict.find state.physToVirt {object = obj}
+type public ConcreteMemory private (physToVirt, virtToPhys) =
 
-module internal ConcreteMemory =
+    let mutable physToVirt = physToVirt
+    let mutable virtToPhys = virtToPhys
 
-// ----------------------------- Primitives -----------------------------
+// ----------------------------- Helpers -----------------------------
 
-    let deepCopy (state : state) =
-        let cm = state.concreteMemory
-        let cm' = System.Collections.Generic.Dictionary<concreteHeapAddress, physicalAddress>()
-        let cmSeq = Seq.map (|KeyValue|) cm
-        let updateOne acc (k, v : physicalAddress) =
-            let v' = {object = v.object} // TODO: deep copy object
-            cm'.Add(k, v')
-            PersistentDict.add v' k acc
-        let physToVirt = Seq.fold updateOne PersistentDict.empty cmSeq
-        state.physToVirt <- physToVirt
-        { state with state.concreteMemory = cm' }
-
-    let getObject (physicalAddress : physicalAddress) = physicalAddress.object
-
-    let contains (cm : concreteMemory) address =
-        cm.ContainsKey address
-
-    let tryFind (cm : concreteMemory) address =
-        let result = ref {object = null}
-        if cm.TryGetValue(address, result) then
-            getObject result.Value |> Some
-        else None
-
-// ----------------------------- Allocation -----------------------------
-
-    let allocate (state : state) address (obj : obj) =
-        let cm = state.concreteMemory
-        assert(cm.ContainsKey address |> not)
-        let physicalAddress = {object = obj}
-        cm.Add(address, physicalAddress)
-        state.physToVirt <- PersistentDict.add physicalAddress address state.physToVirt
-
-// ------------------------------- Reading -------------------------------
-
-    let readObject (cm : concreteMemory) address =
-        assert(cm.ContainsKey address)
-        cm.[address] |> getObject
-
-    let readClassField (cm : concreteMemory) address (field : fieldId) =
-        let object = readObject cm address
-        let fieldInfo = Reflection.getFieldInfo field
-        fieldInfo.GetValue(object)
-
-    let readArrayIndex (cm : concreteMemory) address (indices : int list) =
-        match readObject cm address with
-        | :? System.Array as array -> array.GetValue(Array.ofList indices)
-        | :? System.String as string when List.length indices = 1 -> string.[List.head indices] :> obj
-        | obj -> internalfailf "reading array index from concrete memory: expected to read array, but got %O" obj
-
-    let private getArrayIndicesWithValues (array : System.Array) =
+    let getArrayIndicesWithValues (array : Array) =
         let ubs = List.init array.Rank array.GetUpperBound
         let lbs = List.init array.Rank array.GetLowerBound
         let indices = List.map2 (fun lb ub -> [lb .. ub]) lbs ubs |> List.cartesian
         indices |> Seq.map (fun index -> index, array.GetValue(Array.ofList index))
 
-    let getAllArrayData (cm : concreteMemory) address =
-        match readObject cm address with
-        | :? System.Array as array -> getArrayIndicesWithValues array
-        | :? System.String as string -> string.ToCharArray() |> getArrayIndicesWithValues
-        | obj -> internalfailf "reading array data concrete memory: expected to read array, but got %O" obj
+    let copiedObjects = Dictionary<physicalAddress, physicalAddress>()
 
-    let readArrayLowerBound (cm : concreteMemory) address dimension =
-        match readObject cm address with
-        | :? System.Array as array -> array.GetLowerBound(dimension)
-        | :? System.String when dimension = 0 -> 0
-        | obj -> internalfailf "reading array lower bound from concrete memory: expected to read array, but got %O" obj
+    let rec deepCopyObject (phys : physicalAddress) k =
+        let obj = phys.object
+        let typ = if obj = null then null else obj.GetType()
+        match obj with
+        | null -> k phys
+        | _ when TypeUtils.isPrimitive typ || typ.IsEnum || typ.IsPointer -> k phys
+        | :? System.Reflection.Pointer -> k phys
+        | _ -> deepCopyComplex phys typ k
 
-    let readArrayLength (cm : concreteMemory) address dimension =
-        match readObject cm address with
-        | :? System.Array as array -> array.GetLength(dimension)
-        | :? System.String as string when dimension = 0 -> string.Length
-        | obj -> internalfailf "reading array length from concrete memory: expected to read array, but got %O" obj
+    and deepCopyComplex (phys : physicalAddress) typ k =
+        let copied = ref {object = null}
+        if copiedObjects.TryGetValue(phys, copied) then k copied.Value
+        else createCopyComplex phys typ k
+
+    and createCopyComplex (phys : physicalAddress) typ k =
+        let obj = phys.object
+        match obj with
+        | :? Array as a when typ.GetElementType().IsPrimitive ->
+            let phys' = {object = a.Clone()}
+            copiedObjects.Add(phys, phys')
+            k phys'
+        | :? Array as a ->
+            let rank = a.Rank
+            let dims = Array.init rank id
+            let lengths = Array.map a.GetLength dims
+            let lowerBounds = Array.map a.GetLowerBound dims
+            let a' = Array.CreateInstance(typ.GetElementType(), lengths, lowerBounds)
+            let phys' = {object = a'}
+            copiedObjects.Add(phys, phys')
+            let indices = ArrayHelper.allIndicesOfArray (Array.toList lowerBounds) (Array.toList lengths)
+            let copyIndex _ (index : int list) k =
+                let index = List.toArray index
+                deepCopyObject {object = a.GetValue index} (fun v' ->
+                a'.SetValue(v'.object, index) |> k)
+            Cps.List.foldlk copyIndex () (Seq.toList indices) (fun _ ->
+            k phys')
+        | :? String as s ->
+            let phys' = {object = String(s)}
+            copiedObjects.Add(phys, phys')
+            k phys'
+        | _ when typ.IsClass || typ.IsValueType ->
+            let obj' = FormatterServices.GetUninitializedObject typ
+            let phys' = {object = obj'}
+            copiedObjects.Add(phys, phys')
+            let fields = Reflection.fieldsOf false typ
+            let copyField _ (_, field : System.Reflection.FieldInfo) k =
+                deepCopyObject {object = field.GetValue obj} (fun v' ->
+                field.SetValue(obj', v'.object) |> k)
+            Cps.List.foldlk copyField () (Seq.toList fields) (fun _ ->
+            k phys')
+        | _ -> internalfailf "ConcreteMemory, deepCopyObject: unexpected object %O" obj
+
+// ----------------------------- Constructor -----------------------------
+
+    new () =
+        let physToVirt = Dictionary<physicalAddress, concreteHeapAddress>()
+        let virtToPhys = Dictionary<concreteHeapAddress, physicalAddress>()
+        ConcreteMemory(physToVirt, virtToPhys)
+
+// ----------------------------- Primitives -----------------------------
+
+    member private x.ReadObject address =
+        assert(virtToPhys.ContainsKey address)
+        virtToPhys[address].object
+
+    member private x.WriteObject address obj =
+        assert(virtToPhys.ContainsKey address)
+        let physicalAddress = {object = obj}
+        virtToPhys[address] <- physicalAddress
+
+// ------------------------------- Copying -------------------------------
+
+    interface IConcreteMemory with
+
+        override x.Copy() =
+            let physToVirt' = Dictionary<physicalAddress, concreteHeapAddress>()
+            let virtToPhys' = Dictionary<concreteHeapAddress, physicalAddress>()
+            copiedObjects.Clear()
+            for kvp in physToVirt do
+                let phys, virt = kvp.Key, kvp.Value
+                let phys' = deepCopyObject phys id
+                if virtToPhys.ContainsKey virt then
+                    virtToPhys'.Add(virt, phys')
+                physToVirt'.Add(phys', virt)
+            ConcreteMemory(physToVirt', virtToPhys')
+
+// ----------------------------- Primitives -----------------------------
+
+        override x.Contains address =
+            virtToPhys.ContainsKey address
+
+        // TODO: leave only one function #refactor
+        override x.VirtToPhys virtAddress = x.ReadObject virtAddress
+
+        override x.TryVirtToPhys virtAddress =
+            let result = ref {object = null}
+            if virtToPhys.TryGetValue(virtAddress, result) then
+                Some result.Value.object
+            else None
+
+        override x.PhysToVirt physAddress =
+            let cm = x :> IConcreteMemory
+            match cm.TryPhysToVirt physAddress with
+            | Some address -> address
+            | None -> internalfailf "PhysToVirt: unable to get virtual address for object %O" physAddress
+
+        override x.TryPhysToVirt physAddress =
+            let result = ref List.empty
+            if physToVirt.TryGetValue({object = physAddress}, result) then
+                Some result.Value
+            else None
+
+// ----------------------------- Allocation -----------------------------
+
+        override x.Allocate address (obj : obj) =
+            assert(virtToPhys.ContainsKey address |> not)
+            let physicalAddress = {object = obj}
+            virtToPhys.Add(address, physicalAddress)
+            if obj = String.Empty then physToVirt[physicalAddress] <- address
+            else physToVirt.Add(physicalAddress, address)
+
+// ------------------------------- Reading -------------------------------
+
+        override x.ReadClassField address (field : fieldId) =
+            let object = x.ReadObject address
+            let fieldInfo = Reflection.getFieldInfo field
+            fieldInfo.GetValue(object)
+
+        override x.ReadArrayIndex address (indices : int list) =
+            match x.ReadObject address with
+            | :? Array as array -> array.GetValue(Array.ofList indices)
+            | :? String as string when List.length indices = 1 -> string.[List.head indices] :> obj
+            | obj -> internalfailf "reading array index from concrete memory: expected to read array, but got %O" obj
+
+        override x.GetAllArrayData address =
+            match x.ReadObject address with
+            | :? Array as array -> getArrayIndicesWithValues array
+            | :? String as string -> string.ToCharArray() |> getArrayIndicesWithValues
+            | obj -> internalfailf "reading array data concrete memory: expected to read array, but got %O" obj
+
+        override x.ReadArrayLowerBound address dimension =
+            match x.ReadObject address with
+            | :? Array as array -> array.GetLowerBound(dimension)
+            | :? String when dimension = 0 -> 0
+            | obj -> internalfailf "reading array lower bound from concrete memory: expected to read array, but got %O" obj
+
+        override x.ReadArrayLength address dimension =
+            match x.ReadObject address with
+            | :? Array as array -> array.GetLength(dimension)
+            | :? String as string when dimension = 0 -> string.Length
+            | obj -> internalfailf "reading array length from concrete memory: expected to read array, but got %O" obj
 
 // ------------------------------- Writing -------------------------------
 
-    let private writeObject (state : state) address obj =
-        let cm = state.concreteMemory
-        assert(cm.ContainsKey address)
-        let physicalAddress = {object = obj}
-        state.concreteMemory.[address] <- physicalAddress
+        override x.WriteClassField address (field : fieldId) value =
+            let object = x.ReadObject address
+            let fieldInfo = Reflection.getFieldInfo field
+            fieldInfo.SetValue(object, value)
 
-    let writeClassField (state : state) address (field : fieldId) value =
-        let object = readObject state.concreteMemory address
-        let fieldInfo = Reflection.getFieldInfo field
-        fieldInfo.SetValue(object, value)
-        writeObject state address object
+        override x.WriteArrayIndex address (indices : int list) value =
+            match x.ReadObject address with
+            | :? Array as array ->
+                array.SetValue(value, Array.ofList indices)
+            // TODO: strings must be immutable! This is used by copying, so copy string another way #hack
+            | :? String as string when List.length indices = 1 ->
+                let charArray = string.ToCharArray()
+                charArray.SetValue(value, List.head indices)
+                let newString = String(charArray)
+                x.WriteObject address newString
+            | obj -> internalfailf "writing array index to concrete memory: expected to read array, but got %O" obj
 
-    let writeArrayIndex (state : state) address (indices : int list) value =
-        match readObject state.concreteMemory address with
-        | :? System.Array as array ->
-            array.SetValue(value, Array.ofList indices)
-            writeObject state address array
-        // TODO: strings must be immutable! This is used by copying, so copy string another way #hack
-        | :? System.String as string when List.length indices = 1 ->
-            let charArray = string.ToCharArray()
-            charArray.SetValue(value, List.head indices)
-            let newString = System.String(charArray)
-            writeObject state address newString
-        | obj -> internalfailf "writing array index to concrete memory: expected to read array, but got %O" obj
+        override x.InitializeArray address (rfh : RuntimeFieldHandle) =
+            match x.ReadObject address with
+            | :? Array as array -> RuntimeHelpers.InitializeArray(array, rfh)
+            | obj -> internalfailf "initializing array in concrete memory: expected to read array, but got %O" obj
 
-    let initializeArray (state : state) address (rfh : System.RuntimeFieldHandle) =
-        match readObject state.concreteMemory address with
-        | :? System.Array as array ->
-            System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(array, rfh)
-            writeObject state address array
-        | obj -> internalfailf "initializing array in concrete memory: expected to read array, but got %O" obj
+        override x.CopyCharArrayToString arrayAddress stringAddress =
+            let array = x.ReadObject arrayAddress :?> char array
+            let string = new string(array) :> obj
+            x.WriteObject stringAddress string
+            let physAddress = {object = string}
+            physToVirt[physAddress] <- stringAddress
 
-    let copyCharArrayToString (state : state) arrayAddress stringAddress =
-        let array = readObject state.concreteMemory arrayAddress :?> char array
-        let string = new string(array) :> obj
-        writeObject state stringAddress string
-        state.physToVirt <- PersistentDict.add {object = string} stringAddress state.physToVirt
+    // ------------------------------- Remove -------------------------------
 
-// ------------------------------- Remove -------------------------------
-
-    let remove (state : state) address =
-        let cm = state.concreteMemory
-        let object = readObject cm address
-        let removed = state.concreteMemory.Remove address
-        assert removed
-        state.physToVirt <- PersistentDict.remove {object = object} state.physToVirt
+        override x.Remove address =
+            let removed = virtToPhys.Remove address
+            assert removed

--- a/VSharp.SILI/TestGenerator.fs
+++ b/VSharp.SILI/TestGenerator.fs
@@ -36,7 +36,7 @@ module TestGenerator =
                     // TODO: normalize model (for example, try to minimize lengths of generated arrays)
                     if length > 128 then raise <| InsufficientInformationException "Test generation for too large buffers disabled for now"
                     let contents = Array.init length (fun i ->
-                        let indices = Seq.delinearizeArrayIndex i lengths lowerBounds
+                        let indices = ArrayHelper.delinearizeArrayIndex i lengths lowerBounds
                         let indexTerms = indices |> Seq.map (fun i -> Concrete i Types.IndexType) |> List.ofSeq
                         ArrayIndex(cha, indexTerms, arrayType) |> eval)
                     let repr = test.MemoryGraph.AddArray typ contents lengths lowerBounds index

--- a/VSharp.Test/IntegrationTests.cs
+++ b/VSharp.Test/IntegrationTests.cs
@@ -132,7 +132,7 @@ namespace VSharp.Test
 
             private readonly SearchStrategy _baseSearchStrat;
             private readonly CoverageZone _baseCoverageZone;
-            
+
             public TestSvmCommand(
                 TestCommand innerCommand,
                 int? expectedCoverage,
@@ -150,13 +150,13 @@ namespace VSharp.Test
 
                 _expectedCoverage = TestContext.Parameters[ExpectedCoverageParameterName] == null ?
                     expectedCoverage : int.Parse(TestContext.Parameters[ExpectedCoverageParameterName]);
-                
+
                 _recThresholdForTest = recThresholdForTest;
                 _executionMode = execMode;
-                
+
                 _timeout = TestContext.Parameters[TimeoutParameterName] == null ?
                     timeout : int.Parse(TestContext.Parameters[TimeoutParameterName]);
-                
+
                 _releaseBranches = TestContext.Parameters[ReleaseBranchesParameterName] == null ?
                     releaseBranches : bool.Parse(TestContext.Parameters[ReleaseBranchesParameterName]);
 
@@ -187,14 +187,14 @@ namespace VSharp.Test
             private TestResult Explore(TestExecutionContext context)
             {
                 IStatisticsReporter reporter = null;
-                    
+
                 var csvReportPath = TestContext.Parameters[CsvPathParameterName];
                 if (csvReportPath != null)
                 {
                     reporter = new CsvStatisticsReporter(
                         csvReportPath,
                         "TestResults",
-                        TestContext.Parameters[RunIdParameterName] ?? "" 
+                        TestContext.Parameters[RunIdParameterName] ?? ""
                     );
                 }
 
@@ -208,7 +208,7 @@ namespace VSharp.Test
                     _baseSearchStrat,
                     _baseCoverageZone
                 );
-                    
+
                 try
                 {
                     UnitTests unitTests = new UnitTests(Directory.GetCurrentDirectory());
@@ -235,13 +235,13 @@ namespace VSharp.Test
 
                         var method = Application.getMethod(unitTest.Method);
                         var approximateCoverage = explorer.Statistics.GetApproximateCoverage(method);
-                        
+
                         if (approximateCoverage >= _expectedCoverage)
                         {
                             explorer.Stop();
                         }
                     }
-                    
+
                     void GenerateErrorAndCheckCoverage(UnitTest unitTest)
                     {
                         unitTests.GenerateError(unitTest);
@@ -274,7 +274,7 @@ namespace VSharp.Test
                         TestsGenerated = unitTests.UnitTestsCount,
                         TestsOutputDirectory = unitTests.TestDirectory.FullName
                     };
-                    
+
                     if (unitTests.UnitTestsCount != 0 || unitTests.ErrorsCount != 0)
                     {
                         TestContext.Out.WriteLine("Starting coverage tool...");
@@ -319,7 +319,7 @@ namespace VSharp.Test
         public TestMethod BuildFrom(IMethodInfo method, NUnit.Framework.Internal.Test suite)
         {
             var defaultParameters = method.GetParameters().Select(
-                parameter => TypeUtils.defaultOf(parameter.ParameterType)).ToArray();
+                parameter => Reflection.defaultOf(parameter.ParameterType)).ToArray();
             var parameters = new TestCaseParameters(defaultParameters);
             if (method.ReturnType.Type != typeof(void))
                 parameters.ExpectedResult = null;

--- a/VSharp.Test/Tests/LoanExam/CreditCalculator.cs
+++ b/VSharp.Test/Tests/LoanExam/CreditCalculator.cs
@@ -8,7 +8,7 @@ namespace LoanExam;
 public class CreditResult
 {
     public bool CreditIssued { get; set; }
-    
+
     public double Percent { get; set; }
 }
 
@@ -37,17 +37,17 @@ public class CreditCalculationService
             return SumPoints;
         }
 
-        SumPoints += creditInfo.Deposit == Deposit.None 
-            ? 0 
+        SumPoints += creditInfo.Deposit == Deposit.None
+            ? 0
             : 8;
-        
+
         return SumPoints;
     }
 
     private int CalculateByCriminal(bool certificateOfNoCriminalRecord)
     {
-        return certificateOfNoCriminalRecord 
-            ? 15 
+        return certificateOfNoCriminalRecord
+            ? 15
             : 0;
     }
 
@@ -109,23 +109,23 @@ public class CreditCalculationService
         }
     }
 
-    [TestSvm(95, 0, -1, false, strat: SearchStrategy.Interleaved, releaseBranches: false)]
+    [TestSvm(95, 0, 20, false, strat: SearchStrategy.Interleaved, releaseBranches: false)]
     public CreditResult Build(Request request)
     {
         var SumPoints = 0;
-        
+
         SumPoints += CalculateByAge(request.Personality.Age, request.CreditInfo);
         SumPoints += CalculateByCriminal(request.CertificateOfNoCriminalRecord);
         SumPoints += CalculateByEmployment(request.Personality.Employment, request.Personality.Age);
         SumPoints += CalculateByCreditInfo(request.CreditInfo!);
         SumPoints += CalculateByOtherCredits(request.OtherCredits, request.CreditInfo!.Purpose);
-       
+
         var result = new CreditResult
         {
             Percent = 0,
             CreditIssued = SumPoints >= 80
         };
-        
+
         if (SumPoints < 80)
         {
             return result;

--- a/VSharp.Utils/Collections.fs
+++ b/VSharp.Utils/Collections.fs
@@ -18,19 +18,6 @@ module public Seq =
         if Seq.isEmpty s then Empty
         else Cons (Seq.head s, Seq.tail s)
 
-    let delinearizeArrayIndex idx (lengths : int array) (lowerBounds : int array) =
-        let detachOne (acc, lensProd) dim =
-            let curOffset = acc / lensProd
-            let lb = if lowerBounds = null then 0 else lowerBounds.[dim]
-            let curIndex = curOffset + lb
-            let rest = acc % lensProd
-            let lensProd = if dim = lengths.Length - 1 then 1 else lensProd / lengths.[dim + 1]
-            curIndex, (rest, lensProd)
-        let mutable lenProd = 1
-        for i in 1 .. lengths.Length - 1 do
-            lenProd <- lenProd * lengths.[i]
-        Array.mapFold detachOne (idx, lenProd) (Array.init lengths.Length id) |> fst
-
 module public List =
     let rec private mappedPartitionAcc f left right = function
         | [] -> (List.rev left, List.rev right)
@@ -90,6 +77,24 @@ module public List =
         | [x] -> [f x]
         | x::xs -> x::(mapLast f xs)
         | [] -> []
+
+module public ArrayHelper =
+
+    let delinearizeArrayIndex idx (lengths : int array) (lowerBounds : int array) =
+        let detachOne (acc, lensProd) dim =
+            let curOffset = acc / lensProd
+            let lb = if lowerBounds = null then 0 else lowerBounds.[dim]
+            let curIndex = curOffset + lb
+            let rest = acc % lensProd
+            let lensProd = if dim = lengths.Length - 1 then 1 else lensProd / lengths.[dim + 1]
+            curIndex, (rest, lensProd)
+        let mutable lenProd = 1
+        for i in 1 .. lengths.Length - 1 do
+            lenProd <- lenProd * lengths.[i]
+        Array.mapFold detachOne (idx, lenProd) (Array.init lengths.Length id) |> fst
+
+    let allIndicesOfArray lowerBounds lengths =
+        List.map2 (fun lb len -> [lb .. lb + len - 1]) lowerBounds lengths |> List.cartesian
 
 module public Map =
     let public add2 (map : Map<'a, 'b>) key value = map.Add(key, value)

--- a/VSharp.Utils/MemoryGraph.fs
+++ b/VSharp.Utils/MemoryGraph.fs
@@ -149,7 +149,7 @@ and MemoryGraph(repr : memoryRepr, mocker : ITypeMockSerializer) =
             let arr = obj :?> Array
             repr.contents |> Array.iteri (fun i r ->
                 let value = decodeValue r
-                let indices = Seq.delinearizeArrayIndex i lens lbs
+                let indices = ArrayHelper.delinearizeArrayIndex i lens lbs
                 arr.SetValue(value, indices))
 
     and decodeObject (repr : obj) obj =

--- a/VSharp.Utils/TypeUtils.fs
+++ b/VSharp.Utils/TypeUtils.fs
@@ -103,11 +103,6 @@ module TypeUtils =
         if box value = null then null
         else value.GetType()
 
-    let defaultOf (t : Type) =
-        if t.IsValueType && Nullable.GetUnderlyingType(t) = null && not t.ContainsGenericParameters
-            then Activator.CreateInstance t
-            else null
-
     // TODO: wrap Type, cache size there
     let internalSizeOf (typ: Type) : int32 = // Reflection hacks, don't touch! Marshal.SizeOf lies!
         let meth = DynamicMethod("GetManagedSizeImpl", typeof<uint32>, null);


### PR DESCRIPTION
- added IConcreteMemory interface
- implemented deep copy for concrete memory
- state fork uses concrete memory deep copy
- fixed string internal calls: constructor of char array
- style fixes
- TODO: string constructor of char array creates new string instance, but if char array is null, it should return empty string, which is interned and may be already allocated, so in this case constructor should return existing reference