### PR TITLE
Serialize generic arguments as recursive xml nodes

### DIFF
--- a/VSharp.API/VSharp.cs
+++ b/VSharp.API/VSharp.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -367,7 +367,7 @@ namespace VSharp
         /// Generates test coverage for all public methods of specified types.
         /// </summary>
         /// <param name="types">Types to be covered with tests.</param>
-        /// <param name="timeout">Timeout for code exploration in seconds. Negative value means infinite timeout (up to exhaustive coverage or user interuption).</param>
+        /// <param name="timeout">Timeout for code exploration in seconds. Negative value means infinite timeout (up to exhaustive coverage or user interruption).</param>
         /// <param name="outputDirectory">Directory to place generated *.vst tests. If null or empty, process working directory is used.</param>
         /// <param name="renderTests">Flag, that identifies whether to render NUnit tests or not</param>
         /// <param name="searchStrategy">Strategy which symbolic virtual machine uses for branch selection.</param>
@@ -382,11 +382,13 @@ namespace VSharp
             SearchStrategy searchStrategy = DefaultSearchStrategy,
             Verbosity verbosity = DefaultVerbosity)
         {
-            List<MethodBase> methods = new List<MethodBase>();
+            var methods = new List<MethodBase>();
             var typesArray = types as Type[] ?? types.ToArray();
+            var assemblies = new HashSet<Assembly>();
+
             foreach (var type in typesArray)
             {
-                AssemblyManager.LoadCopy(type.Module.Assembly);
+                assemblies.Add(type.Assembly);
                 methods.AddRange(type.EnumerateExplorableMethods());
             }
 
@@ -394,6 +396,11 @@ namespace VSharp
             {
                 var names = String.Join(", ", typesArray.Select(t => t.FullName));
                 throw new ArgumentException("I've not found any public methods or constructors of classes " + names);
+            }
+
+            foreach (var assembly in assemblies)
+            {
+                AssemblyManager.LoadCopy(assembly);
             }
 
             var statistics = StartExploration(methods, outputDirectory, coverageZone.ClassZone, searchStrategy, verbosity, null, timeout);
@@ -470,7 +477,10 @@ namespace VSharp
 
             var methods = new List<MethodBase> { entryPoint };
 
-            return StartExploration(methods, outputDirectory, coverageZone.MethodZone, searchStrategy, verbosity, args, timeout);
+            var statistics = StartExploration(methods, outputDirectory, coverageZone.MethodZone, searchStrategy, verbosity, args, timeout);
+            if (renderTests)
+                Render(statistics);
+            return statistics;
         }
 
         /// <summary>

--- a/VSharp.Runner/RunnerProgram.cs
+++ b/VSharp.Runner/RunnerProgram.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.CommandLine;

--- a/VSharp.Test/IntegrationTests.cs
+++ b/VSharp.Test/IntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;

--- a/VSharp.Test/Tests/Generic.cs
+++ b/VSharp.Test/Tests/Generic.cs
@@ -342,6 +342,33 @@ namespace IntegrationTests
             return a;
         }
     }
+
+    [TestSvmFixture]
+    public static class NestedGenerics
+    {
+        [TestSvm(100)]
+        public static int NestedGenericsSmokeTest(List<Bag<int>> list)
+        {
+            if (list.Count > 0)
+            {
+                return 0;
+            }
+
+            return 1;
+        }
+        
+        [TestSvm(100)]
+        public static int NestedGenericsSmokeTest2(Dictionary<int, Bag<int>> dict)
+        {
+            if (dict.Count > 0)
+            {
+                return 0;
+            }
+
+            return 1;
+        }
+    }
+
 //    public static class GenericCast
 //    {
 //        public static void FilterAndKeep(List<Pawn> listPawn, IKeeper<Pawn> bag)

--- a/VSharp.Utils/MemoryGraph.fs
+++ b/VSharp.Utils/MemoryGraph.fs
@@ -88,37 +88,38 @@ module Serialization =
 
     let rec encodeType ([<MaybeNull>] t : Type) : typeRepr =
         if t = null then {assemblyName = null; moduleFullyQualifiedName = null; name = null; genericArgs = null}
