### PR TITLE
[feat] Fair multimethod searcher

### DIFF
--- a/VSharp.API/VSharp.cs
+++ b/VSharp.API/VSharp.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
+using Microsoft.FSharp.Core;
+using VSharp.CSharpUtils;
 using VSharp.Interpreter.IL;
 using VSharp.Solver;
 
@@ -80,14 +83,18 @@ namespace VSharp
 
     public static class TestGenerator
     {
-        private static Statistics StartExploration(List<MethodBase> methods, string resultsFolder, string[]? mainArguments = null, int timeout = -1)
+        private static Statistics StartExploration(List<MethodBase> methods, string resultsFolder, coverageZone coverageZone, string[]? mainArguments = null, int timeout = -1)
         {
             var recThreshold = 0u;
-            UnitTests unitTests = new UnitTests(resultsFolder);
+            var unitTests = new UnitTests(resultsFolder);
+            var baseSearcher = searchMode.BFSMode;
             // TODO: customize search strategies via console options
             var options =
                 new SiliOptions(
-                    explorationMode.NewTestCoverageMode(coverageZone.MethodZone, searchMode.DFSMode),
+                    explorationMode.NewTestCoverageMode(
+                        coverageZone,
+                        timeout > 0 ? searchMode.NewFairMode(baseSearcher) : baseSearcher
+                    ),
                     executionMode.SymbolicMode,
                     unitTests.TestDirectory,
                     recThreshold,
@@ -96,27 +103,40 @@ namespace VSharp
                     true,
                     128,
                     true);
-            SILI explorer = new SILI(options);
+
+            var explorer = new SILI(options);
             Core.API.ConfigureSolver(SolverPool.mkSolver());
 
-            void HandleInternalFail(MethodBase method, Exception exception)
+            void HandleInternalFail(Method method, Exception exception)
             {
-                Console.WriteLine($"EXCEPTION | {method.DeclaringType}.{method.Name} | {exception.GetType().Name} {exception.Message}");
+                var messageBuilder = new StringBuilder("EXCEPTION |");
+                if (method is not null)
+                {
+                    messageBuilder.Append($" {method.DeclaringType}.{method.Name} |");
+                }
+
+                messageBuilder.Append($" {exception.GetType().Name} {exception.Message}");
+
+                Console.WriteLine(messageBuilder.ToString());
             }
+
+            var isolated = new List<MethodBase>();
+            var entryPoints = new List<Tuple<MethodBase, string[]>>();
 
             foreach (var method in methods)
             {
                 if (method == method.Module.Assembly.EntryPoint)
                 {
-                    explorer.InterpretEntryPoint(method, mainArguments, unitTests.GenerateTest, unitTests.GenerateError, _ => { },
-                        e => HandleInternalFail(method, e));
+                    entryPoints.Add(new Tuple<MethodBase, string[]>(method, mainArguments));
                 }
                 else
                 {
-                    explorer.InterpretIsolated(method, unitTests.GenerateTest, unitTests.GenerateError, _ => { },
-                        e => HandleInternalFail(method, e));
+                    isolated.Add(method);
                 }
             }
+
+            explorer.Interpret(isolated, entryPoints, unitTests.GenerateTest, unitTests.GenerateError, _ => { },
+                (m, e) => HandleInternalFail(OptionModule.ToObj(m), e));
 
             var statistics = new Statistics(explorer.Statistics.CurrentExplorationTime, unitTests.TestDirectory,
                 unitTests.UnitTestsCount, unitTests.ErrorsCount,
@@ -141,8 +161,6 @@ namespace VSharp
             return TestRunner.TestRunner.ReproduceTests(testDir);
         }
 
-        private static readonly BindingFlags MethodsFlags =
-            BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly;
         /// <summary>
         /// Generates test coverage for specified method.
         /// </summary>
@@ -155,7 +173,7 @@ namespace VSharp
         {
             AssemblyManager.Load(method.Module.Assembly);
             List<MethodBase> methods = new List<MethodBase> {method};
-            var statistics = StartExploration(methods, outputDirectory, null, timeout);
+            var statistics = StartExploration(methods, outputDirectory, coverageZone.MethodZone, null, timeout);
             if (renderTests)
                 Render(statistics, method.DeclaringType);
             return statistics;
@@ -165,7 +183,7 @@ namespace VSharp
         /// Generates test coverage for all public methods of specified type.
         /// </summary>
         /// <param name="type">Type to be covered with tests.</param>
-        /// <param name="timeout">Timeout for code exploration in seconds. Negative value means infinite timeout (up to exhaustive coverage or user interuption).</param>
+        /// <param name="timeout">Timeout for code exploration in seconds. Negative value means infinite timeout (up to exhaustive coverage or user interruption).</param>
         /// <param name="outputDirectory">Directory to place generated *.vst tests. If null or empty, process working directory is used.</param>
         /// <param name="renderTests">Flag, that identifies whether to render NUnit tests or not</param>
         /// <returns>Summary of tests generation process.</returns>
@@ -173,16 +191,14 @@ namespace VSharp
         public static Statistics Cover(Type type, int timeout = -1, string outputDirectory = "", bool renderTests = false)
         {
             AssemblyManager.Load(type.Module.Assembly);
-            List<MethodBase> methods = new List<MethodBase>(type.GetConstructors());
 
-            methods.AddRange(type.GetMethods(MethodsFlags));
-
+            var methods = new List<MethodBase>(type.EnumerateExplorableMethods());
             if (methods.Count == 0)
             {
                 throw new ArgumentException("I've not found any public method or constructor of class " + type.FullName);
             }
 
-            var statistics = StartExploration(methods, outputDirectory, null, timeout);
+            var statistics = StartExploration(methods, outputDirectory, coverageZone.ClassZone, null, timeout);
             if (renderTests)
                 Render(statistics, type);
             return statistics;
@@ -204,8 +220,7 @@ namespace VSharp
             foreach (var type in typesArray)
             {
                 AssemblyManager.Load(type.Module.Assembly);
-                methods.AddRange(type.GetConstructors());
-                methods.AddRange(type.GetMethods(MethodsFlags));
+                methods.AddRange(type.EnumerateExplorableMethods());
             }
 
             if (methods.Count == 0)
@@ -214,7 +229,7 @@ namespace VSharp
                 throw new ArgumentException("I've not found any public methods or constructors of classes " + names);
             }
 
-            var statistics = StartExploration(methods, outputDirectory, null, timeout);
+            var statistics = StartExploration(methods, outputDirectory, coverageZone.ClassZone, null, timeout);
             if (renderTests)
                 Render(statistics);
             return statistics;
@@ -224,7 +239,7 @@ namespace VSharp
         /// Generates test coverage for all public methods of all public classes in the specified assembly.
         /// </summary>
         /// <param name="assembly">Assembly to be covered with tests.</param>
-        /// <param name="timeout">Timeout for code exploration in seconds. Negative value means infinite timeout (up to exhaustive coverage or user interuption).</param>
+        /// <param name="timeout">Timeout for code exploration in seconds. Negative value means infinite timeout (up to exhaustive coverage or user interruption).</param>
         /// <param name="outputDirectory">Directory to place generated *.vst tests. If null or empty, process working directory is used.</param>
         /// <param name="renderTests">Flag, that identifies whether to render NUnit tests or not</param>
         /// <returns>Summary of tests generation process.</returns>
@@ -233,27 +248,14 @@ namespace VSharp
         public static Statistics Cover(Assembly assembly, int timeout = -1, string outputDirectory = "", bool renderTests = false)
         {
             AssemblyManager.Load(assembly);
-            List<MethodBase> methods;
-            methods = new List<MethodBase>();
-
-            foreach (var t in assembly.GetTypes())
-            {
-                if (t.IsPublic || t.IsNestedPublic)
-                {
-                    foreach (var m in t.GetMethods(MethodsFlags))
-                    {
-                        if (m.GetMethodBody() != null && !Reflection.hasByRefLikes(m))
-                            methods.Add(m);
-                    }
-                }
-            }
-
+            var methods =
+                new List<MethodBase>(assembly.EnumerateExplorableTypes().SelectMany(t => t.EnumerateExplorableMethods()));
             if (methods.Count == 0)
             {
                 throw new ArgumentException("I've not found any public method in assembly");
             }
 
-            var statistics = StartExploration(methods, outputDirectory, null, timeout);
+            var statistics = StartExploration(methods, outputDirectory, coverageZone.ModuleZone, null, timeout);
             if (renderTests)
                 Render(statistics);
             return statistics;
@@ -264,7 +266,7 @@ namespace VSharp
         /// </summary>
         /// <param name="assembly">Assembly to be covered with tests.</param>
         /// <param name="args">Command line arguments of entry point</param>
-        /// <param name="timeout">Timeout for code exploration in seconds. Negative value means infinite timeout (up to exhaustive coverage or user interuption).</param>
+        /// <param name="timeout">Timeout for code exploration in seconds. Negative value means infinite timeout (up to exhaustive coverage or user interruption).</param>
         /// <param name="outputDirectory">Directory to place generated *.vst tests. If null or empty, process working directory is used.</param>
         /// <param name="renderTests">Flag, that identifies whether to render NUnit tests or not</param>
         /// <returns>Summary of tests generation process.</returns>
@@ -273,24 +275,23 @@ namespace VSharp
         public static Statistics Cover(Assembly assembly, string[]? args, int timeout = -1, string outputDirectory = "", bool renderTests = false)
         {
             AssemblyManager.Load(assembly);
+
             var entryPoint = assembly.EntryPoint;
             if (entryPoint == null)
             {
                 throw new ArgumentException("I've not found entry point in assembly");
             }
+
             var methods = new List<MethodBase> { entryPoint };
 
-            var statistics = StartExploration(methods, outputDirectory, args, timeout);
-            if (renderTests)
-                Render(statistics, entryPoint.DeclaringType);
-            return statistics;
+            return StartExploration(methods, outputDirectory, coverageZone.MethodZone, args, timeout);
         }
 
         /// <summary>
         /// Generates test coverage for the specified method and runs all tests.
         /// </summary>
         /// <param name="method">Type to be covered with tests.</param>
-        /// <param name="timeout">Timeout for code exploration in seconds. Negative value means infinite timeout (up to exhaustive coverage or user interuption).</param>
+        /// <param name="timeout">Timeout for code exploration in seconds. Negative value means infinite timeout (up to exhaustive coverage or user interruption).</param>
         /// <param name="outputDirectory">Directory to place generated *.vst tests. If null or empty, process working directory is used.</param>
         /// <param name="renderTests">Flag, that identifies whether to render NUnit tests or not</param>
         /// <returns>True if all generated tests have passed.</returns>
@@ -304,7 +305,7 @@ namespace VSharp
         /// Generates test coverage for the specified type and runs all tests.
         /// </summary>
         /// <param name="type">Type to be covered with tests.</param>
-        /// <param name="timeout">Timeout for code exploration in seconds. Negative value means infinite timeout (up to exhaustive coverage or user interuption).</param>
+        /// <param name="timeout">Timeout for code exploration in seconds. Negative value means infinite timeout (up to exhaustive coverage or user interruption).</param>
         /// <param name="outputDirectory">Directory to place generated *.vst tests. If null or empty, process working directory is used.</param>
         /// <param name="renderTests">Flag, that identifies whether to render NUnit tests or not</param>
         /// <returns>True if all generated tests have passed.</returns>
@@ -334,7 +335,7 @@ namespace VSharp
         /// Generates test coverage for all public methods of all public classes of the specified assembly and runs all tests.
         /// </summary>
         /// <param name="assembly">Assembly to be covered with tests.</param>
-        /// <param name="timeout">Timeout for code exploration in seconds. Negative value means infinite timeout (up to exhaustive coverage or user interuption).</param>
+        /// <param name="timeout">Timeout for code exploration in seconds. Negative value means infinite timeout (up to exhaustive coverage or user interruption).</param>
         /// <param name="outputDirectory">Directory to place generated *.vst tests. If null or empty, process working directory is used.</param>
         /// <param name="renderTests">Flag, that identifies whether to render NUnit tests or not</param>
         /// <returns>True if all generated tests have passed.</returns>
@@ -351,7 +352,7 @@ namespace VSharp
         /// </summary>
         /// <param name="assembly">Assembly to be covered with tests.</param>
         /// <param name="args">Command line arguments of entry point</param>
-        /// <param name="timeout">Timeout for code exploration in seconds. Negative value means infinite timeout (up to exhaustive coverage or user interuption).</param>
+        /// <param name="timeout">Timeout for code exploration in seconds. Negative value means infinite timeout (up to exhaustive coverage or user interruption).</param>
         /// <param name="outputDirectory">Directory to place generated *.vst tests. If null or empty, process working directory is used.</param>
         /// <param name="renderTests">Flag, that identifies whether to render NUnit tests or not</param>
         /// <returns>True if all generated tests have passed.</returns>

--- a/VSharp.CSharpUtils/ReflectionUtils.cs
+++ b/VSharp.CSharpUtils/ReflectionUtils.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using VSharp;
+
+namespace VSharp.CSharpUtils
+{
+    public static class ReflectionUtils
+    {
+        public static IEnumerable<MethodBase> EnumerateExplorableMethods(this Type type)
+        {
+            var flags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly;
+
+            foreach (var m in type.GetMethods(flags).Where(m => m.GetMethodBody() != null))
+            {
+                yield return m;
+            }
+
+            foreach (var ctor in type.GetConstructors(flags).Where(ctor => ctor.GetMethodBody() != null))
+            {
+                yield return ctor;
+            }
+
+        }
+
+        public static IEnumerable<Type> EnumerateExplorableTypes(this Assembly assembly)
+        {
+            var types = new List<Type>();
+            try
+            {
+                types.AddRange(assembly.GetTypes());
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                foreach (var type in e.Types)
+                {
+                    if (type is not null)
+                    {
+                        types.Add(type);
+                    }
+                }
+            }
+            return types.Where(t => t.IsPublic || t.IsNestedPublic);
+        }
+    }
+}

--- a/VSharp.SILI/BidirectionalSearcher.fs
+++ b/VSharp.SILI/BidirectionalSearcher.fs
@@ -8,7 +8,6 @@ type BidirectionalSearcher(forward : IForwardSearcher, backward : IBackwardSearc
 
 //    let starts = Queue<MethodBase>()
 //    let addedStarts = HashSet<MethodBase>()
-    let mutable mainMethod : Method = Unchecked.defaultof<Method>
 //    let mutable inverseReachability : Dictionary<MethodBase, HashSet<MethodBase>> = null
 
 //    let rememberStart (m : MethodBase) =
@@ -33,9 +32,8 @@ type BidirectionalSearcher(forward : IForwardSearcher, backward : IBackwardSearc
 //            Seq.iter (fun p -> rememberStart p.loc.method) mainPobs
 //        override x.PriorityQueue _ = StackFrontQueue() :> IPriorityQueue<cilState>
 
-        override x.Init m cilStates mainPobs =
-            mainMethod <- m
-            backward.Init m mainPobs
+        override x.Init cilStates mainPobs =
+            backward.Init mainPobs
 //            let start : cilState = CilStateOperations.makeInitialState m (ExplorerBase.FormInitialStateWithoutStatics m)
             forward.Init cilStates
 
@@ -44,13 +42,11 @@ type BidirectionalSearcher(forward : IForwardSearcher, backward : IBackwardSearc
         override x.UpdatePobs parent child =
             backward.Update parent child
         override x.UpdateStates parent children =
-            let loc = ipOperations.ip2codeLocation parent.startingIP
-            match loc with
-            | Some loc when loc.method = mainMethod && loc.offset = 0<offsets> ->
+            if not <| CilStateOperations.isIsolated parent then
                 forward.Update (parent, children)
                 backward.AddBranch parent |> ignore
                 Seq.iter (backward.AddBranch >> ignore) children
-            | _ ->
+            else
                 let reached = targeted.Update parent children
                 Seq.iter (backward.AddBranch >> ignore) reached
         override x.States() = forward.States()
@@ -82,9 +78,14 @@ type BidirectionalSearcher(forward : IForwardSearcher, backward : IBackwardSearc
             backward.Reset()
             targeted.Reset()
 
+        override x.Remove cilState =
+            forward.Remove cilState
+            backward.Remove cilState
+            targeted.Remove cilState
+
 type OnlyForwardSearcher(searcher : IForwardSearcher) =
     interface IBidirectionalSearcher with
-        override x.Init _ cilStates _ = searcher.Init cilStates
+        override x.Init cilStates _ = searcher.Init cilStates
         override x.Statuses() = []
         override x.Answer _ _ = ()
         override x.UpdatePobs _ _ = ()
@@ -95,6 +96,7 @@ type OnlyForwardSearcher(searcher : IForwardSearcher) =
             | None -> Stop
         override x.States() = searcher.States()
         override x.Reset() = searcher.Reset()
+        override x.Remove cilState = searcher.Remove cilState
 
 // TODO: check pob duplicates
 type BackwardSearcher() =
@@ -105,7 +107,6 @@ type BackwardSearcher() =
     let ancestorOf = Dictionary<pob, List<pob>>()
     let answeredPobs = Dictionary<pob, pobStatus>()
     let loc2pob = Dictionary<codeLocation, List<pob>>()
-    let mutable mainMethod : Method = Unchecked.defaultof<Method>
 
     let doAddPob (pob : pob) =
         currentPobs.Add(pob)
@@ -156,7 +157,6 @@ type BackwardSearcher() =
                     answerYes s' ancestor) ancestorOf.[p']
 
     let clear() =
-        mainMethod <- Unchecked.defaultof<Method>
         mainPobs.Clear()
         currentPobs.Clear()
         qBack.Clear()
@@ -165,9 +165,8 @@ type BackwardSearcher() =
         answeredPobs.Clear()
 
     interface IBackwardSearcher with
-        override x.Init m pobs =
+        override x.Init pobs =
             clear()
-            mainMethod <- m
             Seq.iter mainPobs.Add pobs
             Seq.iter (fun p -> answeredPobs.Add(p, pobStatus.Unknown)) pobs
             Seq.iter doAddPob pobs
@@ -190,7 +189,7 @@ type BackwardSearcher() =
         override x.AddBranch cilState =
             updateQBack cilState
 
-        override x.RemoveBranch cilState =
+        override x.Remove cilState =
             let count = qBack.RemoveAll(fun (cilState', _ as pair) -> if cilState = cilState' then alreadyAddedInQBack.Remove(pair) |> ignore; true else false)
             if count > 0 then
                 // TODO: need this?
@@ -245,3 +244,8 @@ module DummyTargetedSearcher =
                 finished.Clear()
                 reached.Clear()
                 targets.Clear()
+
+            override x.Remove cilState =
+                forPropagation.Values |> Seq.iter (fun s -> s.Remove cilState |> ignore)
+                finished.Values |> Seq.iter (fun s -> s.Remove cilState |> ignore)
+                reached.Values |> Seq.iter (fun s -> s.Remove cilState |> ignore)

--- a/VSharp.SILI/CombinedWeighter.fs
+++ b/VSharp.SILI/CombinedWeighter.fs
@@ -1,21 +1,29 @@
 namespace VSharp.Interpreter.IL
 
+open System
 open VSharp.Interpreter.IL
+open VSharp.Interpreter.IL.TypeUtils
 
 /// <summary>
 /// Combines two weighters using the given combinator function.
 /// </summary>
 type internal CombinedWeighter(one : IWeighter, another : IWeighter, maxPriority : uint, combinator : uint option -> uint option -> uint option) =
-    
+
     interface IWeighter with
         override x.Weight(state) =
             let oneWeight = one.Weight state
             let anotherWeight = another.Weight state
             combinator oneWeight anotherWeight
         override x.Next() = maxPriority
-        
-module internal WeightCombinators =
-    
+
+type internal AugmentedWeighter(baseWeighter : IWeighter, mapping : uint option -> uint option) =
+
+        interface IWeighter with
+            override x.Weight(state) = baseWeighter.Weight state |> mapping
+            override x.Next() = baseWeighter.Next()
+
+module internal WeightOperations =
+
     let withInverseLinearFallback bound (one : uint option) (another : uint option) =
         match one, another with
         | (None | Some 0u), Some anotherWeight ->
@@ -23,3 +31,14 @@ module internal WeightCombinators =
             Some(uint fallbackWeight)
         | Some oneWeight, _ -> Some(bound + oneWeight)
         | None, None -> None
+
+    let inverseLogarithmic (maxValuePower : uint) (weight : uint option) =
+        match weight with
+        | None -> None
+        | Some weight ->
+            let log =
+                match weight with
+                | 0u -> 0.0
+                | _ -> Math.Log2 (float weight)
+            let newWeight = Math.Pow(2.0, float maxValuePower - 5.0) * (32.0 - log)
+            newWeight |> Math.Floor |> uint |> Some

--- a/VSharp.SILI/ConcolicSearcher.fs
+++ b/VSharp.SILI/ConcolicSearcher.fs
@@ -1,0 +1,12 @@
+namespace VSharp.Interpreter.IL
+
+type internal ConcolicSearcher(baseSearcher : IForwardSearcher) =
+
+    interface IForwardSearcher with
+        override x.Init states = baseSearcher.Init states
+        override x.Pick() = baseSearcher.Pick (fun s -> not s.suspended)
+        override x.Pick selector = baseSearcher.Pick (fun s -> not s.suspended && selector s)
+        override x.Update(parent, newStates) = baseSearcher.Update(parent, newStates)
+        override x.States() = baseSearcher.States()
+        override x.Reset() = baseSearcher.Reset()
+        override x.Remove cilState = baseSearcher.Remove cilState

--- a/VSharp.SILI/ContributedCoverageSearcher.fs
+++ b/VSharp.SILI/ContributedCoverageSearcher.fs
@@ -7,22 +7,22 @@ open VSharp.Utils
 /// Considers the number of visited basic blocks not covered yet by tests as a state's weight.
 /// </summary>
 type internal ContributedCoverageWeighter(statistics : SILIStatistics) =
-    
+
     let weight state = Some(statistics.GetVisitedBlocksNotCoveredByTests(state).Count |> uint)
-    
+
     interface IWeighter with
         override x.Weight(state) = weight state
         override x.Next() = UInt32.MaxValue
-        
+
 type internal ContributedCoverageSearcher(maxBound, statistics) =
     inherit WeightedSearcher(maxBound, ContributedCoverageWeighter(statistics), BidictionaryPriorityQueue())
-    
+
 type internal ContributedCoverageWithDistanceAsFallbackWeighter(statistics) =
     inherit CombinedWeighter(
         ContributedCoverageWeighter(statistics),
         IntraproceduralShortestDistanceToUncoveredWeighter(statistics),
         UInt32.MaxValue,
-        WeightCombinators.withInverseLinearFallback 100u)
-    
+        WeightOperations.withInverseLinearFallback 100u)
+
 type internal ContributedCoverageWithDistanceAsFallbackSearcher(maxBound, statistics) =
     inherit WeightedSearcher(maxBound, ContributedCoverageWithDistanceAsFallbackWeighter(statistics), BidictionaryPriorityQueue())

--- a/VSharp.SILI/FairSearcher.fs
+++ b/VSharp.SILI/FairSearcher.fs
@@ -1,0 +1,143 @@
+namespace VSharp.Interpreter.IL
+
+open System
+open System.Collections.Generic
+open System.Diagnostics
+open VSharp
+
+/// <summary>
+/// Enumerates initial values as follows: when pick() yielded a value for the first time, it will continue to yield it until timeout, then
+/// the next value is yielded. When all values were yielded, a new round begins.
+/// <param name="initialValues">Values to yield in the first round.</param>
+/// <param name="getElementTimeoutMs">Checks for current element timeout.</param>
+/// <param name="shouldStop">If true, pick won't yield a value.</param>
+/// <param name="onRound">Called when all elements were yielded, returns the list of elements for the next round.</param>
+/// <param name="onTimeout">Called on timeout, current element and elapsed time are passed.</param>
+/// </summary>
+type private FairEnumerator<'a>(initialValues : 'a list, getElementTimeoutMs : 'a -> uint, shouldStop : unit -> bool, onRound : 'a list -> 'a list, onTimeout : 'a -> uint -> unit) =
+
+    let toExplore = Queue<'a>(initialValues)
+    let remains = HashSet<'a>()
+    let stopwatch = Stopwatch()
+
+    let stopCurrent() =
+        if toExplore.Count > 0 then
+            let elapsed = stopwatch.ElapsedMilliseconds
+            stopwatch.Reset()
+            let dequeued = toExplore.Dequeue()
+            onTimeout dequeued (uint elapsed)
+            remains.Add dequeued |> ignore
+            uint elapsed
+        else 0u
+
+    let rec pick() =
+        let toExploreIsEmpty = toExplore.Count = 0
+        if toExploreIsEmpty && remains.Count = 0 || shouldStop() then
+            None
+        elif toExploreIsEmpty then
+            remains |> List.ofSeq |> onRound |> List.iter toExplore.Enqueue
+            remains.Clear()
+            pick()
+        else
+            let peeked = toExplore.Peek()
+            if stopwatch.ElapsedMilliseconds <= int64 (getElementTimeoutMs peeked) then
+                if not stopwatch.IsRunning then stopwatch.Start()
+                Some peeked
+            else
+                stopCurrent() |> ignore
+                pick()
+
+    member x.Count = toExplore.Count + remains.Count
+
+    member x.Pick() = pick()
+
+    member x.DropCurrent() =
+        if toExplore.Count > 0 then
+            let elapsed = stopwatch.ElapsedMilliseconds
+            stopwatch.Reset()
+            toExplore.Dequeue() |> ignore
+            uint elapsed
+        else 0u
+
+    member x.StopCurrent() = stopCurrent()
+
+type internal FairSearcher(baseSearcherFactory : unit -> IForwardSearcher, timeoutMillis : uint, statistics : SILIStatistics) =
+
+    let baseSearcher = baseSearcherFactory()
+
+    let methodEnumerators = Dictionary<Type, FairEnumerator<Method>>()
+    let mutable typeEnumerator = FairEnumerator([], (fun _ -> 0u), always true, id, fun _ _ -> ())
+
+    let mutable totalTime = timeoutMillis
+    let mutable elapsedTime = 0u
+
+    let shouldStopType() = totalTime = 0u
+
+    let getTypeTimeout _ = totalTime / uint typeEnumerator.Count
+
+    // (method count * 10)ms is hardcoded time minimum to avoid too small timeouts
+    // and too frequent switching between methods
+    let shouldStopMethod typ = getTypeTimeout() <= uint methodEnumerators.[typ].Count * 10u
+
+    let getMethodTimeout typ = getTypeTimeout() / uint methodEnumerators.[typ].Count
+
+    let onTypeTimeout typ _ = elapsedTime <- elapsedTime + methodEnumerators.[typ].StopCurrent()
+
+    let onMethodTimeout _ elapsed = elapsedTime <- elapsedTime + elapsed
+
+    let onTypeRound types =
+        totalTime <- if elapsedTime > totalTime then 0u else totalTime - elapsedTime
+        elapsedTime <- 0u
+        types
+
+    let onMethodRound methods = List.sortBy (fun (m : Method) -> statistics.GetApproximateCoverage m) methods
+
+    let init initialStates =
+        baseSearcher.Init initialStates
+        let groupedByType = initialStates |> Seq.map CilStateOperations.entryMethodOf |> Seq.distinct |> Seq.groupBy (fun m -> m.DeclaringType)
+        typeEnumerator <- FairEnumerator(groupedByType |> Seq.map fst |> Seq.toList, getTypeTimeout, shouldStopType, onTypeRound, onTypeTimeout)
+        for typ, methods in groupedByType do
+            methodEnumerators.[typ] <- FairEnumerator(
+                methods |> Seq.sortBy (fun m -> m.CFG.Calls.Count) |> Seq.toList,
+                (fun _ -> getMethodTimeout typ),
+                (fun _ -> shouldStopMethod typ),
+                onMethodRound,
+                onMethodTimeout
+            )
+
+    let update (parent, newStates) = baseSearcher.Update(parent, newStates)
+
+    let rec pick (selector : cilState -> bool) =
+        match typeEnumerator.Pick() with
+        | None -> None
+        | Some typ ->
+            match methodEnumerators.[typ].Pick() with
+            | None ->
+                typeEnumerator.DropCurrent() |> ignore
+                pick selector
+            | Some method ->
+                match baseSearcher.Pick (fun s -> CilStateOperations.entryMethodOf s = method && selector s) with
+                | None ->
+                    elapsedTime <- elapsedTime + methodEnumerators.[typ].DropCurrent()
+                    pick selector
+                | Some _ as stateOpt -> stateOpt
+
+    let states() = baseSearcher.States()
+
+    let reset() =
+        baseSearcher.Reset()
+        methodEnumerators.Clear()
+        typeEnumerator <- FairEnumerator([], (fun _ -> 0u), always true, id, fun _ _ -> ())
+
+    let remove cilState = baseSearcher.Remove cilState
+
+    member x.BaseSearcher with get() = baseSearcher
+
+    interface IForwardSearcher with
+        override x.Init states = init states
+        override x.Pick() = pick (always true)
+        override x.Pick selector = pick selector
+        override x.Update (parent, newStates) = update (parent, newStates)
+        override x.States() = states()
+        override x.Reset() = reset()
+        override x.Remove cilState = remove cilState

--- a/VSharp.SILI/InterleavedSearcher.fs
+++ b/VSharp.SILI/InterleavedSearcher.fs
@@ -13,8 +13,18 @@ type InterleavedSearcher(searchersWithStepCount: (IForwardSearcher * int) list) 
 
     let init states = for searcher, _ in searchersWithStepCount do searcher.Init states
 
-    // TODO: handle None
-    let pick() = getCurrentSearcher().Pick()
+    let pick selectorOpt =
+        let pickInternal (searcher : IForwardSearcher) =
+            match selectorOpt with
+            | Some selector -> searcher.Pick selector
+            | None -> searcher.Pick()
+        let currentSearcher = getCurrentSearcher()
+        match pickInternal currentSearcher with
+        | Some _ as pickedFromCurrent -> pickedFromCurrent
+        | None ->
+            searchersWithStepCount
+            |> Seq.filter (fun (s, _) -> s <> currentSearcher)
+            |> Seq.tryPick (fun (s, _) -> pickInternal s)
 
     let update (parent, newStates) =
         for searcher, _ in searchersWithStepCount do
@@ -24,9 +34,13 @@ type InterleavedSearcher(searchersWithStepCount: (IForwardSearcher * int) list) 
 
     let reset() = for searcher, _ in searchersWithStepCount do searcher.Reset()
 
+    let remove cilState = for searcher, _ in searchersWithStepCount do searcher.Remove cilState
+
     interface IForwardSearcher with
         override x.Init states = init states
-        override x.Pick() = pick()
+        override x.Pick() = pick None
+        override x.Pick selector = pick (Some selector)
         override x.Update (parent, newStates) = update (parent, newStates)
         override x.States() = states()
         override x.Reset() = reset()
+        override x.Remove cilState = remove cilState

--- a/VSharp.SILI/Interpreter.fs
+++ b/VSharp.SILI/Interpreter.fs
@@ -790,9 +790,8 @@ type internal ILInterpreter(isConcolicMode : bool) as this =
             (fun cilState k -> (); k [cilState])
             (fun cilState k ->
                 reportError cilState "Debug.Assert failed"
-                cilState.suspended <- true
-                k [cilState])
-            (fun cilStates -> cilStates |> List.filter (fun cilState -> not cilState.suspended))
+                k [])
+            id
 
     member private x.TrustedIntrinsics =
         let intPtr = Reflection.getAllMethods typeof<IntPtr> |> Array.map Reflection.getFullMethodName
@@ -894,9 +893,8 @@ type internal ILInterpreter(isConcolicMode : bool) as this =
                 (fun cilState k -> (); k [cilState])
                 (fun cilState k ->
                     if isError then reportError cilState message
-                    cilState.suspended <- true
-                    k [cilState])
-                (fun cilStates -> cilStates |> List.filter (fun cilState -> not cilState.suspended))
+                    k [])
+                id
         else [cilState]
 
     static member CheckDisallowNullAssumptions (cilState : cilState) (method : Method) isError =
@@ -2045,7 +2043,6 @@ type internal ILInterpreter(isConcolicMode : bool) as this =
         let rec executeAllInstructions (finishedStates, incompleteStates, errors) cilState k =
             let ip = currentIp cilState
             try
-                cilState.iie <- None
                 let allStates = x.MakeStep cilState
                 let newErrors, restStates = List.partition isUnhandledError allStates
                 let errors = errors @ newErrors

--- a/VSharp.SILI/Options.fs
+++ b/VSharp.SILI/Options.fs
@@ -8,7 +8,9 @@ type searchMode =
     | BFSMode
     | ShortestDistanceBasedMode
     | ContributedCoverageMode
+    | FairMode of searchMode
     | InterleavedMode of searchMode * int * searchMode * int
+    | ConcolicMode of searchMode
     | GuidedMode of searchMode
 
 type coverageZone =

--- a/VSharp.SILI/SILI.fs
+++ b/VSharp.SILI/SILI.fs
@@ -1,7 +1,6 @@
 namespace VSharp.Interpreter.IL
 
 open System
-open System.Diagnostics
 open System.Reflection
 open System.Collections.Generic
 open FSharpx.Collections
@@ -15,13 +14,14 @@ open VSharp.Solver
 
 type public SILI(options : SiliOptions) =
 
-    let stopwatch = Stopwatch()
-    let timeout = if options.timeout <= 0 then Int64.MaxValue else int64 options.timeout * 1000L
-    let branchReleaseTimeout = if options.timeout <= 0 || not options.releaseBranches then Int64.MaxValue else timeout * 80L / 100L
+    let timeout = if options.timeout <= 0 then Double.PositiveInfinity else float options.timeout * 1000.0
+    let branchReleaseTimeout = if options.timeout <= 0 || not options.releaseBranches then Double.PositiveInfinity else timeout * 80.0 / 100.0
+
     let mutable branchesReleased = false
     let mutable isStopped = false
 
     let statistics = SILIStatistics()
+
     let infty = UInt32.MaxValue
     let emptyState = Memory.EmptyState()
     let isConcolicMode =
@@ -30,11 +30,12 @@ type public SILI(options : SiliOptions) =
         | SymbolicMode -> false
     let interpreter = ILInterpreter(isConcolicMode)
 
-    let mutable entryIP : ip = Unchecked.defaultof<ip>
     let mutable reportFinished : cilState -> unit = fun _ -> internalfail "reporter not configured!"
     let mutable reportError : cilState -> string -> unit = fun _ -> internalfail "reporter not configured!"
-    let mutable reportIncomplete : cilState -> unit = fun _ -> internalfail "reporter not configured!"
-    let mutable reportInternalFail : Exception -> unit = fun _ -> internalfail "reporter not configured!"
+    let mutable reportStateIncomplete : cilState -> unit = fun _ -> internalfail "reporter not configured!"
+    let mutable reportIncomplete : InsufficientInformationException -> unit = fun _ -> internalfail "reporter not configured!"
+    let mutable reportStateInternalFail : cilState -> Exception -> unit = fun _ -> internalfail "reporter not configured!"
+    let mutable reportInternalFail : Method option -> Exception -> unit = fun _ -> internalfail "reporter not configured!"
     let mutable concolicMachines : Dictionary<cilState, ClientMachine> = Dictionary<cilState, ClientMachine>()
 
     let () =
@@ -43,11 +44,11 @@ type public SILI(options : SiliOptions) =
         SetMaxBuferSize options.maxBufferSize
         TestGenerator.setMaxBufferSize options.maxBufferSize
 
-    let inCoverageZone coverageZone (startingMethod : Method) =
+    let inCoverageZone coverageZone (entryMethods : Method list) =
         match coverageZone with
-        | MethodZone -> (=) startingMethod
-        | ClassZone -> fun method -> method.DeclaringType.TypeHandle = startingMethod.DeclaringType.TypeHandle
-        | ModuleZone -> fun method -> method.Module.ModuleHandle = startingMethod.Module.ModuleHandle
+        | MethodZone -> fun method -> entryMethods |> List.contains method
+        | ClassZone -> fun method -> entryMethods |> List.exists (fun m -> method.DeclaringType.TypeHandle = m.DeclaringType.TypeHandle)
+        | ModuleZone -> fun method -> entryMethods |> List.exists (fun m -> method.Module.ModuleHandle = m.Module.ModuleHandle)
 
     let isSat pc =
         // TODO: consider trivial cases
@@ -62,16 +63,21 @@ type public SILI(options : SiliOptions) =
         | DFSMode -> DFSSearcher(infty) :> IForwardSearcher
         | ShortestDistanceBasedMode -> ShortestDistanceBasedSearcher(infty, statistics)
         | ContributedCoverageMode -> DFSSortedByContributedCoverageSearcher(infty, statistics)
+        | FairMode baseMode ->
+            FairSearcher((fun _ -> mkForwardSearcher baseMode), uint branchReleaseTimeout, statistics)
         | InterleavedMode(base1, stepCount1, base2, stepCount2) ->
             InterleavedSearcher([mkForwardSearcher base1, stepCount1; mkForwardSearcher base2, stepCount2])
         | GuidedMode baseMode ->
             let baseSearcher = mkForwardSearcher baseMode
             GuidedSearcher(infty, options.recThreshold, baseSearcher, StatisticsTargetCalculator(statistics)) :> IForwardSearcher
+        | searchMode.ConcolicMode baseMode -> ConcolicSearcher(mkForwardSearcher baseMode)
 
     let mutable searcher : IBidirectionalSearcher =
         match options.explorationMode with
         | TestCoverageMode(_, searchMode) ->
-            BidirectionalSearcher(mkForwardSearcher searchMode, BackwardSearcher(), DummyTargetedSearcher.DummyTargetedSearcher()) :> IBidirectionalSearcher
+            let baseSearcher = mkForwardSearcher searchMode
+            let baseSearcher = if isConcolicMode then ConcolicSearcher(baseSearcher) :> IForwardSearcher else baseSearcher
+            BidirectionalSearcher(baseSearcher, BackwardSearcher(), DummyTargetedSearcher.DummyTargetedSearcher()) :> IBidirectionalSearcher
         | StackTraceReproductionMode _ -> __notImplemented__()
 
     let releaseBranches() =
@@ -79,18 +85,14 @@ type public SILI(options : SiliOptions) =
             branchesReleased <- true
             ReleaseBranches()
             let dfsSearcher = DFSSortedByContributedCoverageSearcher(infty, statistics) :> IForwardSearcher
+            let dfsSearcher = if isConcolicMode then ConcolicSearcher(dfsSearcher) :> IForwardSearcher else dfsSearcher
             let bidirectionalSearcher = OnlyForwardSearcher(dfsSearcher)
             dfsSearcher.Init <| searcher.States()
             searcher <- bidirectionalSearcher
 
-    let coveragePobsForMethod (method : Method) =
-        let cfg = method.CFG
-        cfg.SortedOffsets |> Seq.map (fun offset ->
-            {loc = {offset = offset; method = method}; lvl = infty; pc = EmptyPathCondition})
-        |> List.ofSeq
-
-    let reportState reporter isError (method : Method) cmdArgs cilState message =
+    let reportState reporter isError cmdArgs cilState message =
         try
+            searcher.Remove cilState
             if cilState.history |> Seq.exists (not << CodeLocation.isBasicBlockCoveredByTest)
             then
                 let hasException =
@@ -101,39 +103,60 @@ type public SILI(options : SiliOptions) =
                 then statistics.TrackFinished cilState
                 let callStackSize = Memory.CallStackSize cilState.state
                 let methodHasByRefParameter (m : Method) = m.Parameters |> Seq.exists (fun pi -> pi.ParameterType.IsByRef)
+                let entryMethod = entryMethodOf cilState
                 if isError && not hasException
                     then
-                        if method.DeclaringType.IsValueType || methodHasByRefParameter method
+                        if entryMethod.DeclaringType.IsValueType || methodHasByRefParameter entryMethod
                         then Memory.ForcePopFrames (callStackSize - 2) cilState.state
                         else Memory.ForcePopFrames (callStackSize - 1) cilState.state
                 if not isError || statistics.EmitError cilState message
                 then
-                    match TestGenerator.state2test isError method cmdArgs cilState message with
+                    match TestGenerator.state2test isError entryMethod cmdArgs cilState message with
                     | Some test -> reporter test
                     | None -> ()
         with :? InsufficientInformationException as e ->
             cilState.iie <- Some e
-            reportIncomplete cilState
+            reportStateIncomplete cilState
 
-    let wrapOnTest (action : Action<UnitTest>) (method : Method) cmdArgs (state : cilState) =
-        Logger.info "Result of method %s is %O" method.FullName state.Result
+    let wrapOnTest (action : Action<UnitTest>) cmdArgs (state : cilState) =
+        Logger.info "Result of method %s is %O" (entryMethodOf state).FullName state.Result
         Application.terminateState state
-        reportState action.Invoke false method cmdArgs state null
+        reportState action.Invoke false cmdArgs state null
 
-    let wrapOnError (action : Action<UnitTest>) (method : Method) cmdArgs (state : cilState) errorMessage =
+    let wrapOnError (action : Action<UnitTest>) cmdArgs (state : cilState) errorMessage =
         if not <| String.IsNullOrWhiteSpace errorMessage then
-            Logger.info "Error in %s: %s" method.FullName errorMessage
+            Logger.info "Error in %s: %s" (entryMethodOf state).FullName errorMessage
         Application.terminateState state
-        reportState action.Invoke true method cmdArgs state errorMessage
+        reportState action.Invoke true cmdArgs state errorMessage
 
-    let wrapOnIIE (action : Action<InsufficientInformationException>) (state : cilState) =
+    let wrapOnStateIIE (action : Action<InsufficientInformationException>) (state : cilState) =
         statistics.IncompleteStates.Add(state)
         Application.terminateState state
+        searcher.Remove state
         action.Invoke state.iie.Value
 
-    let wrapOnInternalFail (action : Action<Exception>) (e : Exception) =
-        statistics.InternalFails.Add(e)
-        action.Invoke e
+    let wrapOnIIE (action : Action<InsufficientInformationException>) (iie: InsufficientInformationException) =
+        action.Invoke iie
+
+    let wrapOnStateInternalFail (action : Action<Method option, Exception>) (state : cilState) (e : Exception) =
+        match e with
+        | :? InsufficientInformationException as e ->
+            if state.iie.IsNone then
+                state.iie <- Some e
+            reportStateIncomplete state
+        | _ ->
+            statistics.InternalFails.Add(e)
+            Application.terminateState state
+            searcher.Remove state
+            action.Invoke(entryMethodOf state |> Some, e)
+
+    let wrapOnInternalFail (action : Action<Method option, Exception>) (method : Method option) (e : Exception) =
+        match e with
+        | :? InsufficientInformationException as e ->
+            reportIncomplete e
+        | _ ->
+            statistics.InternalFails.Add(e)
+            action.Invoke(method, e)
 
     static member private AllocateByRefParameters initialState (method : Method) =
         let allocateIfByRef (pi : ParameterInfo) =
@@ -146,29 +169,7 @@ type public SILI(options : SiliOptions) =
                 None
         method.Parameters |> Array.map allocateIfByRef |> Array.toList
 
-    static member private FormInitialStateWithoutStatics (method : Method) =
-        let initialState = Memory.EmptyState()
-        initialState.model <- Memory.EmptyModel method (typeModel.CreateEmpty())
-        let cilState = makeInitialState method initialState
-        try
-            let this(*, isMethodOfStruct*) =
-                if method.IsStatic then None // *TODO: use hasThis flag from Reflection
-                else
-                    let this =
-                        if Types.IsValueType method.DeclaringType then
-                            Memory.NewStackFrame initialState None []
-                            Memory.AllocateTemporaryLocalVariableOfType initialState "this" 0 method.DeclaringType
-                        else
-                            Memory.MakeSymbolicThis method
-                    !!(IsNullReference this) |> AddConstraint initialState
-                    Some this
-            let parameters = SILI.AllocateByRefParameters initialState method
-            ILInterpreter.InitFunctionFrame initialState method this (Some parameters)
-        with :? InsufficientInformationException as e ->
-            cilState.iie <- Some e
-        cilState
-
-    static member private TrySubstituteTypeParameters model (methodBase : MethodBase) =
+    member private x.TrySubstituteTypeParameters model (methodBase : MethodBase) =
         let method = Application.getMethod methodBase
         let getConcreteType = function
         | ConcreteType t -> Some t
@@ -186,30 +187,81 @@ type public SILI(options : SiliOptions) =
                 else
                     None
             | _ -> None
-        with :? InsufficientInformationException -> None
+        with
+        | e ->
+            reportInternalFail (Some method) e
+            None
 
-    member private x.FormInitialStates (method : Method) : cilState list =
-        let cilState = SILI.FormInitialStateWithoutStatics method
-        let cilStates = ILInterpreter.CheckDisallowNullAssumptions cilState method false
-        assert (List.length cilStates = 1)
-        let [cilState] = cilStates
-        match options.executionMode with
-        | ConcolicMode -> List.singleton cilState
-        | SymbolicMode -> interpreter.InitializeStatics cilState method.DeclaringType List.singleton
+    member private x.FormIsolatedInitialStates (method : Method, typModel : typeModel) =
+        try
+            let initialState = Memory.EmptyState()
+            initialState.model <- Memory.EmptyModel method typModel
+            let cilState = makeInitialState method initialState
+            let this(*, isMethodOfStruct*) =
+                if method.IsStatic then None // *TODO: use hasThis flag from Reflection
+                else
+                    let this =
+                        if Types.IsValueType method.DeclaringType then
+                            Memory.NewStackFrame initialState None []
+                            Memory.AllocateTemporaryLocalVariableOfType initialState "this" 0 method.DeclaringType
+                        else
+                            Memory.MakeSymbolicThis method
+                    !!(IsNullReference this) |> AddConstraint initialState
+                    Some this
+            let parameters = SILI.AllocateByRefParameters initialState method
+            ILInterpreter.InitFunctionFrame initialState method this (Some parameters)
+            let cilStates = ILInterpreter.CheckDisallowNullAssumptions cilState method false
+            assert (List.length cilStates = 1)
+            let [cilState] = cilStates
+            match options.executionMode with
+            | ConcolicMode -> List.singleton cilState
+            | SymbolicMode -> interpreter.InitializeStatics cilState method.DeclaringType List.singleton
+        with
+        | e ->
+            reportInternalFail (Some method) e
+            []
+
+    member private x.FormEntryPointInitialStates (method : Method, mainArguments : string[], typModel : typeModel) : cilState list =
+        try
+            assert method.IsStatic
+            let optionArgs = if mainArguments = null then None else Some mainArguments
+            let state = Memory.EmptyState()
+            state.model <- Memory.EmptyModel method typModel
+            let argsToState args =
+                let argTerms = Seq.map (fun str -> Memory.AllocateString str state) args
+                let stringType = typeof<string>
+                let argsNumber = MakeNumber mainArguments.Length
+                Memory.AllocateConcreteVectorArray state argsNumber stringType argTerms
+            let arguments = Option.map (argsToState >> Some >> List.singleton) optionArgs
+            ILInterpreter.InitFunctionFrame state method None arguments
+            if Option.isNone optionArgs then
+                // NOTE: if args are symbolic, constraint 'args != null' is added
+                let parameters = method.Parameters
+                assert(Array.length parameters = 1)
+                let argsParameter = Array.head parameters
+                let argsParameterTerm = Memory.ReadArgument state argsParameter
+                AddConstraint state (!!(IsNullReference argsParameterTerm))
+            Memory.InitializeStaticMembers state method.DeclaringType
+            let initialState = makeInitialState method state
+            [initialState]
+        with
+        | e ->
+            reportInternalFail (Some method) e
+            []
 
     member private x.Forward (s : cilState) =
         let loc = s.currentLoc
         // TODO: update pobs when visiting new methods; use coverageZone
         statistics.TrackStepForward s
         let goodStates, iieStates, errors = interpreter.ExecuteOneInstruction s
-        let goodStates, toReportFinished = goodStates |> List.partition (fun s -> isExecutable s || s.startingIP <> entryIP)
+        let goodStates, toReportFinished = goodStates |> List.partition (fun s -> isExecutable s || isIsolated s)
         toReportFinished |> List.iter reportFinished
-        let errors, toReportExceptions = errors |> List.partition (fun s -> s.startingIP <> entryIP || not <| stoppedByException s)
+        let errors, toReportExceptions = errors |> List.partition (fun s -> isIsolated s || not <| stoppedByException s)
         let runtimeExceptions, userExceptions = toReportExceptions |> List.partition hasRuntimeException
         runtimeExceptions |> List.iter (fun state -> reportError state null)
         userExceptions |> List.iter reportFinished
-        let iieStates, toReportIIE = iieStates |> List.partition (fun s -> s.startingIP <> entryIP)
-        toReportIIE |> List.iter reportIncomplete
+        let iieStates, toReportIIE = iieStates |> List.partition isIsolated
+        toReportIIE |> List.iter reportStateIncomplete
         let newStates =
             match goodStates with
             | s'::goodStates when LanguagePrimitives.PhysicalEquality s s' -> goodStates @ iieStates @ errors
@@ -231,14 +283,14 @@ type public SILI(options : SiliOptions) =
         statistics.TrackFork s newStates
         searcher.UpdateStates s newStates
 
-    member private x.Backward p' s' EP =
+    member private x.Backward p' s' =
         assert(currentLoc s' = p'.loc)
         let sLvl = levelToUnsignedInt s'.level
         if p'.lvl >= sLvl then
             let lvl = p'.lvl - sLvl
             let pc = Memory.WLP s'.state p'.pc
             match isSat pc with
-            | true when s'.startingIP = EP -> searcher.Answer p' (Witnessed s')
+            | true when not <| isIsolated s' -> searcher.Answer p' (Witnessed s')
             | true ->
                 statistics.TrackStepBackward p' s'
                 let p = {loc = startingLoc s'; lvl = lvl; pc = pc}
@@ -248,7 +300,7 @@ type public SILI(options : SiliOptions) =
             | false ->
                 Logger.trace "UNSAT for pob = %O and s'.PC = %s" p' (API.Print.PrintPC s'.state.pc)
 
-    member private x.BidirectionalSymbolicExecution (EP : ip) =
+    member private x.BidirectionalSymbolicExecution() =
         let mutable action = Stop
         let pick() =
             match searcher.Pick() with
@@ -256,37 +308,35 @@ type public SILI(options : SiliOptions) =
             | a -> action <- a; true
         (* TODO: checking for timeout here is not fine-grained enough (that is, we can work significantly beyond the
                  timeout, but we'll live with it for now. *)
-        while not isStopped && pick() && stopwatch.ElapsedMilliseconds < timeout do
-            if stopwatch.ElapsedMilliseconds >= branchReleaseTimeout then
+        while not isStopped && pick() && statistics.CurrentExplorationTime.TotalMilliseconds < timeout do
+            if statistics.CurrentExplorationTime.TotalMilliseconds >= branchReleaseTimeout then
                 releaseBranches()
             match action with
-            | GoFront s -> x.Forward(s)
-            | GoBack(s, p) -> x.Backward p s EP
+            | GoFront s ->
+                try
+                    x.Forward(s)
+                with
+                | e -> reportStateInternalFail s e
+            | GoBack(s, p) ->
+                try
+                    x.Backward p s
+                with
+                | e -> reportStateInternalFail s e
             | Stop -> __unreachable__()
 
-    member private x.AnswerPobs entryPoint initialStates =
-        match options.explorationMode with
-        | TestCoverageMode(coverageZone, _) ->
-            Application.setCoverageZone (inCoverageZone coverageZone entryPoint)
-        | StackTraceReproductionMode _ -> __notImplemented__()
-        Application.setAttributesZone (fun _ -> options.checkAttributes)
-        Application.resetMethodStatistics()
+    member private x.AnswerPobs initialStates =
         statistics.ExplorationStarted()
-        isStopped <- false
-        SolverInteraction.setOnSolverStarted statistics.SolverStarted
-        SolverInteraction.setOnSolverStopped statistics.SolverStopped
-        branchesReleased <- false
-        AcquireBranches()
-        searcher.Reset()
-        let mainPobs = coveragePobsForMethod entryPoint |> Seq.filter (fun pob -> pob.loc.offset <> 0<offsets>)
+
+        // For backward compatibility. TODO: remove main pobs at all
+        let mainPobs = []
         Application.spawnStates (Seq.cast<_> initialStates)
         mainPobs |> Seq.map (fun pob -> pob.loc) |> Seq.toArray |> Application.addGoals
-        searcher.Init entryPoint initialStates mainPobs
-        entryIP <- Instruction(0<offsets>, entryPoint)
+        searcher.Init initialStates mainPobs
+        initialStates |> Seq.filter isIIEState |> Seq.iter reportStateIncomplete
         match options.executionMode with
         | ConcolicMode ->
             initialStates |> List.iter (fun initialState ->
-                let machine = ClientMachine(entryPoint, (fun _ -> ()), initialState)
+                let machine = ClientMachine(entryMethodOf initialState, (fun _ -> ()), initialState)
                 if not <| machine.Spawn() then
                     internalfail "Unable to spawn concolic machine!"
                 concolicMachines.Add(initialState, machine))
@@ -294,103 +344,71 @@ type public SILI(options : SiliOptions) =
                 if concolicMachines.Count = 1 then Seq.head concolicMachines.Values
                 else __notImplemented'__ "Forking in concolic mode"
             while machine.State.suspended && machine.ExecCommand() do // TODO: make better interaction between concolic and SILI #do
-                x.BidirectionalSymbolicExecution entryIP
+                x.BidirectionalSymbolicExecution()
             // TODO: need to report? #do
 //            Logger.error "result state = %O" machine.State
 //            reportFinished.Invoke machine.State
         | SymbolicMode ->
-            x.BidirectionalSymbolicExecution entryIP
+            x.BidirectionalSymbolicExecution()
         searcher.Statuses() |> Seq.iter (fun (pob, status) ->
             match status with
             | pobStatus.Unknown ->
                 Logger.warning "Unknown status for pob at %O" pob.loc
             | _ -> ())
 
-    member private x.InterpretEntryPointInternal (method : MethodBase) (mainArguments : string[]) (onFinished : Action<UnitTest>)
-                                                 (onException : Action<UnitTest>) (onIIE : Action<InsufficientInformationException>)
-                                                 (onInternalFail : Action<Exception>) : unit =
-        assert method.IsStatic
-        stopwatch.Restart()
-        Reset()
+    member x.Reset entryMethods =
+        API.Reset()
         SolverPool.reset()
-        let optionArgs = if mainArguments = null then None else Some mainArguments
-        let state = Memory.EmptyState()
-        let typeModel = typeModel.CreateEmpty()
-        // TODO: resolve type parameters by mainArguments?
-        let method = Option.defaultValue method (SILI.TrySubstituteTypeParameters typeModel method)
-        let method = Application.getMethod method
-        state.model <- Memory.EmptyModel method typeModel
-        reportFinished <- wrapOnTest onFinished method optionArgs
-        reportError <- wrapOnError onException method optionArgs
-        reportIncomplete <- wrapOnIIE onIIE
-        interpreter.ConfigureErrorReporter reportError
-        let argsToState args =
-            let argTerms = Seq.map (fun str -> Memory.AllocateString str state) args
-            let stringType = typeof<string>
-            let argsNumber = MakeNumber mainArguments.Length
-            Memory.AllocateConcreteVectorArray state argsNumber stringType argTerms
-        let arguments = Option.map (argsToState >> Some >> List.singleton) optionArgs
-        ILInterpreter.InitFunctionFrame state method None arguments
-        if Option.isNone optionArgs then
-            // NOTE: if args are symbolic, constraint 'args != null' is added
-            let parameters = method.Parameters
-            assert(Array.length parameters = 1)
-            let argsParameter = Array.head parameters
-            let argsParameterTerm = Memory.ReadArgument state argsParameter
-            AddConstraint state (!!(IsNullReference argsParameterTerm))
-        Memory.InitializeStaticMembers state method.DeclaringType
-        let initialState = makeInitialState method state
-        x.AnswerPobs method [initialState]
-        Restore()
+        statistics.Reset()
+        searcher.Reset()
+        isStopped <- false
+        branchesReleased <- false
+        SolverInteraction.setOnSolverStarted statistics.SolverStarted
+        SolverInteraction.setOnSolverStopped statistics.SolverStopped
+        AcquireBranches()
+        match options.explorationMode with
+        | TestCoverageMode(coverageZone, _) ->
+            Application.setCoverageZone (inCoverageZone coverageZone entryMethods)
+        | StackTraceReproductionMode _ -> __notImplemented__()
+        Application.resetMethodStatistics()
 
-    member private x.InterpretIsolatedInternal (method : MethodBase) (onFinished : Action<UnitTest>)
-                                               (onException : Action<UnitTest>) (onIIE : Action<InsufficientInformationException>)
-                                               (onInternalFail : Action<Exception>) : unit =
-        stopwatch.Restart()
-        Reset()
-        SolverPool.reset()
-        let typeModel = typeModel.CreateEmpty()
-        let method = Option.defaultValue method (SILI.TrySubstituteTypeParameters typeModel method)
-        let method = Application.getMethod method
-        reportFinished <- wrapOnTest onFinished method None
-        reportError <- wrapOnError onException method None
-        reportIncomplete <- wrapOnIIE onIIE
-        interpreter.ConfigureErrorReporter reportError
-        let initialStates = x.FormInitialStates method
-        for cilState in initialStates do
-            let state = cilState.state
-            match state.model with
-            | StateModel(modelState, _) ->
-                state.model <- StateModel(modelState, typeModel)
-            | _ -> ()
-        let iieStates, initialStates = initialStates |> List.partition (fun state -> state.iie.IsSome)
-        iieStates |> List.iter reportIncomplete
-        if not initialStates.IsEmpty then
-            x.AnswerPobs method initialStates
-        Restore()
-
-    member x.InterpretEntryPoint (method : MethodBase) (mainArguments : string[]) (onFinished : Action<UnitTest>)
-                                 (onException : Action<UnitTest>) (onIIE : Action<InsufficientInformationException>)
-                                 (onInternalFail : Action<Exception>) : unit =
-        reportInternalFail <- wrapOnInternalFail onInternalFail
+    member x.Interpret (isolated : MethodBase seq) (entryPoints : (MethodBase * string[]) seq) (onFinished : Action<UnitTest>)
+                       (onException : Action<UnitTest>) (onIIE : Action<InsufficientInformationException>)
+                       (onInternalFail : Action<Method option, Exception>) : unit =
         try
+            reportInternalFail <- wrapOnInternalFail onInternalFail
+            reportStateInternalFail <- wrapOnStateInternalFail onInternalFail
+            reportIncomplete <- wrapOnIIE onIIE
+            reportStateIncomplete <- wrapOnStateIIE onIIE
+            reportFinished <- wrapOnTest onFinished None
+            reportError <- wrapOnError onException None
             try
-                x.InterpretEntryPointInternal method mainArguments onFinished onException onIIE onInternalFail
+                let trySubstituteTypeParameters method =
+                    let typeModel = typeModel.CreateEmpty()
+                    (Option.defaultValue method (x.TrySubstituteTypeParameters typeModel method), typeModel)
+                interpreter.ConfigureErrorReporter reportError
+                let isolated =
+                    isolated
+                    |> Seq.map trySubstituteTypeParameters
+                    |> Seq.map (fun (m, tm) -> Application.getMethod m, tm) |> Seq.toList
+                let entryPoints =
+                    entryPoints
+                    |> Seq.map (fun (m, a) ->
+                        let m, tm = trySubstituteTypeParameters m
+                        (Application.getMethod m, a, tm))
+                    |> Seq.toList
+                x.Reset ((isolated |> List.map fst) @ (entryPoints |> List.map (fun (m, _, _) -> m)))
+                let isolatedInitialStates = isolated |> List.collect x.FormIsolatedInitialStates
+                let entryPointsInitialStates = entryPoints |> List.collect x.FormEntryPointInitialStates
+                let iieStates, initialStates = isolatedInitialStates @ entryPointsInitialStates |> List.partition (fun state -> state.iie.IsSome)
+                iieStates |> List.iter reportStateIncomplete
+                if not initialStates.IsEmpty then
+                    x.AnswerPobs initialStates
             with
-            | e -> reportInternalFail e
+            | e -> reportInternalFail None e
         finally
-            searcher.Reset()
-
-    member x.InterpretIsolated (method : MethodBase) (onFinished : Action<UnitTest>)
-                               (onException : Action<UnitTest>) (onIIE : Action<InsufficientInformationException>)
-                               (onInternalFail : Action<Exception>) : unit =
-        reportInternalFail <- wrapOnInternalFail onInternalFail
-        try
-            try
-                x.InterpretIsolatedInternal method onFinished onException onIIE onInternalFail
-            with
-            | e -> reportInternalFail e
-        finally
+            statistics.ExplorationFinished()
+            API.Restore()
             searcher.Reset()
 
     member x.Stop() = isStopped <- true

--- a/VSharp.SILI/Searcher.fs
+++ b/VSharp.SILI/Searcher.fs
@@ -13,7 +13,7 @@ type action =
     | Stop
 
 type IBidirectionalSearcher =
-    abstract member Init : Method -> cilState list -> pob seq -> unit
+    abstract member Init : cilState list -> pob seq -> unit
     abstract member UpdateStates : cilState -> cilState seq -> unit
     abstract member UpdatePobs : pob -> pob -> unit
     abstract member Pick : unit -> action
@@ -21,33 +21,35 @@ type IBidirectionalSearcher =
     abstract member Statuses : unit -> seq<pob * pobStatus>
     abstract member States : unit -> cilState seq
     abstract member Reset : unit -> unit
+    abstract member Remove : cilState -> unit
 
 type IForwardSearcher =
     abstract member Init : cilState seq -> unit
     abstract member Update : cilState * cilState seq -> unit
     abstract member Pick : unit -> cilState option
+    abstract member Pick : (cilState -> bool) -> cilState option
     abstract member States : unit -> cilState seq
     abstract member Reset : unit -> unit
+    abstract member Remove : cilState -> unit
 
 type ITargetedSearcher =
     abstract member SetTargets : ip -> ip seq -> unit
     abstract member Update : cilState -> cilState seq -> cilState seq // returns states that reached its target
     abstract member Pick : unit -> cilState option
     abstract member Reset : unit -> unit
+    abstract member Remove : cilState -> unit
 
 type backwardAction = Propagate of cilState * pob | InitTarget of ip * pob seq | NoAction
 
 type IBackwardSearcher =
-    abstract member Init : Method -> pob seq -> unit
+    abstract member Init : pob seq -> unit
     abstract member Update : pob -> pob -> unit
     abstract member Answer : pob -> pobStatus -> unit
     abstract member Statuses : unit -> seq<pob * pobStatus>
     abstract member Pick : unit -> backwardAction
     abstract member AddBranch : cilState -> pob list
     abstract member Reset : unit -> unit
-
-    // TODO: get rid of this!
-    abstract member RemoveBranch : cilState -> unit
+    abstract member Remove : cilState -> unit
 
 type IpStackComparer() =
     interface IComparer<cilState> with
@@ -61,7 +63,7 @@ type SimpleForwardSearcher(maxBound) =
 //    let mutable mainMethod = null
 //    let mutable startedFromMain = false
     let forPropagation = List<cilState>()
-    let isStopped s = isStopped s || violatesLevel s maxBound
+
     let add (states : List<cilState>) (s : cilState) =
         if not <| isStopped s then
             assert(states.Contains s |> not)
@@ -69,19 +71,20 @@ type SimpleForwardSearcher(maxBound) =
 
     interface IForwardSearcher with
         override x.Init states = x.Init forPropagation states
-        override x.Pick() =
-            x.Choose (forPropagation |> Seq.filter (fun cilState -> not cilState.suspended))
+        override x.Pick selector = x.Choose forPropagation selector
+        override x.Pick() = x.Choose forPropagation (Prelude.always true)
         override x.Update (parent, newStates) =
             x.Insert forPropagation (parent, newStates)
         override x.States() = forPropagation
         override x.Reset() = forPropagation.Clear()
+        override x.Remove cilState = forPropagation.Remove cilState |> ignore
 
-    abstract member Choose : seq<cilState> -> cilState option
-    default x.Choose states = Seq.tryLast states
+    abstract member Choose : seq<cilState> -> (cilState -> bool) -> cilState option
+    default x.Choose states selector = Seq.tryFindBack selector states
 
     abstract member Insert : List<cilState> -> cilState * seq<cilState> -> unit
     default x.Insert states (parent, newStates) =
-        if isStopped parent then
+        if violatesLevel parent maxBound then
             states.Remove(parent) |> ignore
         Seq.iter (add states) newStates
 
@@ -90,14 +93,13 @@ type SimpleForwardSearcher(maxBound) =
 
 type BFSSearcher(maxBound) =
     inherit SimpleForwardSearcher(maxBound) with
-        let isStopped s = isStopped s || violatesLevel s maxBound
         let add (states : List<cilState>) (s : cilState) =
             if not <| isStopped s then
                 assert(states.Contains s |> not)
                 states.Add(s)
-        override x.Choose states = Seq.tryHead states
+        override x.Choose states selector = Seq.tryFind selector states
         override x.Insert states (parent, newStates) =
-            if isStopped parent then
+            if violatesLevel parent maxBound then
                 states.Remove(parent) |> ignore
             else if not <| Seq.isEmpty newStates then
                 states.Remove(parent) |> ignore
@@ -112,15 +114,14 @@ type IWeighter =
     abstract member Next : unit -> uint
 
 type WeightedSearcher(maxBound, weighter : IWeighter, storage : IPriorityCollection<cilState>) =
-    let modMax n =
-        if storage.MaxPriority = 0u then 0u
-        else n % storage.MaxPriority
-    let isStopped s = isStopped s || violatesLevel s maxBound
     let optionWeight s =
-        option {
-            if not <| s.suspended && not <| isStopped s then
-                return! weighter.Weight s
-        }
+        try
+            option {
+                if not <| violatesLevel s maxBound then return! weighter.Weight s
+            }
+        with :? InsufficientInformationException as e ->
+            s.iie <- Some e
+            None
     let add (s : cilState) =
         let weight = optionWeight s
         match weight with
@@ -129,22 +130,19 @@ type WeightedSearcher(maxBound, weighter : IWeighter, storage : IPriorityCollect
             storage.Insert s w
         | None -> ()
     let update s =
-        let weight = optionWeight s
-        match weight with
-        | Some w ->
-            if not <| storage.Contains s then
-                storage.Insert s w
-            else storage.Update s w
-        | None ->
-            if storage.Contains s then
-                storage.Remove s
+        if storage.Contains s then
+            let weight = optionWeight s
+            match weight with
+            | Some w -> storage.Update s w
+            | None -> storage.Remove s
 
     abstract member Insert : cilState seq -> unit
     default x.Insert states =
         Seq.iter add states
 
-    member x.Pick() =
-        storage.Choose (modMax <| weighter.Next())
+    member x.Pick() = storage.Choose()
+
+    member x.Pick selector = storage.Choose(selector)
 
     abstract member Update : cilState * cilState seq -> unit
     default x.Update (parent, newStates) =
@@ -154,10 +152,13 @@ type WeightedSearcher(maxBound, weighter : IWeighter, storage : IPriorityCollect
     interface IForwardSearcher with
         override x.Init states = x.Insert states
         override x.Pick() = x.Pick()
+        override x.Pick selector = x.Pick selector
         override x.Update (parent, newStates) = x.Update (parent, newStates)
         override x.States() = storage.ToSeq
         override x.Reset() = storage.Clear()
+        override x.Remove cilState = if storage.Contains cilState then storage.Remove cilState
 
     member x.Weighter = weighter
+    member x.Count = storage.Count
     member x.TryGetWeight state = storage.TryGetPriority state
     member x.ToSeq() = storage.ToSeq

--- a/VSharp.SILI/TargetedSearcher.fs
+++ b/VSharp.SILI/TargetedSearcher.fs
@@ -7,16 +7,14 @@ open VSharp.Interpreter.IL
 open VSharp.Utils
 open CilStateOperations
 
-type TargetedSearcher(maxBound, target) =
+type TargetedSearcher(maxBound, target, isPaused) =
     inherit WeightedSearcher(maxBound, ShortestDistanceWeighter(target), BidictionaryPriorityQueue())
-
-    let isStopped s = isStopped s || violatesLevel s maxBound
 
     override x.Insert states =
         base.Insert states
         for state in states do
             match x.TryGetWeight state with
-            | None when not state.suspended ->
+            | None when not <| isPaused state ->
                 removeTarget state target
             | _ -> ()
 
@@ -30,7 +28,7 @@ type TargetedSearcher(maxBound, target) =
                     cfg.IsBasicBlockStart loc.offset
                 | None -> false
 
-            isStopped state  ||  onVertex state
+            violatesLevel state maxBound || onVertex state
 
         if needsUpdating parent then
             base.Update (parent, newStates)
@@ -39,7 +37,7 @@ type TargetedSearcher(maxBound, target) =
 
         for state in Seq.append [parent] newStates do
             match x.TryGetWeight state with
-            | None when not state.suspended ->
+            | None when not <| isPaused state ->
                 removeTarget state target
 
             | _ -> ()
@@ -80,6 +78,9 @@ type GuidedSearcher(maxBound, threshold : uint, baseSearcher : IForwardSearcher,
     let targetedSearchers = Dictionary<codeLocation, TargetedSearcher>()
     let getTargets (state : cilState) = state.targets
     let reachedOrUnreachableTargets = HashSet<codeLocation> ()
+    let pausedStates = HashSet<cilState>()
+
+    let isPaused cilState = pausedStates.Contains cilState
 
     let calculateTarget (state : cilState): codeLocation option =
         targetCalculator.CalculateTarget state
@@ -94,7 +95,7 @@ type GuidedSearcher(maxBound, threshold : uint, baseSearcher : IForwardSearcher,
             onVertex && level > threshold
         | _ -> false
 
-    let mkTargetedSearcher target = TargetedSearcher(maxBound, target)
+    let mkTargetedSearcher target = TargetedSearcher(maxBound, target, isPaused)
     let getTargetedSearcher target =
         Dict.getValueOrUpdate targetedSearchers target (fun () -> mkTargetedSearcher target)
 
@@ -172,59 +173,68 @@ type GuidedSearcher(maxBound, threshold : uint, baseSearcher : IForwardSearcher,
         baseSearcher.Update (parent, newStates)
         updateTargetedSearchers parent newStates
 
-    let suspend (state : cilState) : unit =
-        state.suspended <- true
-        update state Seq.empty
+    let pause (state : cilState) : unit =
+        pausedStates.Add state |> ignore
 
-    let setTargetOrSuspend state =
+    let setTargetOrPause state =
         match calculateTarget state with
         | Some target ->
             addTarget state target
             insertInTargetedSearcher state target
         | None ->
             state.targets <- None
-            suspend state
+            pause state
 
-    let rec pick' k =
-        let pickFromBaseSearcher k =
-            match baseSearcher.Pick() with
+    let rec pick' (selector : (cilState -> bool) option) =
+        let pick() = if selector.IsSome then baseSearcher.Pick selector.Value else baseSearcher.Pick()
+        let pickFromBaseSearcher () =
+            match pick() with
             | Some state ->
                 match state.targets with
                 | None when violatesRecursionLevel state ->
-                    setTargetOrSuspend state
-                    pick' k
-                | _ -> k <| Some state
-            | None -> k None
-        let pickFromTargetedSearcher k =
+                    setTargetOrPause state
+                    pick' selector
+                | _ -> Some state
+            | None -> None
+        let pickFromTargetedSearcher () =
             let targetSearcher = targetedSearchers |> Seq.item index
-            let optState = targetSearcher.Value.Pick()
 
-            if Option.isNone optState then
-                reachedOrUnreachableTargets.Add targetSearcher.Key |> ignore
-            if reachedOrUnreachableTargets.Contains targetSearcher.Key then
+            if targetSearcher.Value.Count = 0u then
                 deleteTargetedSearcher targetSearcher.Key
-            if Option.isSome optState then k <| optState else pick' k
+                pick' selector
+            else
+                let optState = pick()
+                if Option.isSome optState then optState else pick' selector
         let size = targetedSearchers.Count
 
         index <- (index + 1) % (size + 1)
         if index <> size
-            then pickFromTargetedSearcher k
-            else pickFromBaseSearcher k
+            then pickFromTargetedSearcher ()
+            else pickFromBaseSearcher ()
 
-    let pick () = pick' id
+    let pick selector = pick' selector
 
     let reset () =
         baseSearcher.Reset()
         for searcher in targetedSearchers.Values do (searcher :> IForwardSearcher).Reset()
 
+    let remove cilState =
+        baseSearcher.Remove cilState
+        for searcher in targetedSearchers.Values do (searcher :> IForwardSearcher).Remove cilState
+
     interface IForwardSearcher with
         override x.Init states =
             baseSearcher.Init states
             insertInTargetedSearchers states
-        override x.Pick() = pick ()
+        override x.Pick() = pick None
+        override x.Pick selector = pick (Some selector)
         override x.Update (parent, newStates) = update parent newStates
         override x.States() = baseSearcher.States()
         override x.Reset() = reset ()
+        override x.Remove cilState = remove cilState
 
 type ShortestDistanceBasedSearcher(maxBound, statistics : SILIStatistics) =
     inherit WeightedSearcher(maxBound, IntraproceduralShortestDistanceToUncoveredWeighter(statistics), BidictionaryPriorityQueue())
+
+type RandomShortestDistanceBasedSearcher(maxBound, statistics : SILIStatistics) =
+    inherit WeightedSearcher(maxBound, AugmentedWeighter(IntraproceduralShortestDistanceToUncoveredWeighter(statistics), (WeightOperations.inverseLogarithmic 7u)), DiscretePDF(mkCilStateHashComparer))

--- a/VSharp.SILI/VSharp.SILI.fsproj
+++ b/VSharp.SILI/VSharp.SILI.fsproj
@@ -43,10 +43,12 @@
         <Compile Include="Interpreter.fs" />
         <Compile Include="CombinedWeighter.fs" />
         <Compile Include="DistanceWeighter.fs" />
+        <Compile Include="ConcolicSearcher.fs" />
         <Compile Include="ContributedCoverageSearcher.fs" />
         <Compile Include="DFSSortedByContributedCoverageSearcher.fs" />
         <Compile Include="InterleavedSearcher.fs" />
         <Compile Include="TargetedSearcher.fs" />
+        <Compile Include="FairSearcher.fs" />
         <Compile Include="BidirectionalSearcher.fs" />
         <Compile Include="Communication.fs" />
         <Compile Include="Instrumenter.fs" />

--- a/VSharp.Solver/Z3.fs
+++ b/VSharp.Solver/Z3.fs
@@ -808,32 +808,35 @@ module internal Z3 =
                 printLog Trace "SOLVER: trying to solve constraints..."
                 printLogLazy Trace "%s" (lazy(q.ToString()))
                 try
-                    let query = builder.EncodeTerm encCtx q
-                    let assumptions = query.assumptions
-                    let assumptions =
-                        seq {
-                            yield! (Seq.cast<_> assumptions)
-                            yield query.expr
-                        } |> Array.ofSeq
-//                    let pathAtoms = addSoftConstraints q.lvl
-                    let result = optCtx.Check assumptions
-                    match result with
-                    | Status.SATISFIABLE ->
-                        trace "SATISFIABLE"
-                        let z3Model = optCtx.Model
-                        let model = builder.MkModel z3Model
-                        SmtSat { mdl = model }
-                    | Status.UNSATISFIABLE ->
-                        trace "UNSATISFIABLE"
-                        SmtUnsat { core = Array.empty (*optCtx.UnsatCore |> Array.map (builder.Decode Bool)*) }
-                    | Status.UNKNOWN ->
-                        trace "UNKNOWN"
-                        SmtUnknown optCtx.ReasonUnknown
-                    | _ -> __unreachable__()
-                with
-                | :? EncodingException as e ->
-                    printLog Info "SOLVER: exception was thrown: %s" e.Message
-                    SmtUnknown (sprintf "Z3 has thrown an exception: %s" e.Message)
+                    try
+                        let query = builder.EncodeTerm encCtx q
+                        let assumptions = query.assumptions
+                        let assumptions =
+                            seq {
+                                yield! (Seq.cast<_> assumptions)
+                                yield query.expr
+                            } |> Array.ofSeq
+    //                    let pathAtoms = addSoftConstraints q.lvl
+                        let result = optCtx.Check assumptions
+                        match result with
+                        | Status.SATISFIABLE ->
+                            trace "SATISFIABLE"
+                            let z3Model = optCtx.Model
+                            let model = builder.MkModel z3Model
+                            SmtSat { mdl = model }
+                        | Status.UNSATISFIABLE ->
+                            trace "UNSATISFIABLE"
+                            SmtUnsat { core = Array.empty (*optCtx.UnsatCore |> Array.map (builder.Decode Bool)*) }
+                        | Status.UNKNOWN ->
+                            trace "UNKNOWN"
+                            SmtUnknown optCtx.ReasonUnknown
+                        | _ -> __unreachable__()
+                    with
+                    | :? EncodingException as e ->
+                        printLog Info "SOLVER: exception was thrown: %s" e.Message
+                        SmtUnknown (sprintf "Z3 has thrown an exception: %s" e.Message)
+                finally
+                    builder.Reset()
 
             member x.Assert encCtx (fml : term) =
                 printLogLazy Trace "SOLVER: Asserting: %s" (lazy(fml.ToString()))

--- a/VSharp.Test/IntegrationTests.cs
+++ b/VSharp.Test/IntegrationTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
@@ -285,7 +286,7 @@ namespace VSharp.Test
                         }
                     }
 
-                    explorer.InterpretIsolated(methodInfo, GenerateTestAndCheckCoverage, GenerateErrorAndCheckCoverage, _ => { }, e => throw e);
+                    explorer.Interpret(new [] { methodInfo }, new Tuple<MethodBase, string[]>[] {}, GenerateTestAndCheckCoverage, GenerateErrorAndCheckCoverage, _ => { }, (_, e) => throw e);
 
                     if (unitTests.UnitTestsCount == 0 && unitTests.ErrorsCount == 0 && explorer.Statistics.IncompleteStates.Count == 0)
                     {

--- a/VSharp.Test/Tests/LoanExam/CreditCalculator.cs
+++ b/VSharp.Test/Tests/LoanExam/CreditCalculator.cs
@@ -109,7 +109,7 @@ public class CreditCalculationService
         }
     }
 
-    [TestSvm(95, 0, 20, false, strat: SearchStrategy.Interleaved, releaseBranches: false)]
+    [TestSvm(95, 0, -1, false, strat: SearchStrategy.Interleaved, coverageZone: CoverageZone.Class)]
     public CreditResult Build(Request request)
     {
         var SumPoints = 0;

--- a/VSharp.Utils/DiscretePDF.fs
+++ b/VSharp.Utils/DiscretePDF.fs
@@ -1,6 +1,8 @@
 ﻿namespace VSharp.Utils
 
+open System
 open System.Collections.Generic
+open Checked
 
 open VSharp
 
@@ -19,6 +21,7 @@ type public DiscretePDF<'a when 'a : equality>(comparer : IComparer<'a>) =
     let mutable root = None : node<'a> option
     let mutable maxWeight = 0u
     let mutable count = 0u
+    let random = Random()
 
     let mkNode (key : 'a) weight =
         { Left = None
@@ -191,18 +194,36 @@ type public DiscretePDF<'a when 'a : equality>(comparer : IComparer<'a>) =
         | Some n -> balance n
         | None -> None
 
-    let rec choose (nOpt : node<'a> option) weight =
-        option {
-            let! n = nOpt
-            match n.Left, n.Right with
-            | Some left, _ when weight < left.SumWeight ->
-                return! choose n.Left weight
-            | Some left,Some _ when weight >= left.SumWeight && weight - left.SumWeight >= n.Weight ->
-                return! choose n.Right (weight - left.SumWeight - n.Weight)
-            | None, Some _ when weight >= n.Weight ->
-                return! choose n.Right (weight - n.Weight)
-            | _ -> return n.Key
-        }
+    let choose selector =
+        let rec chooseInternal (nOpt : node<'a> option) (k : unit -> 'a option) =
+            let selectSegment3 w1 w2 w3 on1 on2 on3 k =
+                let weight = random.Next(0, w1 + w2 + w3)
+                if weight < w1 then on1 k
+                elif weight < w1 + w2 then on2 k
+                else on3 k
+
+            let selectSegment2 w1 w2 on1 on2 k =
+                let weight = random.Next(0, w1 + w2)
+                if weight < w1 then on1 (fun _ -> on2 k) else on2 (fun _ -> on1 k)
+
+            let unwrapSumWeight (n : node<'a> option) =
+                match n with
+                | Some n -> int n.SumWeight
+                | _ -> 0
+
+            match nOpt with
+            | None -> k()
+            | Some n ->
+                let goToLeft k = chooseInternal n.Left k
+                let goToRight k = chooseInternal n.Right k
+                let tryMiddle k = if selector n.Key then Some n.Key else k()
+                let leftWeight = unwrapSumWeight n.Left
+                let rightWeight = unwrapSumWeight n.Right
+                let onLeft k = goToLeft (fun _ -> selectSegment2 (int n.Weight) rightWeight tryMiddle goToRight k)
+                let onMiddle k = tryMiddle (fun _ -> selectSegment2 leftWeight rightWeight goToLeft goToRight k)
+                let onRight k = goToRight (fun _ -> selectSegment2 leftWeight (int n.Weight) goToLeft tryMiddle k)
+                selectSegment3 leftWeight (int n.Weight) rightWeight onLeft onMiddle onRight k
+        chooseInternal root (always None)
 
     let rec enumerate optNode =
         seq {
@@ -213,7 +234,6 @@ type public DiscretePDF<'a when 'a : equality>(comparer : IComparer<'a>) =
                 yield! enumerate node.Right
             | None -> ()
         }
-
 
     member x.Empty() = root = None
 
@@ -252,19 +272,7 @@ type public DiscretePDF<'a when 'a : equality>(comparer : IComparer<'a>) =
         }
         assert (Option.isSome res)
 
-    member x.Choose(weight) =
-        let wOpt = if weight <> 0u && weight >= maxWeight then None else Some weight
-        option {
-            let! r = root
-            let! w = wOpt
-            let scaledW =
-                if maxWeight > 0u then
-                    (double w / double maxWeight) * double r.SumWeight
-                else double w
-             |> round
-             |> uint
-            return! choose root scaledW
-        }
+    member x.Choose(selector) = choose selector
 
     member x.Clear() =
         root <- None
@@ -278,11 +286,11 @@ type public DiscretePDF<'a when 'a : equality>(comparer : IComparer<'a>) =
         override x.Insert item priority = x.Insert(item, priority)
         override x.Remove item = x.Remove(item)
         override x.Update item priority = x.Update(item, priority)
-        override x.Choose priority = x.Choose(priority)
+        override x.Choose() = x.Choose(always true)
+        override x.Choose(selector) = x.Choose(selector)
         override x.Contains item = x.Contains(item)
         override x.TryGetPriority item = x.TryGetWeight(item)
         override x.Clear() = x.Clear()
-        override x.MaxPriority = x.MaxWeight
         override x.Count = x.Count
         override x.ToSeq = x.ToSeq
 
@@ -290,8 +298,8 @@ module public DiscretePDF =
     let insert (dpdf: DiscretePDF<'a>) item weight = dpdf.Insert(item, weight)
     let remove (dpdf: DiscretePDF<'a>) item = dpdf.Remove(item)
     let update (dpdf: DiscretePDF<'a>) item weight = dpdf.Update(item, weight)
-    let choose (dpdf: DiscretePDF<'a>) weight = dpdf.Choose weight
-    let maxWeight (dpdf: DiscretePDF<'a>) = dpdf.MaxWeight
+    let choose (dpdf: DiscretePDF<'a>) = (dpdf :> IPriorityCollection<'a>).Choose()
+    let chooseWithSelector (dpdf: DiscretePDF<'a>) selector = (dpdf :> IPriorityCollection<'a>).Choose(selector)
     let contains (dpdf: DiscretePDF<'a>) item = dpdf.Contains(item)
     let tryGetWeight (dpdf: DiscretePDF<'a>) item = dpdf.TryGetWeight item
     let toSeq (dpdf: DiscretePDF<'a>) = dpdf.ToSeq


### PR DESCRIPTION
- Make SILI work with multiple methods simultaneously: entry point states are added to the same searcher
- Add Pick method with selector function to IForwardSearcher
- Add new fair searcher, which shares execution between different methods according to given timeout