### PR TITLE
Fix generic types not found due to assembly loaded into wrong context

### DIFF
--- a/VSharp.TestRenderer/TestsRenderer.cs
+++ b/VSharp.TestRenderer/TestsRenderer.cs
@@ -582,7 +582,8 @@ public static class TestsRenderer
             try
             {
                 var method = test.Method;
-                Debug.Assert(method.DeclaringType == declaringType);
+                
+                Debug.Assert(method.DeclaringType?.GetGenericTypeDefinition() == declaringType.GetGenericTypeDefinition());
 
                 if (method.IsConstructor)
                     throw new NotImplementedException("rendering constructors not supported yet");

--- a/VSharp.Utils/AssemblyManager.fs
+++ b/VSharp.Utils/AssemblyManager.fs
@@ -38,7 +38,7 @@ type internal AssemblyResolveContext(assembly : Assembly) as this =
         assemblyContext.add_Resolving resolvingHandler
 
     new(assemblyPath : string) =
-        new AssemblyResolveContext(Assembly.LoadFile(assemblyPath))
+        new AssemblyResolveContext(Assembly.LoadFrom(assemblyPath))
 
     member private x.OnResolving (_ : AssemblyLoadContext) (assemblyName : AssemblyName) : Assembly =
         let compLib = x.TryGetFromCompilationLibs(assemblyName)

--- a/VSharp.Utils/UnitTest.fs
+++ b/VSharp.Utils/UnitTest.fs
@@ -162,8 +162,8 @@ type UnitTest private (m : MethodBase, info : testInfo, createCompactRepr : bool
     member x.Serialize(destination : string) =
         memoryGraph.Serialize info.memory
         let t = typeof<testInfo>
-        let extraAssempliesProperty = t.GetProperty("extraAssemblyLoadDirs")
-        extraAssempliesProperty.SetValue(info, Array.ofList extraAssemblyLoadDirs)
+        let extraAssembliesProperty = t.GetProperty("extraAssemblyLoadDirs")
+        extraAssembliesProperty.SetValue(info, Array.ofList extraAssemblyLoadDirs)
         let typeMocksProperty = t.GetProperty("typeMocks")
         typeMocksProperty.SetValue(info, typeMocks.ToArray() |> Array.map (fun m -> m.Serialize memoryGraph.Encode))
         let serializer = XmlSerializer t


### PR DESCRIPTION
- Replace LoadFile with LoadFrom in AssemblyManager. With LoadFile it seems that the assembly is loaded into separate context and then a type cannot be extracted from it by its name (similar issue: https://github.com/dotnet/runtime/issues/28870)
- Fixes https://github.com/VSharp-team/VSharp/issues/193: in TestRunner we use LoadFrom, so it works

TODO: run benches and check that all is fine