-        else                
+        else
             let name, arguments =
                 if t.IsGenericType then
                     if not t.IsConstructedGenericType then
                         internalfail "Encoding not constructed generic types not supported"
-                
+
                     let arguments = t.GetGenericArguments() |> Seq.map encodeType |> Seq.toArray
                     t.GetGenericTypeDefinition().FullName, arguments
                 else
                     t.FullName, null
-                    
+
             {assemblyName = t.Module.Assembly.FullName; moduleFullyQualifiedName = t.Module.FullyQualifiedName; name = name; genericArgs = arguments}
 
     [<MaybeNull>]
-    let rec decodeType (t : typeRepr) =
-        if t.assemblyName = null then null
-        else
+    let decodeType (t : typeRepr) =
+        let rec decodeTypeRec (t : typeRepr) =
             let mdle = Reflection.resolveModule t.assemblyName t.moduleFullyQualifiedName
             let typ = mdle.GetType t.name
             Debug.Assert(typ <> null)
-            
+
             if typ.IsGenericType then
                 Debug.Assert(t.genericArgs <> null && typ.GetGenericArguments().Length = t.genericArgs.Length)
-                
-                let args = t.genericArgs |> Seq.map decodeType |> Seq.toArray                
+
+                let args = t.genericArgs |> Seq.map decodeTypeRec |> Seq.toArray
                 typ.MakeGenericType args
             else
                 typ
-            
-            AssemblyManager.NormalizeType t1
-
+        if t.assemblyName = null then
+            null
+        else
+            let decodedType = decodeTypeRec t
+            AssemblyManager.NormalizeType decodedType
 
 type ITypeMockSerializer =
     abstract IsMockObject : obj -> bool

--- a/VSharp.Utils/Reflection.fs
+++ b/VSharp.Utils/Reflection.fs
@@ -63,7 +63,7 @@ module public Reflection =
                 try
                     AssemblyManager.LoadFromAssemblyName assemblyName
                 with _ ->
-                AssemblyManager.LoadFromAssemblyPath moduleName
+                    AssemblyManager.LoadFromAssemblyPath moduleName
         assembly.Modules |> Seq.find (fun m -> m.FullyQualifiedName = moduleName)
 
     let resolveMethodBase (assemblyName : string) (moduleName : string) (token : int32) =

--- a/VSharp.Utils/UnitTest.fs
+++ b/VSharp.Utils/UnitTest.fs
@@ -46,7 +46,7 @@ with
         methodTypeParameters = Array.empty
         mockClassTypeParameters = Array.empty
         mockMethodTypeParameters = Array.empty
-        throwsException = {assemblyName = null; moduleFullyQualifiedName = null; fullName = null}
+        throwsException = {assemblyName = null; moduleFullyQualifiedName = null; name = null; genericArgs = null}
         memory = {objects = Array.empty; types = Array.empty}
         extraAssemblyLoadDirs = Array.empty
         typeMocks = Array.empty
@@ -58,7 +58,7 @@ type UnitTest private (m : MethodBase, info : testInfo, createCompactRepr : bool
     let memoryGraph = MemoryGraph(info.memory, mocker, createCompactRepr)
     let exceptionInfo = info.throwsException
     let throwsException =
-        if exceptionInfo = {assemblyName = null; moduleFullyQualifiedName = null; fullName = null} then null
+        if exceptionInfo = {assemblyName = null; moduleFullyQualifiedName = null; name = null; genericArgs = null} then null
         else Serialization.decodeType exceptionInfo
     let thisArg = memoryGraph.DecodeValue info.thisArg
     let args = if info.args = null then null else info.args |> Array.map memoryGraph.DecodeValue


### PR DESCRIPTION
Use recursive XML nodes to represent generic arguments instead of fully qualified type name (because of some issues with getting types by fully qualified name)

Fixes issue https://github.com/VSharp-team/VSharp/issues/193

**Merge after https://github.com/VSharp-team/VSharp/pull/213https://github.com/VSharp-team/VSharp/pull/213**