### PR TITLE
Stabilization and fixes for Lifetimes benchmarks

### DIFF
--- a/VSharp.InternalCalls/Buffer.fs
+++ b/VSharp.InternalCalls/Buffer.fs
@@ -10,14 +10,20 @@ module Buffer =
 
     let internal Memmove (state : state) (args : term list) : term =
         let dst, src, elemCount = args.[1], args.[2], args.[3]
-        match dst.term, src.term with
-        | Ref(ArrayIndex(addr1, indices1, arrayType1)), Ref(ArrayIndex(addr2, indices2, arrayType2)) ->
-            let typ1 = Types.ArrayTypeToSymbolicType arrayType1
-            let typ2 = Types.ArrayTypeToSymbolicType arrayType2
-            let heapRef1 = HeapRef addr1 typ1
-            let heapRef2 = HeapRef addr2 typ2
-            let linearIndex1 = Memory.LinearizeArrayIndex state addr1 indices1 arrayType1
-            let linearIndex2 = Memory.LinearizeArrayIndex state addr2 indices2 arrayType2
-            Memory.CopyArray state heapRef1 linearIndex1 typ1 heapRef2 linearIndex2 typ2 elemCount
-            Nop
-        | _ -> internalfailf "Memmove is not implemented for src: %O, dst: %O" src dst
+        let getArrayInfo ref =
+            match ref.term with
+            | Ref(ArrayIndex(address, indices, arrayType)) -> address, indices, arrayType
+            | Ref(ClassField(address, field)) when field = Reflection.stringFirstCharField ->
+                let stringArrayType = (typeof<char>, 1, true)
+                address, [MakeNumber 0], stringArrayType
+            | _ -> internalfail $"Memmove: unexpected reference {ref}"
+        let addr1, indices1, arrayType1 = getArrayInfo dst
+        let addr2, indices2, arrayType2 = getArrayInfo src
+        let typ1 = Types.ArrayTypeToSymbolicType arrayType1
+        let typ2 = Types.ArrayTypeToSymbolicType arrayType2
+        let heapRef1 = HeapRef addr1 typ1
+        let heapRef2 = HeapRef addr2 typ2
+        let linearIndex1 = Memory.LinearizeArrayIndex state addr1 indices1 arrayType1
+        let linearIndex2 = Memory.LinearizeArrayIndex state addr2 indices2 arrayType2
+        Memory.CopyArray state heapRef1 linearIndex1 typ1 heapRef2 linearIndex2 typ2 elemCount
+        Nop

--- a/VSharp.Runner/RunnerProgram.cs
+++ b/VSharp.Runner/RunnerProgram.cs
@@ -119,7 +119,9 @@ namespace VSharp.Runner
                 return null;
             }
 
