### PR TITLE
[fix] Allocate value-type this and byref parameters on stack

### DIFF
--- a/VSharp.SILI.Core/API.fs
+++ b/VSharp.SILI.Core/API.fs
@@ -266,7 +266,7 @@ module API =
         let EmptyState() = Memory.makeEmpty false
         let EmptyModel method =
             let modelState = Memory.makeEmpty true
-            Memory.fillWithParametersAndThis modelState method
+            Memory.fillModelWithParametersAndThis modelState method
             StateModel modelState
 
         let PopFrame state = Memory.popFrame state
@@ -394,11 +394,13 @@ module API =
         let InitializeStaticMembers state targetType =
             Memory.initializeStaticMembers state targetType
 
-        let AllocateTemporaryLocalVariable state typ term =
-            let tmpKey = TemporaryLocalVariableKey typ
+        let AllocateTemporaryLocalVariable state index typ term =
+            let tmpKey = TemporaryLocalVariableKey(typ, index)
             let ref = PrimitiveStackLocation tmpKey |> Ref
             Memory.allocateOnStack state tmpKey term
             ref
+
+        let AllocateTemporaryLocalVariableOfType state name index typ = Memory.allocateTemporaryLocalVariableOfType state name index typ
 
         let AllocateDefaultClass state typ =
             if typ = typeof<string> then
@@ -424,6 +426,7 @@ module API =
 
         let AllocateString string state = Memory.allocateString state string
         let AllocateEmptyString state length = Memory.allocateEmptyString state length
+
         let CreateStringFromChar state char = Memory.createStringFromChar state char
 
         let AllocateConcreteObject state (obj : obj) typ = Memory.allocateConcreteObject state obj typ

--- a/VSharp.SILI.Core/API.fsi
+++ b/VSharp.SILI.Core/API.fsi
@@ -248,7 +248,8 @@ module API =
 
         val InitializeStaticMembers : state -> Type -> unit
 
-        val AllocateTemporaryLocalVariable : state -> Type -> term -> term
+        val AllocateTemporaryLocalVariable : state -> int -> Type -> term -> term
+        val AllocateTemporaryLocalVariableOfType : state -> string -> int -> Type -> term
         val AllocateDefaultClass : state -> Type -> term
         val AllocateDefaultArray : state -> term list -> Type -> term
         val AllocateVectorArray : state -> term -> Type -> term

--- a/VSharp.SILI.Core/CallStack.fs
+++ b/VSharp.SILI.Core/CallStack.fs
@@ -66,6 +66,7 @@ module internal CallStack =
             match key with
             | ParameterKey pi -> pi.ParameterType |> makeDefaultValue
             | ThisKey m -> nullRef m.DeclaringType
+            | TemporaryLocalVariableKey (t, _) -> makeDefaultValue t
             | _ -> __unreachable__()
         else
             let entry = findFrameAndRead stack.frames key id
@@ -136,7 +137,7 @@ module internal CallStack =
         |> join "\n"
 
     let stackTrace (stack : callStack) =
-        stack.frames |> List.map (fun frame -> frame.func |> Option.get)
+        stack.frames |> List.choose (fun frame -> frame.func)
 
     let stackTraceString (stack : callStack) =
         stack.frames

--- a/VSharp.SILI/CILState.fs
+++ b/VSharp.SILI/CILState.fs
@@ -4,6 +4,7 @@ open VSharp
 open System.Text
 open System.Collections.Generic
 open VSharp.Core
+open VSharp.Interpreter.IL
 open ipOperations
 
 [<ReferenceEquality>]
@@ -31,7 +32,7 @@ type cilState =
     member x.Result with get() =
 //        assert(Memory.CallStackSize x.state = 1)
         match EvaluationStack.Length x.state.evaluationStack with
-        | _ when Memory.CallStackSize x.state <> 1 -> internalfail "Finished state has many frames on stack! (possibly unhandled exception)"
+        | _ when Memory.CallStackSize x.state > 2 -> internalfail "Finished state has many frames on stack! (possibly unhandled exception)"
         | 0 -> Nop
         | 1 ->
             let result = EvaluationStack.Pop x.state.evaluationStack |> fst

--- a/VSharp.SILI/SILI.fs
+++ b/VSharp.SILI/SILI.fs
@@ -126,7 +126,12 @@ type public SILI(options : SiliOptions) =
             let this(*, isMethodOfStruct*) =
                 if method.IsStatic then None // *TODO: use hasThis flag from Reflection
                 else
