### PR TITLE
LoanExam test regress fixes

### DIFF
--- a/VSharp.API/VSharp.cs
+++ b/VSharp.API/VSharp.cs
@@ -143,7 +143,7 @@ namespace VSharp
         private static Statistics StartExploration(IEnumerable<MethodBase> methods, string resultsFolder,
             coverageZone coverageZone, SearchStrategy searchStrategy, Verbosity verbosity, string[]? mainArguments = null, int timeout = -1)
         {
-            Logger.current_log_level = verbosity.ToLoggerLevel();
+            Logger.currentLogLevel = verbosity.ToLoggerLevel();
 
             var recThreshold = 0u;
             var unitTests = new UnitTests(resultsFolder);

--- a/VSharp.API/VSharp.cs
+++ b/VSharp.API/VSharp.cs
@@ -173,7 +173,11 @@ namespace VSharp
                 );
 
             using var explorer = new SILI(options);
-            Core.API.ConfigureSolver(SolverPool.mkSolver());
+
+            // Setting timeout / 2 as solver's timeout doesn't guarantee that SILI
+            // stops exactly in timeout. To guarantee that we need to pass timeout
+            // based on remaining time to solver dynamically.
+            Core.API.ConfigureSolver(SolverPool.mkSolver(timeout / 2 * 1000));
 
             void HandleInternalFail(Method? method, Exception exception)
             {

--- a/VSharp.API/VSharp.cs
+++ b/VSharp.API/VSharp.cs
@@ -61,11 +61,15 @@ namespace VSharp
         /// </summary>
         Error,
         /// <summary>
-        /// Error and info messages.
+        /// Error and warning messages.
+        /// </summary>
+        Warning,
+        /// <summary>
+        /// Error, warning and info messages.
         /// </summary>
         Info,
         /// <summary>
-        /// Only error messages with detailed continuous statistics saved to .csv file in the output directory.
+        /// Only error messages with detailed continuous statistics which is saved to .csv file in the output directory.
         /// </summary>
         StatisticsCollection
     }
@@ -193,14 +197,15 @@ namespace VSharp
                     messageBuilder.AppendLine($"Explored method: {method.DeclaringType}.{method.Name}");
                 }
 
-                messageBuilder.AppendLine($"Exception: {exception.GetType()} {exception.Message}");
+                messageBuilder.Append($"Exception: {exception.GetType()} {exception.Message}");
 
                 var trace = new StackTrace(exception, true);
                 var frame = trace.GetFrame(0);
 
                 if (frame is not null)
                 {
-                    messageBuilder.AppendLine($"At: {frame.GetFileName()}, {frame.GetFileLineNumber()}");
+                    messageBuilder.AppendLine();
+                    messageBuilder.Append($"At: {frame.GetFileName()}, {frame.GetFileLineNumber()}");
                 }
 
                 Logger.printLogString(Logger.Error, messageBuilder.ToString());
@@ -213,7 +218,7 @@ namespace VSharp
                     return;
                 }
 
-                Logger.printLogString(Logger.Critical, $"{exception}\n");
+                Logger.printLogString(Logger.Critical, $"{exception}");
             }
 
             var isolated = new List<MethodBase>();
@@ -279,6 +284,7 @@ namespace VSharp
                 Verbosity.Quiet => Logger.Quiet,
                 Verbosity.Critical => Logger.Critical,
                 Verbosity.Error => Logger.Error,
+                Verbosity.Warning => Logger.Warning,
                 Verbosity.Info => Logger.Info,
                 Verbosity.StatisticsCollection => Logger.Error
             };

--- a/VSharp.IL/CFG.fs
+++ b/VSharp.IL/CFG.fs
@@ -361,11 +361,11 @@ type ApplicationGraph() as this =
         //__notImplemented__()
 
     let moveState (initialPosition: codeLocation) (stateWithNewPosition: IGraphTrackableState) =
-        Logger.trace "Move state."
+        ()
         //__notImplemented__()
 
     let addStates (parentState:Option<IGraphTrackableState>) (states:array<IGraphTrackableState>) =
-        Logger.trace "Add states."
+        ()
         //__notImplemented__()
 
     let getShortestDistancesToGoals (states:array<codeLocation>) =

--- a/VSharp.IL/CFG.fs
+++ b/VSharp.IL/CFG.fs
@@ -300,10 +300,7 @@ and Method internal (m : MethodBase) as this =
     member x.BasicBlocksCount with get() =
         if x.HasBody then x.CFG.SortedOffsets |> Seq.length |> uint else 0u
 
-    member x.BlocksCoveredByTests with get() = blocksCoverage.Keys |> Set.ofSeq
-
-    member x.BlocksCoveredFromEntryPoint with get() =
-        blocksCoverage |> Seq.choose (fun kv -> if kv.Value = ByEntryPointTest then Some kv.Key else None) |> Set.ofSeq
+    member x.BlocksCoverage with get() = blocksCoverage :> IReadOnlyDictionary<_, _>
 
     member x.SetBlockIsCoveredByTest(offset : offset, testEntryMethod : Method) =
         match blocksCoverage.GetValueOrDefault(offset, ByTest) with

