### PR TITLE
[fix] PC, deep copy and error stats fixes

### DIFF
--- a/VSharp.SILI.Core/ConcreteMemory.fs
+++ b/VSharp.SILI.Core/ConcreteMemory.fs
@@ -4,6 +4,7 @@ open System
 open System.Collections.Generic
 open System.Runtime.Serialization
 open System.Runtime.CompilerServices
+open System.Threading
 open VSharp
 
 type public ConcreteMemory private (physToVirt, virtToPhys) =
@@ -12,6 +13,13 @@ type public ConcreteMemory private (physToVirt, virtToPhys) =
     let mutable virtToPhys = virtToPhys
 
 // ----------------------------- Helpers -----------------------------
+
+    static let nonCopyableTypes = [
+        typeof<Type>
+        typeof<Thread>
+    ]
+
+    let cannotBeCopied typ = List.contains typ nonCopyableTypes
 
     let getArrayIndicesWithValues (array : Array) =
         let ubs = List.init array.Rank array.GetUpperBound
@@ -26,7 +34,7 @@ type public ConcreteMemory private (physToVirt, virtToPhys) =
         let typ = TypeUtils.getTypeOfConcrete obj
         match obj with
         | null -> phys
-        | _ when TypeUtils.isPrimitive typ || typ.IsEnum || typ.IsPointer -> phys
+        | _ when cannotBeCopied typ || TypeUtils.isPrimitive typ || typ.IsEnum || typ.IsPointer -> phys
         | :? System.Reflection.Pointer -> phys
         | _ -> deepCopyComplex phys typ
 

--- a/VSharp.SILI.Core/PathCondition.fs
+++ b/VSharp.SILI.Core/PathCondition.fs
@@ -24,14 +24,14 @@ module internal PC =
         match cond with
         | True -> pc
         | False -> falsePC
+        | _ when isFalse pc -> falsePC
+        | _ when PersistentSet.contains !!cond pc -> falsePC
         | {term = Disjunction xs} ->
             let xs' = xs |> List.filter (fun x -> PersistentSet.contains !!x pc |> not)
             if xs'.Length = xs.Length then
                 PersistentSet.add pc cond
             else
                 PersistentSet.add pc (disjunction xs')
-        | _ when isFalse pc -> falsePC
-        | _ when PersistentSet.contains !!cond pc -> falsePC
         | _ ->
             let notCond = !!cond
             let pc' = pc |> PersistentSet.fold (fun pc e ->


### PR DESCRIPTION
- Fix appeared false PC-s with multiple elements
- Fix copying System.Type objects, causing inconsistent CLR state with access violation
- Fix duplicate errors reported (tested with JB Lifetimes.Collections -- 177 errors vs 134)