-            var types = assembly.EnumerateExplorableTypes().Where(t => t.Namespace == namespaceArgumentValue);
+            var types =
+                assembly.EnumerateExplorableTypes()
+                    .Where(t => t.Namespace?.StartsWith(namespaceArgumentValue) == true);
 
             if (types.Count() == 0)
             {

--- a/VSharp.SILI.Core/API.fs
+++ b/VSharp.SILI.Core/API.fs
@@ -316,7 +316,7 @@ module API =
                 assert(isSuitableField address typ)
                 ClassField(address, fieldId) |> Ref
             | Ref address ->
-                assert(Memory.baseTypeOfAddress state address |> TypeUtils.isStruct)
+                assert fieldId.declaringType.IsValueType
                 StructField(address, fieldId) |> Ref
             | Ptr(baseAddress, _, offset) ->
                 let fieldOffset = Reflection.getFieldOffset fieldId |> makeNumber

--- a/VSharp.SILI.Core/ArrayInitialization.fs
+++ b/VSharp.SILI.Core/ArrayInitialization.fs
@@ -63,7 +63,7 @@ module internal ArrayInitialization =
         let arrayType = symbolicTypeToArrayType typeOfArray
         let lbs = List.init dims (fun dim -> Memory.readLowerBound state address (makeNumber dim) arrayType |> extractIntFromTerm)
         let lens = List.init dims (fun dim -> Memory.readLength state address (makeNumber dim) arrayType |> extractIntFromTerm)
-        let allIndices = Array.allIndicesOfArray lbs lens
+        let allIndices = Array.allIndicesViaLens lbs lens
         let indicesAndValues = allIndices |> Seq.mapi (fun i indices -> List.map makeNumber indices, termCreator rawData (i * size)) // TODO: sort if need
         Memory.initializeArray state address indicesAndValues arrayType
 

--- a/VSharp.SILI.Core/ConcreteMemory.fs
+++ b/VSharp.SILI.Core/ConcreteMemory.fs
@@ -222,6 +222,14 @@ type public ConcreteMemory private (physToVirt, virtToPhys) =
                 Array.Copy(srcArray, srcIndex, dstArray, dstIndex, length)
                 let newString = String(dstArray)
                 x.WriteObject dstAddress newString
+            | :? String as srcString, (:? Array as dstArray) ->
+                let srcArray = srcString.ToCharArray()
+                Array.Copy(srcArray, srcIndex, dstArray, dstIndex, length)
+            | :? Array as srcArray, (:? String as dstString) ->
+                let dstArray = dstString.ToCharArray()
+                Array.Copy(srcArray, srcIndex, dstArray, dstIndex, length)
+                let newString = String(dstArray)
+                x.WriteObject dstAddress newString
             | obj -> internalfailf "copying array in concrete memory: expected to read array, but got %O" obj
 
         override x.CopyCharArrayToString arrayAddress stringAddress =

--- a/VSharp.SILI.Core/ConcreteMemory.fs
+++ b/VSharp.SILI.Core/ConcreteMemory.fs
@@ -5,6 +5,7 @@ open System.Collections.Generic
 open System.Runtime.Serialization
 open System.Runtime.CompilerServices
 open System.Threading
+open System.Linq
 open VSharp
 
 type public ConcreteMemory private (physToVirt, virtToPhys) =
@@ -22,10 +23,29 @@ type public ConcreteMemory private (physToVirt, virtToPhys) =
     let cannotBeCopied typ = List.contains typ nonCopyableTypes
 
     let getArrayIndicesWithValues (array : Array) =
-        let ubs = List.init array.Rank array.GetUpperBound
-        let lbs = List.init array.Rank array.GetLowerBound
-        let indices = List.map2 (fun lb ub -> [lb .. ub]) lbs ubs |> List.cartesian
-        indices |> Seq.map (fun index -> index, array.GetValue(Array.ofList index))
+        assert(array <> null)
+        match array with
+        // Any T[] when T is reference type is matched with 'array<obj>'
+        | :? array<obj> as a -> Array.mapi (fun i x -> (List.singleton i, x :> obj)) a :> seq<int list * obj>
+        | :? array<bool> as a -> Array.mapi (fun i x -> (List.singleton i, x :> obj)) a :> seq<int list * obj>
+        | :? array<int8> as a -> Array.mapi (fun i x -> (List.singleton i, x :> obj)) a :> seq<int list * obj>
+        | :? array<uint8> as a -> Array.mapi (fun i x -> (List.singleton i, x :> obj)) a :> seq<int list * obj>
+        | :? array<int16> as a -> Array.mapi (fun i x -> (List.singleton i, x :> obj)) a :> seq<int list * obj>
+        | :? array<uint16> as a -> Array.mapi (fun i x -> (List.singleton i, x :> obj)) a :> seq<int list * obj>
+        | :? array<int> as a -> Array.mapi (fun i x -> (List.singleton i, x :> obj)) a :> seq<int list * obj>
+        | :? array<uint> as a -> Array.mapi (fun i x -> (List.singleton i, x :> obj)) a :> seq<int list * obj>
+        | :? array<int64> as a -> Array.mapi (fun i x -> (List.singleton i, x :> obj)) a :> seq<int list * obj>
+        | :? array<uint64> as a -> Array.mapi (fun i x -> (List.singleton i, x :> obj)) a :> seq<int list * obj>
+        | :? array<single> as a -> Array.mapi (fun i x -> (List.singleton i, x :> obj)) a :> seq<int list * obj>
+        | :? array<double> as a -> Array.mapi (fun i x -> (List.singleton i, x :> obj)) a :> seq<int list * obj>
+        | _ when array.GetType().IsSZArray ->
+            let szArray = array.Cast<obj>()
+            Seq.mapi (fun i x -> (List.singleton i, x :> obj)) szArray
+        | _ ->
+            let ubs = List.init array.Rank array.GetUpperBound
+            let lbs = List.init array.Rank array.GetLowerBound
+            let indices = Array.allIndicesViaBound lbs ubs
+            indices |> Seq.map (fun index -> index, array.GetValue(Array.ofList index))
 
     let copiedObjects = Dictionary<physicalAddress, physicalAddress>()
 
@@ -58,7 +78,7 @@ type public ConcreteMemory private (physToVirt, virtToPhys) =
             let a' = Array.CreateInstance(typ.GetElementType(), lengths, lowerBounds)
             let phys' = {object = a'}
             copiedObjects.Add(phys, phys')
-            let indices = Array.allIndicesOfArray (Array.toList lowerBounds) (Array.toList lengths)
+            let indices = Array.allIndicesViaLens (Array.toList lowerBounds) (Array.toList lengths)
             for index in indices do
                 let index = List.toArray index
                 let v' = deepCopyObject {object = a.GetValue index}

--- a/VSharp.SILI.Core/Memory.fs
+++ b/VSharp.SILI.Core/Memory.fs
@@ -1058,7 +1058,7 @@ module internal Memory =
             let value = array.GetValue(Array.ofList indices) |> objToTerm state elemType
             let termIndices = List.map makeNumber indices
             writeArrayIndexSymbolic state address termIndices arrayType value
-        let allIndices = Array.allIndicesOfArray lbs lens
+        let allIndices = Array.allIndicesViaLens lbs lens
         Seq.iter (writeIndex state) allIndices
         let termLBs = List.map (objToTerm state typeof<int>) lbs
         let termLens = List.map (objToTerm state typeof<int>) lens

--- a/VSharp.SILI.Core/Memory.fs
+++ b/VSharp.SILI.Core/Memory.fs
@@ -200,15 +200,15 @@ module internal Memory =
         address.GetHashCode() |> makeNumber
 
     let getHashCode object =
-        assert(isReference object)
         // TODO: implement GetHashCode() for value type (it's boxed)
         match object.term with
+        | ConcreteHeapAddress address
         | HeapRef({term = ConcreteHeapAddress address}, _) -> hashConcreteAddress address
         | HeapRef(address, _) ->
-            let name = sprintf "HashCode(%O)" address
+            let name = $"HashCode({address})"
             let source = {object = address}
             Constant name source typeof<Int32>
-        | _ -> internalfailf "expected HeapRef, but got %O" object
+        | _ -> internalfail $"Getting hash code: unexpected object {object}"
 
 // ------------------------------- Instantiation -------------------------------
 

--- a/VSharp.SILI/FairSearcher.fs
+++ b/VSharp.SILI/FairSearcher.fs
@@ -95,16 +95,21 @@ type internal FairSearcher(baseSearcherFactory : unit -> IForwardSearcher, timeo
 
     let init initialStates =
         baseSearcher.Init initialStates
+        // Some states may be filtered out
+        let initialStates = baseSearcher.States()
         let groupedByType = initialStates |> Seq.map CilStateOperations.entryMethodOf |> Seq.distinct |> Seq.groupBy (fun m -> m.DeclaringType)
         typeEnumerator <- FairEnumerator(groupedByType |> Seq.map fst |> Seq.toList, getTypeTimeout, shouldStopType, onTypeRound, onTypeTimeout)
         for typ, methods in groupedByType do
-            methodEnumerators.[typ] <- FairEnumerator(
-                methods |> Seq.sortBy (fun m -> m.CFG.Calls.Count) |> Seq.toList,
-                (fun _ -> getMethodTimeout typ),
-                (fun _ -> shouldStopMethod typ),
-                onMethodRound,
-                onMethodTimeout
-            )
+            try
+                let methods = methods |> Seq.sortBy (fun m -> m.CFG.Calls.Count) |> Seq.toList
+                methodEnumerators.[typ] <- FairEnumerator(
+                    methods,
+                    (fun _ -> getMethodTimeout typ),
+                    (fun _ -> shouldStopMethod typ),
+                    onMethodRound,
+                    onMethodTimeout
+                )
+            with e -> Logger.error $"Initializing FairSearcher: unable to get CFG from methods {methods}, {e}"
 
     let update (parent, newStates) = baseSearcher.Update(parent, newStates)
 

--- a/VSharp.SILI/Searcher.fs
+++ b/VSharp.SILI/Searcher.fs
@@ -124,8 +124,12 @@ type WeightedSearcher(maxBound, weighter : IWeighter, storage : IPriorityCollect
             option {
                 if not <| violatesLevel s maxBound then return! weighter.Weight s
             }
-        with :? InsufficientInformationException as e ->
+        with
+        | :? InsufficientInformationException as e ->
             s.iie <- Some e
+            None
+        | :? InternalException as e ->
+            Logger.error "WeightedSearcher: failed to get weight of state %O" e
             None
     let add (s : cilState) =
         let weight = optionWeight s

--- a/VSharp.SILI/Statistics.fs
+++ b/VSharp.SILI/Statistics.fs
@@ -257,6 +257,12 @@ type public SILIStatistics(statsDumpIntervalMs : int) as this =
     member x.CreateContinuousDump() =
         if collectContinuousStatistics then
             let states = getStates() |> Seq.toList
+            let coveringStatesCount =
+                let isCovering s =
+                    let notCoveredBlocks = x.GetVisitedBlocksNotCoveredByTests(s)
+                    let blocksInZone = Seq.filter (fun b -> b.method.InCoverageZone) notCoveredBlocks
+                    Seq.length blocksInZone > 0
+                states |> Seq.filter isCovering |> Seq.length |> uint
             let continuousStatisticsDump = {
                 millis = stopwatch.ElapsedMilliseconds;
                 coveringStepsInsideZone = coveringStepsInsideZone;
@@ -267,7 +273,7 @@ type public SILIStatistics(statsDumpIntervalMs : int) as this =
                 branchesReleased = branchesReleased;
                 internalFailsCount = uint internalFails.Count;
                 statesCount = getStatesCount()
-                coveringStatesCount = states |> Seq.filter (fun s -> (x.GetVisitedBlocksNotCoveredByTests(s) |> Seq.filter (fun b -> b.method.InCoverageZone)) |> Seq.length > 0) |> Seq.length |> uint
+                coveringStatesCount = coveringStatesCount
             }
             continuousStatistics.Add continuousStatisticsDump
 

--- a/VSharp.SILI/Statistics.fs
+++ b/VSharp.SILI/Statistics.fs
@@ -211,9 +211,9 @@ type public SILIStatistics(statsDumpIntervalMs : int) as this =
             for visitedState in s.history do
                 if hasSiblings visitedState then historyRef.Value.Add visitedState |> ignore
 
-            if currentMethod.InCoverageZone && not <| x.IsBasicBlockCoveredByTest coverageType.ByTest currentLoc then
-                if visitedBlocksNotCoveredByTests.ContainsKey s |> not then
-                    visitedBlocksNotCoveredByTests.[s] <- Set.empty
+            let isCovered = x.IsBasicBlockCoveredByTest coverageType.ByTest currentLoc
+            if currentMethod.InCoverageZone && not isCovered then
+                visitedBlocksNotCoveredByTests.TryAdd(s, Set.empty) |> ignore
                 isVisitedBlocksNotCoveredByTestsRelevant <- false
 
             setBasicBlockIsVisited s currentLoc
@@ -224,11 +224,15 @@ type public SILIStatistics(statsDumpIntervalMs : int) as this =
 
     member x.GetVisitedBlocksNotCoveredByTests (s : cilState) =
         if not isVisitedBlocksNotCoveredByTestsRelevant then
-            for kvp in visitedBlocksNotCoveredByTests do
-                visitedBlocksNotCoveredByTests.[kvp.Key] <- kvp.Key.history |> Set.filter (not << x.IsBasicBlockCoveredByTest coverageType.ByTest)
+            let currentCilStates = visitedBlocksNotCoveredByTests.Keys |> Seq.toList
+            for cilState in currentCilStates do
+                let history = Set.filter (not << x.IsBasicBlockCoveredByTest coverageType.ByTest) cilState.history
+                visitedBlocksNotCoveredByTests[cilState] <- history
             isVisitedBlocksNotCoveredByTestsRelevant <- true
 
-        if visitedBlocksNotCoveredByTests.ContainsKey s then visitedBlocksNotCoveredByTests.[s] else Set.empty
+        let blocks = ref Set.empty
+        if visitedBlocksNotCoveredByTests.TryGetValue(s, blocks) then blocks.Value
+        else Set.empty
 
     member x.IsBasicBlockCoveredByTest (coverageType : coverageType) (blockStart : codeLocation) =
         match coverageType with
@@ -254,6 +258,7 @@ type public SILIStatistics(statsDumpIntervalMs : int) as this =
     member x.OnBranchesReleased() =
         branchesReleased <- true
 
+    // TODO: GetVisitedBlocksNotCoveredByTests doesn't work in parallel, rewrite 'CreateContinuousDump'
     member x.CreateContinuousDump() =
         if collectContinuousStatistics then
             let states = getStates() |> Seq.toList
@@ -296,8 +301,12 @@ type public SILIStatistics(statsDumpIntervalMs : int) as this =
         ()
 
     member x.TrackFork (parent : cilState) (children : cilState seq) =
-        for child in children do
-            visitedBlocksNotCoveredByTests.[child] <- visitedBlocksNotCoveredByTests.[parent]
+        let blocks = ref Set.empty
+        // TODO: check why 'parent' may not be in 'visitedBlocksNotCoveredByTests'
+        if visitedBlocksNotCoveredByTests.TryGetValue(parent, blocks) then
+            let parentBlocks = blocks.Value
+            for child in children do
+                visitedBlocksNotCoveredByTests[child] <- parentBlocks
 
     member x.AddUnansweredPob (p : pob) = unansweredPobs.Add(p)
 

--- a/VSharp.Solver/Z3.fs
+++ b/VSharp.Solver/Z3.fs
@@ -821,11 +821,12 @@ module internal Z3 =
                         x.WriteDictOfValueTypes stackEntries key fields key.TypeOfLocation decoded
                 | {term = Constant(_, (:? IMemoryAccessConstantSource as ms), _)} as constant ->
                     match ms with
-                    | HeapAddressSource(StackReading(key)) ->
+                    | HeapAddressSource(StructFieldChain(fields, StackReading(key))) ->
                         let refinedExpr = m.Eval(kvp.Value.expr, false)
                         let t = key.TypeOfLocation
-                        let addr = refinedExpr |> x.DecodeConcreteHeapAddress t |> ConcreteHeapAddress
-                        stackEntries.Add(key, HeapRef addr t |> ref)
+                        let address = refinedExpr |> x.DecodeConcreteHeapAddress t |> ConcreteHeapAddress
+                        let value = HeapRef address t
+                        x.WriteDictOfValueTypes stackEntries key fields key.TypeOfLocation value
                     | HeapAddressSource(:? functionResultConstantSource as frs) ->
                         let refinedExpr = m.Eval(kvp.Value.expr, false)
                         let t = (frs :> ISymbolicConstantSource).TypeOfLocation

--- a/VSharp.Solver/Z3.fs
+++ b/VSharp.Solver/Z3.fs
@@ -812,6 +812,8 @@ module internal Z3 =
             let subst = Dictionary<ISymbolicConstantSource, term>()
             let stackEntries = Dictionary<stackKey, term ref>()
             let state = {Memory.EmptyState() with complete = true}
+            // TODO: some of evaluated constants are written to model: most of them contain stack reading
+            // TODO: maybe encode stack reading as reading from array?
             encodingCache.t2e |> Seq.iter (fun kvp ->
                 match kvp.Key with
                 | {term = Constant(_, StructFieldChain(fields, StackReading(key)), t)} as constant ->

--- a/VSharp.TestRenderer/CodeRenderer.cs
+++ b/VSharp.TestRenderer/CodeRenderer.cs
@@ -490,16 +490,20 @@ internal class CodeRenderer
 
     public static ExpressionSyntax RenderArrayCreation(
         ArrayTypeSyntax type,
-        IEnumerable<ExpressionSyntax>? init,
+        List<ExpressionSyntax>? init,
         bool allowImplicit)
     {
         InitializerExpressionSyntax? initializer = null;
         if (init != null)
+        {
             initializer =
                 InitializerExpression(
                     SyntaxKind.ArrayInitializerExpression,
                     SeparatedList(init)
                 );
+            // If init is empty, we should use explicit type
+            if (init.Count == 0) allowImplicit = false;
+        }
 
         ExpressionSyntax array;
         if (allowImplicit && initializer != null)

--- a/VSharp.Utils/Mocking.fs
+++ b/VSharp.Utils/Mocking.fs
@@ -201,6 +201,7 @@ module Mocking =
             interfaces |> ResizeArray.iter typeBuilder.AddInterfaceImplementation
 
             methods |> ResizeArray.iter (fun methodMock -> methodMock.Build typeBuilder)
+            // TODO: type = ICollection, method GetEnumerator does not overriden and fails to create type
             typeBuilder.CreateType()
 
         member x.Serialize(encode : obj -> obj) =

--- a/VSharp.Utils/UnitTest.fs
+++ b/VSharp.Utils/UnitTest.fs
@@ -207,6 +207,7 @@ type UnitTest private (m : MethodBase, info : testInfo, createCompactRepr : bool
 
             // Ensure that parameters are substituted in memoryRepr
             if not method.IsStatic && declaringType.IsGenericType && ti.memory.types.Length > 0 then
+                // TODO: index out of bounds exceptions #lifetimes
                 ti.memory.types.[declaringTypeIndex] <- Serialization.encodeType declaringType
 
             let method = Reflection.concretizeMethodParameters declaringType method mp


### PR DESCRIPTION
- fixed https://github.com/VSharp-team/VSharp/issues/223
- fixed efficiency for getting all indices of array and all indices of array with values
- fixed 'Memmove' internal call
- fixed decoding of stack reading constant
- fixed '--namespace' console command (exploring all underlying namespaces)
- fixed searcher initialization