--- a/VSharp.IL/CFG.fs
+++ b/VSharp.IL/CFG.fs
@@ -514,4 +514,5 @@ module Application =
         MethodWithBody.InstantiateNew <- fun m -> getMethod m :> MethodWithBody
         Method.ReportCFGLoaded <- fun m ->
             graph.RegisterMethod m
-            let added = _loadedMethods.Add(m) in assert added
+            let added = lock _loadedMethods (fun () -> _loadedMethods.Add m)
+            assert added

--- a/VSharp.IL/CallGraph.fs
+++ b/VSharp.IL/CallGraph.fs
@@ -44,10 +44,12 @@ module CallGraph =
             if List.contains current processedMethods || not (fromCurrentAssembly assembly current) then exit processedMethods methodsQueue
             else
                 let processedMethods = current :: processedMethods
-                if current.HasBody then
-                    current.CFG.Calls |> Seq.iter (fun kvp ->
+                match current.CFG with
+                | Some cfg ->
+                    cfg.Calls |> Seq.iter (fun kvp ->
                         let m = kvp.Value.Callee
                         addCall methods methodsReachability current m)
+                | None -> ()
                 let newQ =
                     if methodsReachability.ContainsKey(current) then List.ofSeq methodsReachability.[current] @ methodsQueue
                     else methodsQueue
@@ -120,4 +122,3 @@ module CallGraph =
             if i.Value <> GraphUtils.infinity then
                 distToNode.Add(i.Key, i.Value)
         distToNode)
-

--- a/VSharp.IL/DotVisualizer.fs
+++ b/VSharp.IL/DotVisualizer.fs
@@ -19,7 +19,7 @@ type DotVisualizer(outputDirectory : DirectoryInfo) =
     let visitedEdges = HashSet<codeLocation * codeLocation>()
     let states = ResizeArray<IGraphTrackableState>()
 
-    let loc2BB loc = {method = loc.method; offset = loc.method.CFG.ResolveBasicBlock loc.offset}
+    let loc2BB loc = {method = loc.method; offset = loc.method.ForceCFG.ResolveBasicBlock loc.offset}
 
     let leave loc =
         stateMarkers.[loc] <- stateMarkers.[loc] - 1
@@ -53,7 +53,7 @@ type DotVisualizer(outputDirectory : DirectoryInfo) =
         $"{id fromLoc} -> {id toLoc} [color=\"{colorOfEdge fromLoc toLoc}\"]"
 
     let methodToDot (m : Method) =