-                    let this = Memory.MakeSymbolicThis method
+                    let this =
+                        if Types.IsValueType method.DeclaringType then
+                            Memory.NewStackFrame initialState None []
+                            Memory.AllocateTemporaryLocalVariableOfType initialState "this" 0 method.DeclaringType
+                        else
+                            Memory.MakeSymbolicThis method
                     !!(IsNullReference this) |> AddConstraint initialState
                     Some this
             ILInterpreter.InitFunctionFrame initialState method this None

--- a/VSharp.Test/IntegrationTests.cs
+++ b/VSharp.Test/IntegrationTests.cs
@@ -252,7 +252,10 @@ namespace VSharp.Test
                             return;
                         }
 
-                        if (explorer.Statistics.GetApproximateCoverage(Application.getMethod(unitTest.Method)) >= _expectedCoverage)
+                        var method = Application.getMethod(unitTest.Method);
+                        var approximateCoverage = explorer.Statistics.GetApproximateCoverage(method);
+
+                        if (approximateCoverage >= _expectedCoverage)
                         {
                             explorer.Stop();
                         }

--- a/VSharp.Test/Tests/Byrefs.cs
+++ b/VSharp.Test/Tests/Byrefs.cs
@@ -1,0 +1,106 @@
+﻿using VSharp.Test;
+
+namespace IntegrationTests
+{
+    [TestSvmFixture]
+    public static class Byrefs
+    {
+        [TestSvm(100)]
+        public static bool RefTest1(ref int n)
+        {
+            if (n + 1 > 0)
+            {
+                n = n + 10;
+                if (n > 100)
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
+            return false;
+        }
+
+        [TestSvm(100)]
+        public static int RefTest2(int n)
+        {
+            var result = RefTest1(ref n);
+            if (result)
+            {
+                return n;
+            }
+
+            return -n;
+        }
+
+        [TestSvm(100)]
+        public static int OutTest1(out int n, int m)
+        {
+            if (m > 0)
+            {
+                n = 1;
+            }
+            else if (m < 0)
+            {
+                n = -1;
+            }
+            else
+            {
+                n = 0;
+            }
+
+            return n;
+        }
+
+        [TestSvm(100)]
+        public static int OutTest2(int m)
+        {
+            var result = OutTest1(out var n, m);
+
+            if (result > 0)
+            {
+                return n;
+            }
+
+            return -n;
+        }
+
+        [TestSvm(100)]
+        public static int InTest1(in int n)
+        {
+            if (n > 0)
+            {
+                return 1;
+            }
+            else if (n < 0)
+            {
+                return  -1;
+            }
+
+            return 0;
+        }
+
+        [TestSvm(100)]
+        public static int InTest2(in int n)
+        {
+            if (InTest1(n) >= 0)
+            {
+                return n;
+            }
+
+            return -n;
+        }
+
+        [TestSvm(100)]
+        public static int RefTest3(ref int n, ref int m)
+        {
+            if (n == m)
+            {
+                return 0;
+            }
+
+            return 1;
+        }
+    }
+}

--- a/VSharp.Test/Tests/Structs.cs
+++ b/VSharp.Test/Tests/Structs.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using VSharp.Test;
+
+namespace IntegrationTests
+{
+    [TestSvmFixture]
+    public struct Point
+    {
+        private int _x;
+        private int _y;
+
+        public Point(int x, int y)
+        {
+            _x = x;
+            _y = y;
+        }
+
+        [TestSvm(100)]
+        public bool IsInRect(int left, int top, int right, int bottom)
+        {
+            if (_x > left && _x < right && _y > bottom && _y < top)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        [TestSvm(100)]
+        public void ThrowIfNotOnXAxis()
+        {
+            if (_y != 0)
+            {
+                throw new ArgumentException();
+            }
+        }
+    }
+}

--- a/VSharp.Utils/TestResultsChecker.fs
+++ b/VSharp.Utils/TestResultsChecker.fs
@@ -59,6 +59,8 @@ type TestResultsChecker(testDir : DirectoryInfo, runnerDir : string, expectedCov
             let trimmedName = if index >= 0 then name.Substring(0, index) else name
             sprintf "%s<%s>" trimmedName (args |> Array.map typeName4Dotcover |> join ",")
         elif typ.IsGenericParameter then typ.Name
+        elif typ.IsByRef then
+            typeName4Dotcover (typ.GetElementType())
         else typ.FullName.Replace("+", ".") // Replace + in inner class names with dots
 
     let splitTypeName (typeName : string) =


### PR DESCRIPTION
- For struct methods, allocate this on additional stack frame, struct methods can be explored without IIE
- Allocate byref parameters on additional stack frame, methods with byref parameters can be explored