### PR TITLE
Add Docker image publishing for UTBot integration

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - master
   workflow_dispatch:
+  workflow_call:
+
+# Cancel previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run_integration_tests:

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -1,0 +1,100 @@
+name: 'Run tests and publish docker image'
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: vsharp_cli
+  DOCKERFILE_PATH: docker/Dockerfile_runner_cli
+
+# Cancel previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run_tests:
+    uses: ./.github/workflows/integration_tests.yml
+  build:
+    uses: ./.github/workflows/build_vsharp.yml
+  publish-cli-image:
+    needs: [run_tests, build]
+    runs-on: ubuntu-20.04
+    steps:
+
+    - name: Checkout VSharp
+      uses: actions/checkout@v3
+      with:
+        submodules: false
+
+    - name: Download VSharp.Runner binaries
+      uses: actions/download-artifact@v3
+      with:
+        name: runner
+        path: ./runner
+    
+    - name: Zip VSharp.Runner binaries
+      run: |
+        cd ./runner
+        zip -r ${{ github.workspace }}/runner.zip ./*
+
+    - name: Set timezone
+      uses: szenius/set-timezone@v1.0
+      with:
+        timezoneLinux: "Europe/Moscow"
+
+    - name: Get commit short SHA
+      run:
+        echo "COMMIT_SHORT_SHA="$(git rev-parse --short HEAD)"" >> $GITHUB_ENV
+
+    - name: Set Docker tag
+      run:
+        echo "DOCKER_TAG="$(date +%Y).$(date +%-m).$(date +%-d)-${{ env.COMMIT_SHORT_SHA }}"" >> $GITHUB_ENV
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=raw,value=${{ env.DOCKER_TAG }}
+      
+    - name: Docker Buildx (build and push)
+      run: |
+        docker buildx build \
+          -f ${{ env.DOCKERFILE_PATH }} \
+          --cache-from "type=local,src=/tmp/.buildx-cache" \
+          --cache-to "type=local,dest=/tmp/.buildx-cache-new" \
+          --tag ${{ steps.meta.outputs.tags }} \
+          --build-arg VSHARP_RUNNER_ARCHIVE=runner.zip \
+          --push .
+      
+    # Temp fix
+    # https://github.com/docker/build-push-action/issues/252
+    # https://github.com/moby/buildkit/issues/1896
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/docker/Dockerfile_runner_cli
+++ b/docker/Dockerfile_runner_cli
@@ -1,0 +1,48 @@
+FROM mcr.microsoft.com/dotnet/aspnet:6.0.11-focal-amd64
+
+ARG VSHARP_RUNNER_ARCHIVE
+
+WORKDIR /usr/src/
+
+ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=6.0.403 \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        git \
+        wget \
+		unzip \
+        nano \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install .NET SDK
+RUN curl -fSL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-x64.tar.gz \
+    && dotnet_sha512='779b3e24a889dbb517e5ff5359dab45dd3296160e4cb5592e6e41ea15cbf87279f08405febf07517aa02351f953b603e59648550a096eefcb0a20fdaf03fadde' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet ./packs ./sdk ./sdk-manifests ./templates ./LICENSE.txt ./ThirdPartyNotices.txt \
+    && rm dotnet.tar.gz \
+    # Trigger first run experience by running arbitrary cmd
+    && dotnet help
+
+# Install VSharp runner
+
+COPY ${VSHARP_RUNNER_ARCHIVE} .
+
+RUN VSHARP_RUNNER_ARCHIVE_NAME="$(find /usr/src -type f -name '*.zip')" \
+	&& VSHARP_RUNNER_DIR=vsharp_runner \
+	&& mkdir ${VSHARP_RUNNER_DIR} \
+	&& unzip ${VSHARP_RUNNER_ARCHIVE_NAME} -d ${VSHARP_RUNNER_DIR} \
+	&& rm ${VSHARP_RUNNER_ARCHIVE_NAME}


### PR DESCRIPTION
Add new GitHub actions pipeline which runs integration tests on push to master and publishes Docker image with V# runner to packages