-        let cfg = m.CFG
+        let cfg = m.ForceCFG
         seq{
             let name = m.FullName
             let id = m.Id

--- a/VSharp.Runner/RunnerProgram.cs
+++ b/VSharp.Runner/RunnerProgram.cs
@@ -37,9 +37,8 @@ namespace VSharp.Runner
             var specificClass =
                 assembly.GetType(classArgumentValue) ??
                 assembly.GetTypes()
-                    .Where(t => (t.FullName ?? t.Name)
-                    .Contains(classArgumentValue))
-                    .MinBy(t => t.Name.Length);
+                    .Where(t => (t.FullName ?? t.Name).Contains(classArgumentValue))
+                    .MinBy(t => t.FullName?.Length ?? t.Name.Length);
             if (specificClass == null)
             {
                 Console.Error.WriteLine("I did not found type you specified {0} in assembly {1}", classArgumentValue,

--- a/VSharp.SILI/CILState.fs
+++ b/VSharp.SILI/CILState.fs
@@ -17,7 +17,7 @@ type cilState =
       //TODO: #mb frames list #mb transfer to Core.State
       mutable iie : InsufficientInformationException option
       mutable level : level
-      mutable startingIP : ip
+      startingIP : ip
       mutable initialEvaluationStackSize : uint32
       mutable stepsNumber : uint
       mutable suspended : bool
@@ -68,8 +68,9 @@ module internal CilStateOperations =
         nextId
 
     let makeCilState entryMethod curV initialEvaluationStackSize state =
+        let currentLoc = ip2codeLocation curV |> Option.get
         { ipStack = [curV]
-          currentLoc = ip2codeLocation curV |> Option.get
+          currentLoc = currentLoc
           state = state
           filterResult = None
           iie = None
@@ -80,7 +81,7 @@ module internal CilStateOperations =
           suspended = false
           targets = None
           lastPushInfo = None
-          history = Set.empty
+          history = Set.singleton currentLoc
           entryMethod = Some entryMethod
           id = getNextStateId()
         }

--- a/VSharp.SILI/DistanceWeighter.fs
+++ b/VSharp.SILI/DistanceWeighter.fs
@@ -18,7 +18,7 @@ type ShortestDistanceWeighter(target : codeLocation) =
     // Returns the number proportional to distance from the offset in frameOffset of frameMethod to target. Uses both
     // call graph for interprocedural and CFG for intraprocedural distance approximation.
     let frameWeight (frameMethod : Method) frameOffset frameNumber =
-        let frameMethodCFG = frameMethod.CFG
+        let frameMethodCFG = frameMethod.ForceCFG
         let frameDist = frameMethodCFG.DistancesFrom frameOffset
         let checkDist () = Dict.tryGetValue frameDist target.offset infinity <> infinity
         let callWeight callMethod =
@@ -54,7 +54,7 @@ type ShortestDistanceWeighter(target : codeLocation) =
 
     // Returns the number proportional to distance from loc to target in CFG.
     let localWeight loc (tagets : codeLocation seq) =
-        let localCFG = loc.method.CFG
+        let localCFG = loc.method.ForceCFG
         let dist = localCFG.DistancesFrom loc.offset
         tagets
         |> Seq.fold (fun m l -> min m (Dict.tryGetValue dist l.offset infinity)) infinity
@@ -66,7 +66,7 @@ type ShortestDistanceWeighter(target : codeLocation) =
 
     // Returns the number proportional to distance from loc to relevant calls in this method
     let preTargetWeight currLoc =
-        let localCFG = currLoc.method.CFG
+        let localCFG = currLoc.method.ForceCFG
         let targets =
             localCFG.Calls
             |> Seq.filter (fun kv -> callGraphDistanceToTarget.ContainsKey kv.Value.Callee)
@@ -75,7 +75,7 @@ type ShortestDistanceWeighter(target : codeLocation) =
 
     // Returns the number proportional to distance from loc to return of this method
     let postTargetWeight currLoc =
-        let localCFG = currLoc.method.CFG
+        let localCFG = currLoc.method.ForceCFG
         let targets = localCFG.Sinks |> Seq.map (fun offset -> { offset = localCFG.ResolveBasicBlock offset; method = currLoc.method })
         localWeight currLoc targets |> Option.map ((+) 32u)
 
@@ -99,9 +99,8 @@ type IntraproceduralShortestDistanceToUncoveredWeighter(statistics : SILIStatist
 
     let minDistance (method : Method) fromLoc =
         let infinity = UInt32.MaxValue
-        if method.IsAbstract then None
-        else
-            let cfg = method.CFG
+        match method.CFG with
+        | Some cfg ->
             let minDistance =
                 cfg.DistancesFrom fromLoc
                 |> Seq.fold (fun min kvp ->
@@ -110,6 +109,7 @@ type IntraproceduralShortestDistanceToUncoveredWeighter(statistics : SILIStatist
                     if distance < min && distance <> 0u && not <| statistics.IsCovered loc then distance
                     else min) infinity
             Some minDistance
+        | None -> None
 
     interface IWeighter with
         override x.Weight(state) =

--- a/VSharp.SILI/FairSearcher.fs
+++ b/VSharp.SILI/FairSearcher.fs
@@ -91,7 +91,7 @@ type internal FairSearcher(baseSearcherFactory : unit -> IForwardSearcher, timeo
         types
 
     let onMethodRound methods =
-        List.sortBy (fun (m : Method) -> statistics.GetApproximateCoverage(m, coverageType.ByTest)) methods
+        List.sortBy (fun (m : Method) -> statistics.GetApproximateCoverage m) methods
 
     let init initialStates =
         baseSearcher.Init initialStates

--- a/VSharp.SILI/FairSearcher.fs
+++ b/VSharp.SILI/FairSearcher.fs
@@ -94,16 +94,15 @@ type internal FairSearcher(baseSearcherFactory : unit -> IForwardSearcher, timeo
         List.sortBy (fun (m : Method) -> statistics.GetApproximateCoverage m) methods
 
     let rec getCallsCount (m : Method) =
-        assert m.HasBody
         try
             match m.CFG with
             | Some cfg -> cfg.Calls.Count
-            // Internal call case
-            | None -> -1
+            | None ->
+                Logger.warning $"Fair searcher: cannot get CFG while getting calls count in {m.FullName}"
+                Int32.MaxValue
         with :? InsufficientInformationException as e ->
-            // IIEs will be propagated by SILI later if needed
-            Logger.info $"Fair searcher: IIE ({e.Message}) on getting calls count in {m.FullName}"
-            -1
+            Logger.warning $"Fair searcher: IIE ({e.Message}) on getting calls count in {m.FullName}"
+            Int32.MaxValue
 
     let init initialStates =
         baseSearcher.Init initialStates

--- a/VSharp.SILI/Interpreter.fs
+++ b/VSharp.SILI/Interpreter.fs
@@ -2031,7 +2031,7 @@ type internal ILInterpreter(isConcolicMode : bool) as this =
         let ip = currentIp cilState
         assert(ip.CanBeExpanded())
         let startingOffset = ip.Offset()
-        let cfg = m.CFG
+        let cfg = m.ForceCFG
         let endOffset =
             let lastOffset = Seq.last cfg.SortedOffsets
             let rec binarySearch l r =
@@ -2075,7 +2075,7 @@ type internal ILInterpreter(isConcolicMode : bool) as this =
         executeAllInstructions ([],[],[]) cilState id
 
     member private x.IncrementLevelIfNeeded (m : Method) (offset : offset) (cilState : cilState) =
-        let cfg = m.CFG
+        let cfg = m.ForceCFG
         if offset = 0<offsets> || cfg.IsLoopEntry offset then
             incrementLevel cilState {offset = offset; method = m}
 

--- a/VSharp.SILI/SILI.fs
+++ b/VSharp.SILI/SILI.fs
@@ -100,7 +100,7 @@ type public SILI(options : SiliOptions) =
     let reportState reporter isError cmdArgs cilState message =
         try
             searcher.Remove cilState
-            if cilState.history |> Seq.exists (not << statistics.IsBasicBlockCoveredByTest coverageType.ByEntryPointTest)
+            if cilState.history |> Seq.exists (not << statistics.IsBasicBlockCoveredByTest)
             then
                 let hasException =
                     match cilState.state.exceptionsRegister with
@@ -381,11 +381,10 @@ type public SILI(options : SiliOptions) =
             Application.setCoverageZone (inCoverageZone coverageZone entryMethods)
             if options.stopOnCoverageAchieved > 0 then
                 let checkCoverage() =
-                    let cov = statistics.GetApproximateCoverage(entryMethods, coverageType.ByEntryPointTest)
+                    let cov = statistics.GetApproximateCoverage entryMethods
                     cov >= uint options.stopOnCoverageAchieved
                 isCoverageAchieved <- checkCoverage
         | StackTraceReproductionMode _ -> __notImplemented__()
-        Application.resetMethodStatistics()
 
     member x.Interpret (isolated : MethodBase seq) (entryPoints : (MethodBase * string[]) seq) (onFinished : Action<UnitTest>)
                        (onException : Action<UnitTest>) (onIIE : Action<InsufficientInformationException>)

--- a/VSharp.SILI/SILI.fs
+++ b/VSharp.SILI/SILI.fs
@@ -400,7 +400,6 @@ type public SILI(options : SiliOptions) =
             reportInternalFail <- wrapOnInternalFail onInternalFail
             reportStateInternalFail <- wrapOnStateInternalFail onInternalFail
             reportCrash <- wrapOnCrash onCrash
-
             reportIncomplete <- wrapOnIIE onIIE
             reportStateIncomplete <- wrapOnStateIIE onIIE
             reportFinished <- wrapOnTest onFinished None

--- a/VSharp.SILI/SILI.fs
+++ b/VSharp.SILI/SILI.fs
@@ -15,7 +15,10 @@ open VSharp.Solver
 type public SILI(options : SiliOptions) =
 
     let timeout = if options.timeout <= 0 then Double.PositiveInfinity else float options.timeout * 1000.0
-    let branchReleaseTimeout = if options.timeout <= 0 || not options.releaseBranches then Double.PositiveInfinity else timeout * 80.0 / 100.0
+    let branchReleaseTimeout =
+        if options.timeout <= 0 then Double.PositiveInfinity
+        elif not options.releaseBranches then timeout
+        else timeout * 80.0 / 100.0
 
     let mutable branchesReleased = false
     let mutable isStopped = false
@@ -321,7 +324,7 @@ type public SILI(options : SiliOptions) =
         (* TODO: checking for timeout here is not fine-grained enough (that is, we can work significantly beyond the
                  timeout, but we'll live with it for now. *)
         while not isStopped && pick() && statistics.CurrentExplorationTime.TotalMilliseconds < timeout do
-            if statistics.CurrentExplorationTime.TotalMilliseconds >= branchReleaseTimeout then
+            if options.releaseBranches && statistics.CurrentExplorationTime.TotalMilliseconds >= branchReleaseTimeout then
                 releaseBranches()
             match action with
             | GoFront s ->

--- a/VSharp.SILI/Statistics.fs
+++ b/VSharp.SILI/Statistics.fs
@@ -244,23 +244,20 @@ type public SILIStatistics(statsDumpIntervalMs : int) as this =
         let mutable coveredBlocks = ref null
         if blocksCoveredByTests.TryGetValue(blockStart.method, coveredBlocks) then
             coveredBlocks.Value.Contains blockStart.offset
-        else
-            false
+        else false
 
     member x.GetApproximateCoverage (methods : Method seq) =
         let getCoveredBlocksCount (m : Method) =
             let mutable coveredBlocks = ref null
             if blocksCoveredByTests.TryGetValue(m, coveredBlocks) then
                 coveredBlocks.Value.Count
-            else
-                0
+            else 0
         let methodsInZone = methods |> Seq.filter (fun m -> m.InCoverageZone)
         let totalBlocksCount = methodsInZone |> Seq.sumBy (fun m -> m.BasicBlocksCount)
         let coveredBlocksCount = methodsInZone |> Seq.sumBy getCoveredBlocksCount
         if totalBlocksCount <> 0u then
             uint <| floor (double coveredBlocksCount / double totalBlocksCount * 100.0)
-        else
-            0u
+        else 0u
 
     member x.GetApproximateCoverage (method : Method) =
         x.GetApproximateCoverage(Seq.singleton method)
@@ -299,14 +296,12 @@ type public SILIStatistics(statsDumpIntervalMs : int) as this =
 
         let mutable coveredBlocks = ref null
         for block in s.history do
-
             if blocksCoveredByTests.TryGetValue(block.method, coveredBlocks) then
                 coveredBlocks.Value.Add block.offset |> ignore
             else
                 let coveredBlocks = HashSet()
                 coveredBlocks.Add block.offset |> ignore
                 blocksCoveredByTests[block.method] <- coveredBlocks
-
             if block.method.InCoverageZone then
                 isVisitedBlocksNotCoveredByTestsRelevant <- false
 

--- a/VSharp.SILI/Statistics.fs
+++ b/VSharp.SILI/Statistics.fs
@@ -232,7 +232,7 @@ type public SILIStatistics(statsDumpIntervalMs : int) as this =
         if not isVisitedBlocksNotCoveredByTestsRelevant then
             let currentCilStates = visitedBlocksNotCoveredByTests.Keys |> Seq.toList
             for cilState in currentCilStates do
-                let history = Set.filter (not << x.IsBasicBlockCoveredByTest coverageType.ByTest) cilState.history
+                let history = Set.filter (not << x.IsBasicBlockCoveredByTest) cilState.history
                 visitedBlocksNotCoveredByTests[cilState] <- history
             isVisitedBlocksNotCoveredByTestsRelevant <- true
 
@@ -320,6 +320,10 @@ type public SILIStatistics(statsDumpIntervalMs : int) as this =
         ()
 
     member x.TrackFork (parent : cilState) (children : cilState seq) =
+        if Logger.isTagEnabled Logger.stateTraceTag then
+            for child in children do
+                Logger.traceWithTag Logger.stateTraceTag $"BRANCH: {parent.id} -> {child.id}"
+
         let blocks = ref Set.empty
         // TODO: check why 'parent' may not be in 'visitedBlocksNotCoveredByTests'
         if visitedBlocksNotCoveredByTests.TryGetValue(parent, blocks) then

--- a/VSharp.SILI/TargetedSearcher.fs
+++ b/VSharp.SILI/TargetedSearcher.fs
@@ -186,7 +186,11 @@ type GuidedSearcher(maxBound, threshold : uint, baseSearcher : IForwardSearcher,
             pause state
 
     let rec pick' (selector : (cilState -> bool) option) =
-        let pick (searcher : IForwardSearcher) = if selector.IsSome then searcher.Pick selector.Value else searcher.Pick()
+        let pick (searcher : IForwardSearcher) =
+            if selector.IsSome then
+                searcher.Pick(fun s -> not <| isPaused s && selector.Value s)
+            else
+                searcher.Pick(not << isPaused)
         let pickFromBaseSearcher () =
             match pick baseSearcher with
             | Some state ->

--- a/VSharp.SILI/TargetedSearcher.fs
+++ b/VSharp.SILI/TargetedSearcher.fs
@@ -122,6 +122,12 @@ type GuidedSearcher(maxBound, threshold : uint, baseSearcher : IForwardSearcher,
                 state.targets <-Some (Set.add target Set.empty)
                 insertInTargetedSearcher state target
 
+    let deleteTargetedSearcher target =
+        let targetedSearcher = getTargetedSearcher target
+        for state in targetedSearcher.ToSeq () do
+            removeTarget state target
+        targetedSearchers.Remove target |> ignore
+
     let updateTargetedSearchers parent (newStates : cilState seq) =
         let addedCilStates = Dictionary<codeLocation, cilState list>()
         let updateParentTargets = getTargets parent
@@ -151,13 +157,8 @@ type GuidedSearcher(maxBound, threshold : uint, baseSearcher : IForwardSearcher,
         if not <| List.isEmpty reachedStates then
             reachedOrUnreachableTargets.Add kvpair.Key |> ignore
             for state in reachedStates do
+                deleteTargetedSearcher kvpair.Key
                 addReturnTarget state)
-
-    let deleteTargetedSearcher target =
-        let targetedSearcher = getTargetedSearcher target
-        for state in targetedSearcher.ToSeq () do
-            removeTarget state target
-        targetedSearchers.Remove target |> ignore
 
     let insertInTargetedSearchers states =
         states

--- a/VSharp.SILI/TargetedSearcher.fs
+++ b/VSharp.SILI/TargetedSearcher.fs
@@ -24,7 +24,7 @@ type TargetedSearcher(maxBound, target, isPaused) =
                 let currLoc = tryCurrentLoc state
                 match currLoc with
                 | Some loc ->
-                    let cfg = loc.method.CFG
+                    let cfg = loc.method.ForceCFG
                     cfg.IsBasicBlockStart loc.offset
                 | None -> false
 
@@ -89,7 +89,7 @@ type GuidedSearcher(maxBound, threshold : uint, baseSearcher : IForwardSearcher,
         let optCurrLoc = tryCurrentLoc s
         match optCurrLoc with
         | Some currLoc ->
-            let cfg = currLoc.method.CFG
+            let cfg = currLoc.method.ForceCFG
             let onVertex = cfg.IsBasicBlockStart currLoc.offset
             let level = if PersistentDict.contains currLoc s.level then s.level.[currLoc] else 0u
             onVertex && level > threshold
@@ -108,7 +108,7 @@ type GuidedSearcher(maxBound, threshold : uint, baseSearcher : IForwardSearcher,
     let addReturnTarget state =
         let startingLoc = startingLoc state
         let startingMethod = startingLoc.method
-        let cfg = startingMethod.CFG
+        let cfg = startingMethod.ForceCFG
 
         for retOffset in cfg.Sinks do
             let target = {offset = retOffset; method = startingMethod}

--- a/VSharp.Solver/SolverPool.fs
+++ b/VSharp.Solver/SolverPool.fs
@@ -11,9 +11,10 @@ module public SolverPool =
     let switchSolver (solver : SupportedSolvers) =
         currentSolver <- solver
 
-    let mkSolver () : ISolver =
+    let mkSolver (timeoutMs : int) : ISolver =
+        let timeoutOpt = if timeoutMs > 0 then Some(uint timeoutMs) else None
         match currentSolver with
-        | Z3 -> Z3.Z3Solver() :> ISolver
+        | Z3 -> Z3.Z3Solver timeoutOpt :> ISolver
 
     let reset() =
         Z3.reset()

--- a/VSharp.Test/IntegrationTests.cs
+++ b/VSharp.Test/IntegrationTests.cs
@@ -224,7 +224,7 @@ namespace VSharp.Test
                     );
                 }
 
-                Core.API.ConfigureSolver(SolverPool.mkSolver());
+                Core.API.ConfigureSolver(SolverPool.mkSolver(_timeout / 2 * 1000));
                 var methodInfo = innerCommand.Test.Method.MethodInfo;
                 var stats = new TestStatistics(
                     methodInfo,

--- a/VSharp.Test/IntegrationTests.cs
+++ b/VSharp.Test/IntegrationTests.cs
@@ -254,7 +254,15 @@ namespace VSharp.Test
                     using var explorer = new SILI(_options);
                     AssemblyManager.Load(methodInfo.Module.Assembly);
 
-                    explorer.Interpret(new [] { methodInfo }, new Tuple<MethodBase, string[]>[] {}, unitTests.GenerateTest, unitTests.GenerateError, _ => { }, (_, e) => throw e);
+                    explorer.Interpret(
+                        new [] { methodInfo },
+                        new Tuple<MethodBase, string[]>[] {},
+                        unitTests.GenerateTest,
+                        unitTests.GenerateError,
+                        _ => { },
+                        (_, e) => throw e,
+                        e => throw e
+                    );
 
                     if (unitTests.UnitTestsCount == 0 && unitTests.ErrorsCount == 0 && explorer.Statistics.IncompleteStates.Count == 0)
                     {

--- a/VSharp.Test/IntegrationTests.cs
+++ b/VSharp.Test/IntegrationTests.cs
@@ -73,7 +73,7 @@ namespace VSharp.Test
             };
             Thread.CurrentThread.CurrentCulture = ci;
 
-            Logger.ConfigureWriter(TestContext.Progress);
+            Logger.configureWriter(TestContext.Progress);
             // SVM.ConfigureSimplifier(new Z3Simplifier()); can be used to enable Z3-based simplification (not recommended)
         }
 

--- a/VSharp.Test/Tests/LoanExam.cs
+++ b/VSharp.Test/Tests/LoanExam.cs
@@ -194,7 +194,7 @@ public class LoanExam
         }
     }
 
-    [TestSvm(95, 0, 20, false, strat: SearchStrategy.Interleaved, coverageZone: CoverageZone.Class, guidedMode: false)]
+    [TestSvm(90, 0, 20, false, strat: SearchStrategy.Interleaved, coverageZone: CoverageZone.Class, guidedMode: false)]
     public CreditResult Build(Request request)
     {
         var SumPoints = 0;

--- a/VSharp.Test/Tests/LoanExam.cs
+++ b/VSharp.Test/Tests/LoanExam.cs
@@ -194,7 +194,7 @@ public class LoanExam
         }
     }
 
-    [TestSvm(90, 0, 20, false, strat: SearchStrategy.Interleaved, coverageZone: CoverageZone.Class, guidedMode: false)]
+    [TestSvm(95, 0, 15, false, strat: SearchStrategy.Interleaved, coverageZone: CoverageZone.Class, guidedMode: false, releaseBranches: false)]
     public CreditResult Build(Request request)
     {
         var SumPoints = 0;

--- a/VSharp.Test/Tests/RecursiveObjects.cs
+++ b/VSharp.Test/Tests/RecursiveObjects.cs
@@ -1,0 +1,42 @@
+﻿using VSharp.Test;
+
+namespace IntegrationTests;
+
+[TestSvmFixture]
+public class RecursiveObjects
+{
+    public class A
+    {
+        private B _b;
+
+        public void SetB(B b)
+        {
+            _b = b;
+        }
+    }
+
+    public class B
+    {
+        private A _a;
+
+        public void SetA(A a)
+        {
+            _a = a;
+        }
+    }
+
+    [TestSvm]
+    public static A RecObject(int n)
+    {
+        if (n > 0)
+        {
+            return null;
+        }
+
+        var a = new A();
+        var b = new B();
+        a.SetB(b);
+        b.SetA(a);
+        return a;
+    }
+}

--- a/VSharp.TestExtensions/ObjectsComparer.cs
+++ b/VSharp.TestExtensions/ObjectsComparer.cs
@@ -5,7 +5,7 @@ namespace VSharp.TestExtensions;
 
 public static class ObjectsComparer
 {
-    private class InnerComparer
+    private class Comparer
     {
         // For circular references handling
         private readonly HashSet<(object, object)> _comparedObjects = new();
@@ -94,7 +94,7 @@ public static class ObjectsComparer
 
     public static bool CompareObjects(object? expected, object? got)
     {
-        var comparer = new InnerComparer();
+        var comparer = new Comparer();
         return comparer.CompareObjects(expected, got);
     }
 }

--- a/VSharp.TestExtensions/ObjectsComparer.cs
+++ b/VSharp.TestExtensions/ObjectsComparer.cs
@@ -1,68 +1,100 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Reflection;
 
 namespace VSharp.TestExtensions;
 
 public static class ObjectsComparer
 {
-    private static bool StructurallyEqual(object? expected, object? got)
+    private class InnerComparer
     {
-        Debug.Assert(expected != null && got != null && expected.GetType() == got.GetType());
-        var flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
-        var fields = expected.GetType().GetFields(flags);
-        foreach (var field in fields)
+        // For circular references handling
+        private readonly HashSet<(object, object)> _comparedObjects = new();
+
+        private bool StructurallyEqual(object? expected, object? got)
         {
-            if (!typeof(MulticastDelegate).IsAssignableFrom(field.FieldType) &&
-                !field.Name.Contains("threadid", StringComparison.OrdinalIgnoreCase) &&
-                !CompareObjects(field.GetValue(expected), field.GetValue(got)))
+            Debug.Assert(expected != null && got != null && expected.GetType() == got.GetType());
+            var flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+            var fields = expected.GetType().GetFields(flags);
+            foreach (var field in fields)
             {
-                return false;
+                if (!typeof(MulticastDelegate).IsAssignableFrom(field.FieldType) &&
+                    !field.Name.Contains("threadid", StringComparison.OrdinalIgnoreCase) &&
+                    !InnerCompareObjects(field.GetValue(expected), field.GetValue(got)))
+                {
+                    return false;
+                }
             }
+
+            return true;
         }
 
-        return true;
-    }
-
-    private static bool ContentwiseEqual(global::System.Array? expected, global::System.Array? got)
-    {
-        Debug.Assert(expected != null && got != null && expected.GetType() == got.GetType());
-        if (expected.Rank != got.Rank)
-            return false;
-        for (int i = 0; i < expected.Rank; ++i)
-            if (expected.GetLength(i) != got.GetLength(i) || expected.GetLowerBound(i) != got.GetLowerBound(i))
-                return false;
-        var enum1 = expected.GetEnumerator();
-        var enum2 = got.GetEnumerator();
-        while (enum1.MoveNext() && enum2.MoveNext())
+        private bool ContentwiseEqual(global::System.Array? expected, global::System.Array? got)
         {
-            if (!CompareObjects(enum1.Current, enum2.Current))
+            Debug.Assert(expected != null && got != null && expected.GetType() == got.GetType());
+            if (expected.Rank != got.Rank)
                 return false;
+            for (int i = 0; i < expected.Rank; ++i)
+                if (expected.GetLength(i) != got.GetLength(i) || expected.GetLowerBound(i) != got.GetLowerBound(i))
+                    return false;
+            var enum1 = expected.GetEnumerator();
+            var enum2 = got.GetEnumerator();
+            while (enum1.MoveNext() && enum2.MoveNext())
+            {
+                if (!InnerCompareObjects(enum1.Current, enum2.Current))
+                    return false;
+            }
+            return true;
         }
-        return true;
+
+        private bool InnerCompareObjects(object? expected, object? got)
+        {
+            if (expected == null)
+                return got == null;
+            if (got == null)
+                return false;
+            var type = expected.GetType();
+            if (type != got.GetType())
+                return false;
+
+            if (Object.ReferenceEquals(expected, got))
+                return true;
+
+            if (type == typeof(Pointer) || type.IsPrimitive || expected is string || type.IsEnum)
+            {
+                // TODO: compare double with epsilon?
+                return got.Equals(expected);
+            }
+
+            if (expected is global::System.Array array)
+                return ContentwiseEqual(array, got as global::System.Array);
+
+            if (_comparedObjects.Contains((expected, got)))
+            {
+                return true;
+            }
+
+            _comparedObjects.Add((expected, got));
+
+            return StructurallyEqual(expected, got);
+        }
+
+        public bool CompareObjects(object? expected, object? got)
+        {
+            try
+            {
+                return InnerCompareObjects(expected, got);
+            }
+            finally
+            {
+                _comparedObjects.Clear();
+            }
+
+        }
     }
 
     public static bool CompareObjects(object? expected, object? got)
     {
-        if (expected == null)
-            return got == null;
-        if (got == null)
-            return false;
-        var type = expected.GetType();
-        if (type != got.GetType())
-            return false;
-
-        if (Object.ReferenceEquals(expected, got))
-            return true;
-
-        if (type == typeof(Pointer) || type.IsPrimitive || expected is string || type.IsEnum)
-        {
-            // TODO: compare double with epsilon?
-            return got.Equals(expected);
-        }
-
-        if (expected is global::System.Array array)
-            return ContentwiseEqual(array, got as global::System.Array);
-        return StructurallyEqual(expected, got);
+        var comparer = new InnerComparer();
+        return comparer.CompareObjects(expected, got);
     }
 }

--- a/VSharp.TestRenderer/RendererTool.cs
+++ b/VSharp.TestRenderer/RendererTool.cs
@@ -318,7 +318,7 @@ public static class Renderer
             }
             default:
             {
-                Logger.writeLineString(Logger.Error, $"NameOfMember: unexpected case {member}");
+                Logger.printLogString(Logger.Error, $"NameOfMember: unexpected case {member}");
                 return member.ToString();
             }
         }
@@ -553,7 +553,7 @@ public static class Renderer
             }
             catch (Exception e)
             {
-                Logger.writeLineString(Logger.Error, $"Tests renderer: deserialization of test failed: {e}");
+                Logger.printLogString(Logger.Error, $"Tests renderer: deserialization of test failed: {e}");
             }
         }
 

--- a/VSharp.TestRenderer/TestsRenderer.cs
+++ b/VSharp.TestRenderer/TestsRenderer.cs
@@ -626,7 +626,7 @@ public static class TestsRenderer
             }
             catch (Exception e)
             {
-                Logger.writeLineString(Logger.Error, $"Tests renderer: rendering test failed: {e}");
+                Logger.printLogString(Logger.Error, $"Tests renderer: rendering test failed: {e}");
             }
         }
         generatedClass.Render();

--- a/VSharp.TestRunner/TestRunnerProgram.cs
+++ b/VSharp.TestRunner/TestRunnerProgram.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using System.IO;
 using System.CommandLine;
 using System.CommandLine.Invocation;
-
+using System.IO;
 
 namespace VSharp.TestRunner
 {
@@ -71,7 +70,7 @@ namespace VSharp.TestRunner
                 return ReproduceTests(testPath, suite, disableCheck, recursive);
             });
 
-            return rootCommand.InvokeAsync(args).Result;
+            return rootCommand.Invoke(args);
         }
     }
 }

