### PR TITLE
Interprocedural searcher

### DIFF
--- a/VSharp.API/VSharp.cs
+++ b/VSharp.API/VSharp.cs
@@ -30,6 +30,10 @@ namespace VSharp
         /// </summary>
         ShortestDistance,
         /// <summary>
+        /// Picks the state closest to not covered locations (considering function calls).
+        /// </summary>
+        InterproceduralShortestDistance,
+        /// <summary>
         /// With a high probability picks the state closest to not covered locations.
         /// </summary>
         RandomShortestDistance,
@@ -238,7 +242,8 @@ namespace VSharp
                 SearchStrategy.ShortestDistance => searchMode.ShortestDistanceBasedMode,
                 SearchStrategy.RandomShortestDistance => searchMode.RandomShortestDistanceBasedMode,
                 SearchStrategy.ContributedCoverage => searchMode.ContributedCoverageMode,
-                SearchStrategy.Interleaved => searchMode.NewInterleavedMode(searchMode.ShortestDistanceBasedMode, 1, searchMode.ContributedCoverageMode, 9)
+                SearchStrategy.Interleaved => searchMode.NewInterleavedMode(searchMode.ShortestDistanceBasedMode, 1, searchMode.ContributedCoverageMode, 9),
+                SearchStrategy.InterproceduralShortestDistance => searchMode.InterproceduralShortestDistanceMode
             };
         }
 

--- a/VSharp.SILI/BidirectionalSearcher.fs
+++ b/VSharp.SILI/BidirectionalSearcher.fs
@@ -78,6 +78,8 @@ type BidirectionalSearcher(forward : IForwardSearcher, backward : IBackwardSearc
             backward.Reset()
             targeted.Reset()
 
+        override x.Refresh() = forward.Refresh()
+
         override x.Remove cilState =
             forward.Remove cilState
             backward.Remove cilState
@@ -98,6 +100,7 @@ type OnlyForwardSearcher(searcher : IForwardSearcher) =
             | Some s -> GoFront s
             | None -> Stop
         override x.States() = searcher.States()
+        override x.Refresh() = searcher.Refresh()
         override x.Reset() = searcher.Reset()
         override x.Remove cilState = searcher.Remove cilState
         override x.StatesCount with get() = searcher.StatesCount

--- a/VSharp.SILI/CombinedWeighter.fs
+++ b/VSharp.SILI/CombinedWeighter.fs
@@ -7,20 +7,18 @@ open VSharp.Interpreter.IL.TypeUtils
 /// <summary>
 /// Combines two weighters using the given combinator function.
 /// </summary>
-type internal CombinedWeighter(one : IWeighter, another : IWeighter, maxPriority : uint, combinator : uint option -> uint option -> uint option) =
+type internal CombinedWeighter(one : IWeighter, another : IWeighter, combinator : uint option -> uint option -> uint option) =
 
     interface IWeighter with
         override x.Weight(state) =
             let oneWeight = one.Weight state
             let anotherWeight = another.Weight state
             combinator oneWeight anotherWeight
-        override x.Next() = maxPriority
 
 type internal AugmentedWeighter(baseWeighter : IWeighter, mapping : uint option -> uint option) =
 
         interface IWeighter with
             override x.Weight(state) = baseWeighter.Weight state |> mapping
-            override x.Next() = baseWeighter.Next()
 
 module internal WeightOperations =
 

--- a/VSharp.SILI/ConcolicSearcher.fs
+++ b/VSharp.SILI/ConcolicSearcher.fs
@@ -9,5 +9,6 @@ type internal ConcolicSearcher(baseSearcher : IForwardSearcher) =
         override x.Update(parent, newStates) = baseSearcher.Update(parent, newStates)
         override x.States() = baseSearcher.States()
         override x.Reset() = baseSearcher.Reset()
+        override x.Refresh() = baseSearcher.Refresh()
         override x.Remove cilState = baseSearcher.Remove cilState
         override x.StatesCount with get() = baseSearcher.StatesCount

--- a/VSharp.SILI/ContributedCoverageSearcher.fs
+++ b/VSharp.SILI/ContributedCoverageSearcher.fs
@@ -12,7 +12,6 @@ type internal ContributedCoverageWeighter(statistics : SILIStatistics) =
 
     interface IWeighter with
         override x.Weight(state) = weight state
-        override x.Next() = UInt32.MaxValue
 
 type internal ContributedCoverageSearcher(maxBound, statistics) =
     inherit WeightedSearcher(maxBound, ContributedCoverageWeighter(statistics), BidictionaryPriorityQueue())
@@ -21,8 +20,6 @@ type internal ContributedCoverageWithDistanceAsFallbackWeighter(statistics) =
     inherit CombinedWeighter(
         ContributedCoverageWeighter(statistics),
         IntraproceduralShortestDistanceToUncoveredWeighter(statistics),
-        UInt32.MaxValue,
         WeightOperations.withInverseLinearFallback 100u)
-
 type internal ContributedCoverageWithDistanceAsFallbackSearcher(maxBound, statistics) =
     inherit WeightedSearcher(maxBound, ContributedCoverageWithDistanceAsFallbackWeighter(statistics), BidictionaryPriorityQueue())

--- a/VSharp.SILI/DistanceWeighter.fs
+++ b/VSharp.SILI/DistanceWeighter.fs
@@ -93,7 +93,6 @@ type ShortestDistanceWeighter(target : codeLocation) =
                     return weight * logarithmicScale state.stepsNumber
                 | None -> return 1u
             }