--- a/VSharp.Utils/Logger.fs
+++ b/VSharp.Utils/Logger.fs
@@ -4,7 +4,7 @@ open System.Text
 
 module Logger =
     open System
-    
+
     // Tag for state transitions info logs
     let stateTraceTag = "StateTrace"
 
@@ -18,10 +18,11 @@ module Logger =
     let mutable currentTextWriter = Console.Out
     let mutable writeTimestamps = true
     let mutable tagFilter : string -> bool = fun s -> s <> stateTraceTag
-    
+
     let public configureWriter writer = currentTextWriter <- writer
     let public enableTimestamps value = writeTimestamps <- value
     let public setTagFilter filter = tagFilter <- filter
+    let public isTagEnabled tag = tagFilter tag
 
     let LevelToString = function
         | 1 -> "Error"
@@ -37,15 +38,15 @@ module Logger =
         let builder = builder.Append message
         currentTextWriter.WriteLine(builder.ToString())
         currentTextWriter.Flush()
-        
+
     let public printLogString vLevel (message : string) =
         writeLineString vLevel "" message
-        
+
     let public printLogWithTag tag vLevel format =
         Printf.ksprintf (fun message -> if currentLogLevel >= vLevel && tagFilter tag then writeLineString vLevel tag message) format
 
     let public printLog vLevel format = printLogWithTag "" vLevel format