-        override x.Next() = 0u
 
 type IntraproceduralShortestDistanceToUncoveredWeighter(statistics : SILIStatistics) =
 
@@ -107,6 +106,7 @@ type IntraproceduralShortestDistanceToUncoveredWeighter(statistics : SILIStatist
                 |> Seq.fold (fun min kvp ->
                     let loc = { offset = kvp.Key; method = method }
                     let distance = kvp.Value
+                    // TODO: check all instructions of basic block for coverage
                     if distance < min && distance <> 0u && not <| statistics.IsCovered loc then distance
                     else min) infinity
             Some minDistance
@@ -118,5 +118,3 @@ type IntraproceduralShortestDistanceToUncoveredWeighter(statistics : SILIStatist
                 | Some loc when loc.method.InCoverageZone -> minDistance loc.method loc.offset
                 | Some _ -> None
                 | None -> Some 1u)
-
-        override x.Next() = 0u

--- a/VSharp.SILI/FairSearcher.fs
+++ b/VSharp.SILI/FairSearcher.fs
@@ -131,6 +131,8 @@ type internal FairSearcher(baseSearcherFactory : unit -> IForwardSearcher, timeo
 
     let remove cilState = baseSearcher.Remove cilState
 
+    let refresh() = baseSearcher.Refresh()
+
     member x.BaseSearcher with get() = baseSearcher
 
     interface IForwardSearcher with
@@ -141,4 +143,5 @@ type internal FairSearcher(baseSearcherFactory : unit -> IForwardSearcher, timeo
         override x.States() = states()
         override x.Reset() = reset()
         override x.Remove cilState = remove cilState
+        override x.Refresh() = refresh()
         override x.StatesCount with get() = baseSearcher.StatesCount

--- a/VSharp.SILI/InterleavedSearcher.fs
+++ b/VSharp.SILI/InterleavedSearcher.fs
@@ -32,6 +32,8 @@ type InterleavedSearcher(searchersWithStepCount: (IForwardSearcher * int) list) 
 
     let states() = searchersWithStepCount |> Seq.collect (fun (s, _) -> s.States()) |> Seq.distinct
 
+    let refresh() = for searcher, _ in searchersWithStepCount do searcher.Refresh()
+
     let reset() = for searcher, _ in searchersWithStepCount do searcher.Reset()
 
     let remove cilState = for searcher, _ in searchersWithStepCount do searcher.Remove cilState
@@ -42,6 +44,7 @@ type InterleavedSearcher(searchersWithStepCount: (IForwardSearcher * int) list) 
         override x.Pick selector = pick (Some selector)
         override x.Update (parent, newStates) = update (parent, newStates)
         override x.States() = states()
+        override x.Refresh() = refresh()
         override x.Reset() = reset()
         override x.Remove cilState = remove cilState
         override x.StatesCount with get() = searchersEnumerator.Current.StatesCount

--- a/VSharp.SILI/InterproceduralSearcher.fs
+++ b/VSharp.SILI/InterproceduralSearcher.fs
@@ -1,0 +1,332 @@
+namespace VSharp.Interpreter.IL
+
+open System
+open System.Collections.Generic
+open Microsoft.FSharp.Core
+open VSharp
+open VSharp.GraphUtils
+open VSharp.Interpreter.IL
+open VSharp.Utils
+open CilStateOperations
+
+[<StructuralEquality; CustomComparison>]
+type InterprocDistance =
+    | Approximate of uint
+    | Precise of uint
+    | Infinity
+
+    member x.IsPrecise_ =
+        match x with
+        | Precise _ -> true
+        | _ -> false
+
+    member x.IsApproximate_ =
+        match x with
+        | Approximate _ -> true
+        | _ -> false
+
+    member x.Unwrap() =
+        match x with
+        | Approximate d
+        | Precise d -> d
+        | Infinity -> UInt32.MaxValue
+
+    static member (+) (one, another) =
+        match one, another with
+        | Infinity, _ | _, Infinity -> Infinity
+        | Precise d1, Precise d2 -> Precise(d1 + d2)
+        | Approximate d1, Precise d2
+        | Precise d1, Approximate d2
+        | Approximate d1, Approximate d2 -> Approximate(d1 + d2)
+
+    interface IComparable with
+        member this.CompareTo other =
+            match other with
+            | :? InterprocDistance as other -> (this :> IComparable<_>).CompareTo other
+            | _ -> invalidArg (nameof(other)) "(InterprocDistance) Types of compared objects don't match"
+
+    interface IComparable<InterprocDistance> with
+        member this.CompareTo other =
+            match this, other with
+            | Infinity, Infinity -> 0
+            | Infinity, _ -> 1
+            | _, Infinity -> -1
+            | Approximate d1, Precise d2 -> 1
+            | Precise d1, Approximate d2 -> -1
+            | Approximate d1, Approximate d2
+            | Precise d1, Precise d2 -> d1.CompareTo d2
+
+type private callTree = {
+        parent : callTree option
+        children : HashSet<callTree>
+        callLocation : codeLocation option
+        mutable minDistanceToUncoveredOnReturn : InterprocDistance
+    }
+
+type private distanceCache = Dictionary<offset, Dictionary<offset, InterprocDistance>>
+
+type InterproceduralSearcher(maxBound, statistics : SILIStatistics) =
+
+    let mutable priorityQueue : IPriorityCollection<cilState, InterprocDistance> = BidictionaryPriorityQueue()
+
+    let callTreeRoot = {
+        parent = None
+        children = HashSet()
+        callLocation = None
+        minDistanceToUncoveredOnReturn = Precise 0u
+    }
+
+    let callTrees = Dictionary<cilState, callTree>()
+    let callWeights = Dictionary<Method, InterprocDistance * HashSet<Method>>()
+    let dijkstraWeightCaches = Dictionary<Method, distanceCache>()
+    let returnsCache = Dictionary<Method, HashSet<offset>>()
+
+    let ignoreState s = violatesLevel s maxBound
+
+    let getReturns method =
+        Dict.getValueOrUpdate returnsCache method (fun _ ->  HashSet method.CFG.Sinks)
+
+    let getCallWeight method =
+        if callWeights.ContainsKey method then
+            let weight, _ = callWeights.[method]
+            weight
+        else
+            Approximate 1u
+
+    let getCallInfo codeLocation =
+        if codeLocation.method.CFG.Calls.ContainsKey codeLocation.offset then
+            Some codeLocation.method.CFG.Calls.[codeLocation.offset]
+        else
+            None
+
+    let stepWeight toLocation =
+        let callInfo = getCallInfo toLocation
+        if callInfo.IsSome then (getCallWeight callInfo.Value.Callee) + Precise 1u else Precise 1u
+
+    let dijkstra offsetFrom (edges : graph<offset>) (cache : distanceCache) method =
+        let dist = Dictionary<offset, InterprocDistance>()
+        dist.Add (offsetFrom, Precise 0u)
+        let queue = Queue<_>()
+        queue.Enqueue offsetFrom
+        while not <| Seq.isEmpty queue do
+            let parent = queue.Dequeue()
+            if cache.ContainsKey parent then
+                for parentWeight in cache.[parent] do
+                    if not <| dist.ContainsKey parentWeight.Key then
+                        dist.Add (parentWeight.Key, dist.[parent] + parentWeight.Value)
+            else
+                for child in edges.[parent] do
+                    let codeLocation = { offset = child; method = method }
+                    if dist.ContainsKey child && dist.[parent] + stepWeight codeLocation < dist.[child] then
+                        dist.Remove child |> ignore
+                    if not <| dist.ContainsKey child then
+                        dist.Add (child, dist.[parent] + stepWeight codeLocation)
+                        queue.Enqueue child
+        dist
+
+    let localDistancesFrom location =
+        let cfg = location.method.CFG
+        let basicBlock = cfg.ResolveBasicBlock location.offset
+        let distanceCache = Dict.getValueOrUpdate dijkstraWeightCaches location.method distanceCache
+
+        Dict.getValueOrUpdate distanceCache basicBlock (fun () ->
+            dijkstra basicBlock cfg.Edges distanceCache location.method)
+
+    let getMinDistanceToReturn codeLocation =
+        let localDistances = localDistancesFrom codeLocation
+        let returns = getReturns codeLocation.method
+        let distancesToReturn = returns |> Seq.filter localDistances.ContainsKey |> Seq.map (fun o -> localDistances.[o])
+        if Seq.isEmpty distancesToReturn then Precise 0u else Seq.min distancesToReturn
+
+    let getMinDistanceToUncoveredAndToReturn codeLocation =
+        let localDistances = localDistancesFrom codeLocation
+        let returns = getReturns codeLocation.method
+        let updateMinDistances (currentMinToUncovered, currentMinToReturn) (kvp : KeyValuePair<offset, InterprocDistance>) =
+            // TODO: check all instructions of basic block for coverage
+            let loc = { offset = kvp.Key; method = codeLocation.method }
+            let distance = kvp.Value
+            let newMinToUncovered =
+                if distance < currentMinToUncovered && distance.Unwrap() <> 0u && not <| CodeLocation.isBasicBlockCoveredByTest loc then distance
+                else currentMinToUncovered
+            let newMinToReturn =
+                if distance < currentMinToReturn && (returns.Contains kvp.Key) then distance
+                else currentMinToReturn
+            newMinToUncovered, newMinToReturn
+        let minToUncovered, minToReturn = Seq.fold updateMinDistances (Infinity, Infinity) localDistances
+        if minToReturn = Infinity then minToUncovered, Precise 0u else minToUncovered, minToReturn
+
+    let weightLocation location minDistanceOnReturn =
+        if not <| location.method.InCoverageZone then
+            let minDistanceToReturn = getMinDistanceToReturn location
+            minDistanceToReturn + minDistanceOnReturn
+        else
+            let minDistanceToLocalUncovered, minDistanceToReturn = getMinDistanceToUncoveredAndToReturn location
+            min minDistanceToLocalUncovered (minDistanceToReturn + minDistanceOnReturn)
+
+    let weight state =
+        match ipOperations.ip2codeLocation state.ipStack.Head with
+        | Some location ->
+            let tree = callTrees.[state]
+            //assert tree.callLocation.IsSome
+            weightLocation location tree.minDistanceToUncoveredOnReturn
+        | None -> Precise 0u
+
+    // TODO: use CPS?
+    let rec updateCallTree (queue : Queue<callTree>) =
+        if queue.Count = 0 then
+            ()
+        else
+            let dequeued = queue.Dequeue()
+            match dequeued.callLocation with
+            | Some location ->
+                let newMinDistanceOnReturn = weightLocation location (if dequeued.parent.IsSome then dequeued.parent.Value.minDistanceToUncoveredOnReturn else Precise 0u)
+                if newMinDistanceOnReturn <> dequeued.minDistanceToUncoveredOnReturn && newMinDistanceOnReturn.IsApproximate_ && dequeued.minDistanceToUncoveredOnReturn.IsPrecise_ then
+                    Logger.info $"Distance is updated: {dequeued.minDistanceToUncoveredOnReturn} -> {newMinDistanceOnReturn}"
+                dequeued.minDistanceToUncoveredOnReturn <- newMinDistanceOnReturn
+            | None -> ()
+            dequeued.children |> Seq.iter queue.Enqueue
+            updateCallTree queue
+
+    let calculateCallWeight (method : Method) =
+        let startBlock = { method = method; offset = 0<offsets> }
+        getMinDistanceToReturn startBlock + stepWeight startBlock
+
+    let recalculateWeights() =
+        let queue = Queue()
+        queue.Enqueue callTreeRoot
+        updateCallTree queue
+
+        let states = priorityQueue.ToSeq
+        priorityQueue <- BidictionaryPriorityQueue()
+        for state in states do
+            let weight = weight state
+            priorityQueue.Insert state weight
+
+    // TODO: use CPS?
+    let rec updateCallWeights (preciseWeightMethods : Queue<Method>) =
+        if preciseWeightMethods.Count = 0 then
+            ()
+        else
+            let preciseWeightMethod = preciseWeightMethods.Dequeue()
+            Logger.info $"Weight for {preciseWeightMethod.Name} is precise, recalculate"
+            let weightsToRecalculate =
+                callWeights
+                |> Seq.map (|KeyValue|)
+                |> Seq.filter (fun (_, v) -> (snd v).Contains preciseWeightMethod)
+
+            for method, _ in weightsToRecalculate do
+                if dijkstraWeightCaches.ContainsKey method then
+                    dijkstraWeightCaches.[method].Clear()
+
+                let newWeight = calculateCallWeight method
+                callWeights.[method] <- (newWeight, snd callWeights.[method])
+
+                if newWeight.IsPrecise_ then
+                    preciseWeightMethods.Enqueue method
+
+            updateCallWeights preciseWeightMethods
+
+    let addCallWeight method =
+        let callWeight = calculateCallWeight method
+        let callees = method.CFG.Calls.Values |> Seq.map (fun ci -> ci.Callee) |> HashSet
+        callWeights.[method] <- (callWeight, callees)
+
+        if callWeight.IsPrecise_ then
+            let queue = Queue()
+            queue.Enqueue(method)
+            updateCallWeights queue
+            recalculateWeights()
+
+    let pushToTree state fromLoc =
+        let callTree = callTrees.[state]
+        let newCallTreeNode = {
+            parent = Some callTree
+            children = HashSet()
+            callLocation = fromLoc
+            minDistanceToUncoveredOnReturn =
+                if fromLoc.IsSome then weightLocation fromLoc.Value callTree.minDistanceToUncoveredOnReturn else Precise 0u
+        }
+        callTree.children.Add newCallTreeNode |> ignore
+        callTrees.[state] <- newCallTreeNode
+
+    let storageDump() =
+        Logger.info "Storage:"
+        priorityQueue.ToSeqWithPriority
+        |> Seq.sortByDescending snd
+        |> Seq.iter (fun (state, weight) ->
+            Logger.info $"{weight} {state.currentLoc.method} {state.currentLoc.offset}")
+
+    let init states =
+        for state in states |> Seq.filter (not << ignoreState) do
+            callTrees.[state] <- callTreeRoot
+            pushToTree state None
+            let weight = weight state
+            priorityQueue.Insert state weight
+
+    let pick() =
+        //storageDump()
+        priorityQueue.Choose()
+
+    let pickWithSelector selector = priorityQueue.Choose selector
+
+    let popFromTree state =
+        let callTree = callTrees.[state]
+        assert callTree.parent.IsSome
+        callTrees.[state] <- callTree.parent.Value
+
+    let update parent newStates =
+        if priorityQueue.Contains parent then
+            assert(callTrees.ContainsKey parent)
+            if ignoreState parent && priorityQueue.Contains parent then
+                priorityQueue.Remove parent
+            else
+                for event in parent.lastCallStackEvents do
+                    match event with
+                    | Push(fromLoc, _) -> pushToTree parent (Some fromLoc)
+                    | Pop -> popFromTree parent
+
+                let newParentWeight = weight parent
+                priorityQueue.Update parent newParentWeight
+
+                let tryAddCallWeight state =
+                    match ipOperations.ip2codeLocation state.ipStack.Head with
+                    | Some location ->
+                        if not <| callWeights.ContainsKey location.method then
+                            addCallWeight location.method
+                    | None -> ()
+
+                tryAddCallWeight parent
+
+                let parentCallTree = callTrees.[parent]
+
+                for state in newStates |> Seq.filter (not << ignoreState) do
+                    assert(not <| priorityQueue.Contains state)
+                    callTrees.[state] <- parentCallTree
+                    let weight = weight state
+                    priorityQueue.Insert state weight
+                    tryAddCallWeight state
+
+    let reset() =
+        priorityQueue.Clear()
+        callTrees.Clear()
+        callWeights.Clear()
+        dijkstraWeightCaches.Clear()
+        returnsCache.Clear()
+
+    let remove state =
+        if priorityQueue.Contains state then
+            priorityQueue.Remove state
+            callTrees.Remove state |> ignore
+
+    member x.RecalculateWeights() = recalculateWeights()
+
+    interface IForwardSearcher with
+        override x.Init states = init states
+        override x.Pick() = pick()
+        override x.Pick(selector) = pickWithSelector selector
+        override x.Update (parent, newStates) = update parent newStates
+        override x.States() = priorityQueue.ToSeq
+        override x.Refresh() = x.RecalculateWeights()
+        override x.Remove(state) = remove state
+        override x.Reset() = reset()
+        override x.StatesCount with get() = int priorityQueue.Count

--- a/VSharp.SILI/Options.fs
+++ b/VSharp.SILI/Options.fs
@@ -11,6 +11,7 @@ type searchMode =
     | ContributedCoverageMode
     | FairMode of searchMode
     | InterleavedMode of searchMode * int * searchMode * int
+    | InterproceduralShortestDistanceMode
     | ConcolicMode of searchMode
     | GuidedMode of searchMode
 

--- a/VSharp.SILI/SILI.fs
+++ b/VSharp.SILI/SILI.fs
@@ -70,6 +70,7 @@ type public SILI(options : SiliOptions) =
             FairSearcher((fun _ -> mkForwardSearcher baseMode), uint branchReleaseTimeout, statistics) :> IForwardSearcher
         | InterleavedMode(base1, stepCount1, base2, stepCount2) ->
             InterleavedSearcher([mkForwardSearcher base1, stepCount1; mkForwardSearcher base2, stepCount2]) :> IForwardSearcher
+        | InterproceduralShortestDistance -> InterproceduralSearcher(infty, statistics) :> IForwardSearcher
         | GuidedMode baseMode ->
             let baseSearcher = mkForwardSearcher baseMode
             GuidedSearcher(infty, options.recThreshold, baseSearcher, StatisticsTargetCalculator(statistics)) :> IForwardSearcher
@@ -116,6 +117,7 @@ type public SILI(options : SiliOptions) =
                     match TestGenerator.state2test isError entryMethod cmdArgs cilState message with
                     | Some test ->
                         statistics.TrackFinished cilState
+                        searcher.Refresh()
                         reporter test
                     | None -> ()
         with :? InsufficientInformationException as e ->
@@ -286,6 +288,7 @@ type public SILI(options : SiliOptions) =
         Application.moveState loc s (Seq.cast<_> newStates)
         statistics.TrackFork s newStates
         searcher.UpdateStates s newStates
+        clearLastCallStackEvents s
 
     member private x.Backward p' s' =
         assert(currentLoc s' = p'.loc)

--- a/VSharp.SILI/Searcher.fs
+++ b/VSharp.SILI/Searcher.fs
@@ -20,6 +20,7 @@ type IBidirectionalSearcher =
     abstract member Answer : pob -> pobStatus -> unit
     abstract member Statuses : unit -> seq<pob * pobStatus>
     abstract member States : unit -> cilState seq
+    abstract member Refresh : unit -> unit
     abstract member Reset : unit -> unit
     abstract member Remove : cilState -> unit
     abstract member StatesCount : int
@@ -30,6 +31,7 @@ type IForwardSearcher =
     abstract member Pick : unit -> cilState option
     abstract member Pick : (cilState -> bool) -> cilState option
     abstract member States : unit -> cilState seq
+    abstract member Refresh : unit -> unit
     abstract member Reset : unit -> unit
     abstract member Remove : cilState -> unit
     abstract member StatesCount : int
@@ -80,6 +82,7 @@ type SimpleForwardSearcher(maxBound) =
         override x.Update (parent, newStates) =
             x.Insert forPropagation (parent, newStates)
         override x.States() = forPropagation
+        override x.Refresh() = ()
         override x.Reset() = forPropagation.Clear()
         override x.Remove cilState = forPropagation.Remove cilState |> ignore
         override x.StatesCount with get() = forPropagation.Count
@@ -116,9 +119,8 @@ type DFSSearcher(maxBound) =
 
 type IWeighter =
     abstract member Weight : cilState -> uint option
-    abstract member Next : unit -> uint
 
-type WeightedSearcher(maxBound, weighter : IWeighter, storage : IPriorityCollection<cilState>) =
+type WeightedSearcher(maxBound, weighter : IWeighter, storage : IPriorityCollection<cilState, uint>) =
     let optionWeight s =
         try
             option {
@@ -160,6 +162,7 @@ type WeightedSearcher(maxBound, weighter : IWeighter, storage : IPriorityCollect
         override x.Pick selector = x.Pick selector
         override x.Update (parent, newStates) = x.Update (parent, newStates)
         override x.States() = storage.ToSeq
+        override x.Refresh() = ()
         override x.Reset() = storage.Clear()
         override x.Remove cilState = if storage.Contains cilState then storage.Remove cilState
         override x.StatesCount with get() = int x.Count

--- a/VSharp.SILI/TargetedSearcher.fs
+++ b/VSharp.SILI/TargetedSearcher.fs
@@ -230,6 +230,7 @@ type GuidedSearcher(maxBound, threshold : uint, baseSearcher : IForwardSearcher,
         override x.Pick selector = pick (Some selector)
         override x.Update (parent, newStates) = update parent newStates
         override x.States() = baseSearcher.States()
+        override x.Refresh() = ()
         override x.Reset() = reset ()
         override x.Remove cilState = remove cilState
         override x.StatesCount with get() = baseSearcher.StatesCount + (targetedSearchers.Values |> Seq.sumBy (fun s -> int s.Count))

--- a/VSharp.SILI/VSharp.SILI.fsproj
+++ b/VSharp.SILI/VSharp.SILI.fsproj
@@ -47,6 +47,7 @@
         <Compile Include="ContributedCoverageSearcher.fs" />
         <Compile Include="DFSSortedByContributedCoverageSearcher.fs" />
         <Compile Include="InterleavedSearcher.fs" />
+        <Compile Include="InterproceduralSearcher.fs" />
         <Compile Include="TargetedSearcher.fs" />
         <Compile Include="FairSearcher.fs" />
         <Compile Include="BidirectionalSearcher.fs" />

--- a/VSharp.Test/IntegrationTests.cs
+++ b/VSharp.Test/IntegrationTests.cs
@@ -24,7 +24,8 @@ namespace VSharp.Test
         ShortestDistance,
         RandomShortestDistance,
         ContributedCoverage,
-        Interleaved
+        Interleaved,
+        InterproceduralShortestDistance
     }
 
     public enum CoverageZone
@@ -189,6 +190,7 @@ namespace VSharp.Test
                     SearchStrategy.RandomShortestDistance => searchMode.RandomShortestDistanceBasedMode,
                     SearchStrategy.ContributedCoverage => searchMode.ContributedCoverageMode,
                     SearchStrategy.Interleaved => searchMode.NewInterleavedMode(searchMode.ShortestDistanceBasedMode, 1, searchMode.ContributedCoverageMode, 9),
+                    SearchStrategy.InterproceduralShortestDistance => searchMode.InterproceduralShortestDistanceMode,
                     _ => throw new ArgumentOutOfRangeException(nameof(strat), strat, null)
                 };
 

--- a/VSharp.Test/Tests/LoanExam.cs
+++ b/VSharp.Test/Tests/LoanExam.cs
@@ -194,7 +194,7 @@ public class LoanExam
         }
     }
 
-    [TestSvm(95, 0, -1, false, strat: SearchStrategy.Interleaved, coverageZone: CoverageZone.Class)]
+    [TestSvm(95, 0, 40, false, strat: SearchStrategy.InterproceduralShortestDistance, releaseBranches: true)]
     public CreditResult Build(Request request)
     {
         var SumPoints = 0;

--- a/VSharp.Utils/PriorityCollection.fs
+++ b/VSharp.Utils/PriorityCollection.fs
@@ -1,25 +1,28 @@
 namespace VSharp.Utils
 
+open System
 open System.Collections.Generic
 open System.Linq
 
 open VSharp
 
-type IPriorityCollection<'a> =
-    abstract member Insert : 'a -> uint -> unit
+type IPriorityCollection<'a, 'b> =
+    abstract member Insert : 'a -> 'b -> unit
     abstract member Remove : 'a -> unit
-    abstract member Update : 'a -> uint -> unit
+    abstract member Update : 'a -> 'b -> unit
     abstract member Choose : unit -> 'a option
     abstract member Choose : ('a -> bool) -> 'a option
     abstract member Contains : 'a -> bool
-    abstract member TryGetPriority : 'a -> uint option
+    abstract member TryGetPriority : 'a -> 'b option
     abstract member Clear : unit -> unit
     abstract member Count : uint
     abstract member ToSeq : 'a seq
+    abstract member ToSeqWithPriority : ('a * 'b) seq
 
-type BidictionaryPriorityQueue<'a when 'a : equality>() =
-    let valuesToPriority = Dictionary<'a, uint>()
-    let priorityToList = SortedDictionary<uint, LinkedList<'a>>()
+// Less == better
+type BidictionaryPriorityQueue<'a, 'b when 'a : equality and 'b : comparison>() =
+    let valuesToPriority = Dictionary<'a, 'b>()
+    let priorityToList = SortedDictionary<'b, LinkedList<'a>>()
     let isEmpty () = valuesToPriority.Count = 0
     let insert item priority =
         assert(not <| valuesToPriority.ContainsKey item)
@@ -53,7 +56,7 @@ type BidictionaryPriorityQueue<'a when 'a : equality>() =
         valuesToPriority.Clear()
         priorityToList.Clear()
 
-    interface IPriorityCollection<'a> with
+    interface IPriorityCollection<'a, 'b> with
         override x.Insert item priority = insert item priority
         override x.Remove item = remove item
         override x.Update item priority =
@@ -66,3 +69,4 @@ type BidictionaryPriorityQueue<'a when 'a : equality>() =
         override x.Clear() = clear ()
         override x.Count = uint valuesToPriority.Count
         override x.ToSeq = valuesToPriority.Keys |> seq
+        override x.ToSeqWithPriority = valuesToPriority |> Seq.map (|KeyValue|)


### PR DESCRIPTION
New searcher, which selects (hopefully 😺) a state closest to not covered yet instruction, calculating distance considering whole call stack (current ShortestDistance works only within a function)

How it works:

A "CallTree" data structure is maintained: it is like a persistent call stack, saving all call chains which appeared during execution.  In each tree node (stack frame in fact) we save distance from it's return point to the closest not covered basic block.

We have:

`D1` --- distance from the current location to the closest return
`D2` --- distance from the return point of the current method to the closest not covered basic block (which we save in CallTree)
`D3` --- distance from the current location to the closest not covered basic block _in current method_

Then the final distance is calculated recursively as follows:

If state's method location is not in coverage zone:  `D1 + D2`
If state's method location is in coverage zone: `min(D3, D1 + D2)`

This distance is used as states' weight.

Distance itself is not just a number: it also can be Approximate or Precise. Approximate means that there are some calls in the path for which we don't know how deep they would be. In precise distances all calls are known and already considered. Approximate distances are always considered "bigger" than precise ones.

When we finish the exploration of method without calls, distances are recalculated, as some approximate distances become precise in this moment.

Another case when distances are recalculated is test generation event: not covered basic blocks could become covered