-    
+
     let public printLogLazyWithTag tag vLevel format (s : Lazy<_>) =
         if currentLogLevel >= vLevel && tagFilter tag then
             Printf.ksprintf (writeLineString vLevel tag) format (s.Force())
@@ -56,7 +57,7 @@ module Logger =
     let public warning format = printLog Warning format
     let public info format = printLog Info format
     let public trace format = printLog Trace format
-    
+
     let public errorWithTag tag format = printLogWithTag tag Error format
     let public warningWithTag tag format = printLogWithTag tag Warning format
     let public infoWithTag tag format = printLogWithTag tag Info format

--- a/VSharp.Utils/Logger.fs
+++ b/VSharp.Utils/Logger.fs
@@ -9,10 +9,11 @@ module Logger =
     let stateTraceTag = "StateTrace"
 
     let Quiet = 0
-    let Error = 1
-    let Warning = 2
-    let Info = 3
-    let Trace = 4
+    let Critical = 1
+    let Error = 2
+    let Warning = 3
+    let Info = 4
+    let Trace = 5
 
     let mutable currentLogLevel = Error
     let mutable currentTextWriter = Console.Out
@@ -25,10 +26,11 @@ module Logger =
     let public isTagEnabled tag = tagFilter tag
 
     let LevelToString = function
-        | 1 -> "Error"
-        | 2 -> "Warning"
-        | 3 -> "Info"
-        | 4 -> "Trace"
+        | 1 -> "Critical"
+        | 2 -> "Error"
+        | 3 -> "Warning"
+        | 4 -> "Info"
+        | 5 -> "Trace"
         | _ -> "Unknown"
 
     let writeLineString vLevel tag (message : string) =


### PR DESCRIPTION
- Add ability to add tags to logs for state transitions debugging convenience
- Fix paused states not filtered in Guided Searcher
- Fix inefficient block coverage info extraction
- Remove different types of coverage (ByTest and ByEntryPointTest)

LoanExam is fully covered in less than 10 seconds with guided mode disabled (like it was before FairSearcher), with guided its still covered worse