### PR TITLE
Stabilization: part VI

### DIFF
--- a/VSharp.Runner/RunnerProgram.cs
+++ b/VSharp.Runner/RunnerProgram.cs
@@ -187,7 +187,7 @@ namespace VSharp.Runner
             allPublicMethodsCommand.AddGlobalOption(searchStrategyOption);
             allPublicMethodsCommand.AddGlobalOption(verbosityOption);
             var publicMethodsOfClassCommand =
-                new Command("--public-methods-of-class", "Generate unit tests for all public methods of specified class");
+                new Command("--type", "Generate unit tests for all public methods of specified class");
             rootCommand.AddCommand(publicMethodsOfClassCommand);
             var classArgument = new Argument<string>("class-name");
             publicMethodsOfClassCommand.AddArgument(classArgument);

--- a/VSharp.SILI.Core/API.fs
+++ b/VSharp.SILI.Core/API.fs
@@ -137,6 +137,12 @@ module API =
 
         let (|StackReading|_|) src = Memory.(|StackReading|_|) src
         let (|HeapReading|_|) src = Memory.(|HeapReading|_|) src
+
+        let (|ArrayRangeReading|_|) (src : ISymbolicConstantSource) =
+            match src with
+            | Memory.ArrayRangeReading _ -> Some()
+            | _ -> None
+
         let (|ArrayIndexReading|_|) src = Memory.(|ArrayIndexReading|_|) src
         let (|VectorIndexReading|_|) src = Memory.(|VectorIndexReading|_|) src
         let (|StackBufferReading|_|) src = Memory.(|StackBufferReading|_|) src
@@ -163,7 +169,7 @@ module API =
 
         let GetHeapReadingRegionSort src = Memory.getHeapReadingRegionSort src
 
-        let SpecializeWithKey constant key = Memory.specializeWithKey constant key
+        let SpecializeWithKey constant key writeKey = Memory.specializeWithKey constant key writeKey
 
         let rec HeapReferenceToBoxReference reference =
             match reference.term with

--- a/VSharp.SILI.Core/API.fsi
+++ b/VSharp.SILI.Core/API.fsi
@@ -94,6 +94,7 @@ module API =
 
         val (|StackReading|_|) : ISymbolicConstantSource -> option<stackKey>
         val (|HeapReading|_|) : ISymbolicConstantSource -> option<heapAddressKey * memoryRegion<heapAddressKey, vectorTime intervals>>
+        val (|ArrayRangeReading|_|) : ISymbolicConstantSource -> option<unit>
         val (|ArrayIndexReading|_|) : ISymbolicConstantSource -> option<bool * heapArrayKey * memoryRegion<heapArrayKey, productRegion<vectorTime intervals, int points listProductRegion>>>
         val (|VectorIndexReading|_|) : ISymbolicConstantSource -> option<bool * heapVectorIndexKey * memoryRegion<heapVectorIndexKey, productRegion<vectorTime intervals, int points>>>
         val (|StackBufferReading|_|) : ISymbolicConstantSource -> option<stackBufferIndexKey * memoryRegion<stackBufferIndexKey, int points>>
@@ -110,7 +111,7 @@ module API =
 
         val GetHeapReadingRegionSort : ISymbolicConstantSource -> regionSort
 
-        val SpecializeWithKey : term -> heapArrayKey -> term
+        val SpecializeWithKey : term -> heapArrayKey -> heapArrayKey -> term
 
         val HeapReferenceToBoxReference : term -> term
 

--- a/VSharp.SILI.Core/Memory.fs
+++ b/VSharp.SILI.Core/Memory.fs
@@ -269,6 +269,21 @@ module internal Memory =
         | :? arrayReading as ar -> Some(isConcreteHeapAddress ar.key.Address, ar.key, ar.memoryObject)
         | _ -> None
 
+    let (|ArrayRangeReading|_|) (src : ISymbolicConstantSource) =
+        match src with
+        | :? arrayReading as { memoryObject = mo; key = RangeArrayIndexKey(address, fromIndices, toIndices); picker = picker; time = time } ->
+            Some(mo, address, fromIndices, toIndices, picker, time)
+        | _ -> None
+
+    let specializeWithKey constant (key : heapArrayKey) (writeKey : heapArrayKey) =
+        match constant.term with
+        | Constant(_, ArrayRangeReading(mo, srcAddress, srcFrom, srcTo, picker, time), typ) ->
+            let key = key.Specialize writeKey srcAddress srcFrom srcTo
+            let source : arrayReading = {picker = picker; key = key; memoryObject = mo; time = time}
+            let name = picker.mkname key
+            Constant name source typ
+        | _ -> constant
+
     // VectorIndexKey is used for length and lower bounds
     // We suppose, that lower bounds will always be default -- 0
     let (|VectorIndexReading|_|) (src : ISymbolicConstantSource) =
@@ -300,34 +315,6 @@ module internal Memory =
             internalfail "unexpected array index reading via 'heapReading' source"
         | :? arrayReading as ar -> ar.picker.sort
         | _ -> __unreachable__()
-
-    [<StructuralEquality;NoComparison>]
-    type boundReading =
-        {
-            arrayAddress : heapAddress
-            picker : regionPicker<heapArrayKey, productRegion<vectorTime intervals, int points listProductRegion>>
-            memoryObject : memoryRegion<heapArrayKey, productRegion<vectorTime intervals, int points listProductRegion>>
-            time : vectorTime
-        }
-        interface IMemoryAccessConstantSource with
-            override x.SubTerms = Seq.empty
-            override x.Time = x.time
-            override x.TypeOfLocation = x.picker.sort.TypeOfLocation
-
-    let (|BoundReading|_|) (src : ISymbolicConstantSource) =
-        match src with
-        | :? boundReading as { memoryObject = mo; arrayAddress = srcAddress; picker = picker; time = time } ->
-            Some(mo, srcAddress, picker, time)
-        | _ -> None
-
-    let specializeWithKey constant (key : heapArrayKey) =
-        match constant.term with
-        | Constant(_, BoundReading(mo, srcAddress, picker, time), typ) ->
-            let key = key.ChangeAddress(srcAddress)
-            let source : arrayReading = {picker = picker; key = key; memoryObject = mo; time = time}
-            let name = picker.mkname key
-            Constant name source typ
-        | _ -> constant
 
     [<StructuralEquality;NoComparison>]
     type private structField =
@@ -398,20 +385,15 @@ module internal Memory =
 
     let rec private makeArraySymbolicHeapRead state picker (key : heapArrayKey) time typ memoryObject (singleValue : updateTreeKey<heapArrayKey, term> option) =
         match singleValue with
-        | Some {key = key'; value = {term = Constant(_, BoundReading(mo, srcAddress, picker, _), _)}} when key'.Includes key ->
-            let key = key.ChangeAddress(srcAddress)
-            let inst = makeArraySymbolicHeapRead state picker key state.startingTime
-            MemoryRegion.read mo key (picker.isDefaultKey state) inst
+        | Some {key = key'; value = {term = Constant(_, ArrayRangeReading(mo, srcA, srcF, srcT, p, _), _)}} when key'.Includes key ->
+            let key = key.Specialize key' srcA srcF srcT
+            let inst = makeArraySymbolicHeapRead state p key state.startingTime
+            MemoryRegion.read mo key (p.isDefaultKey state) inst
         | Some { key = key'; value = value } when key'.Includes key -> value
         | _ ->
             let source : arrayReading = {picker = picker; key = key; memoryObject = memoryObject; time = time}
             let name = picker.mkname key
             makeSymbolicValue source name typ
-
-    let private makeSymbolicHeapRangeRead picker time typ memoryObject fromAddress =
-        let source = {arrayAddress = fromAddress; picker = picker; memoryObject = memoryObject; time = time}
-        let name = memoryObject.ToString()
-        makeSymbolicValue source name typ
 
     let makeSymbolicThis (m : IMethod) =
         let declaringType = m.DeclaringType
@@ -648,11 +630,7 @@ module internal Memory =
             let time =
                 if isValueType typ then state.startingTime
                 else MemoryRegion.maxTime region.updates state.startingTime
-            match key with
-            | OneArrayIndexKey _ ->
-                makeArraySymbolicHeapRead state picker key time typ memory singleValue
-            | RangeArrayIndexKey(address, _, _) ->
-                makeSymbolicHeapRangeRead picker time typ memory address
+            makeArraySymbolicHeapRead state picker key time typ memory singleValue
         MemoryRegion.read region key (isDefault state) instantiate
 
     let private readArrayKeySymbolic state key arrayType =
@@ -1460,21 +1438,6 @@ module internal Memory =
                 let read region =
                     let inst = makeArraySymbolicHeapRead state x.picker key state.startingTime
                     MemoryRegion.read region key (x.picker.isDefaultKey state) inst
-                afters |> List.map (mapsnd read) |> Merging.merge
-
-    type boundReading with
-        interface IMemoryAccessConstantSource with
-            override x.Compose state =
-                // TODO: do nothing if state is empty!
-                let substTerm = fillHoles state
-                let substType = substituteTypeVariables state
-                let substTime = composeTime state
-                let address = substTerm x.arrayAddress
-                let effect = MemoryRegion.map substTerm substType substTime x.memoryObject
-                let before = x.picker.extract state
-                let afters = MemoryRegion.compose before effect
-                let read (region : memoryRegion<heapArrayKey, productRegion<intervals<vectorTime>, listProductRegion<points<int>>>>) =
-                    makeSymbolicHeapRangeRead x.picker state.startingTime region.typ region address
                 afters |> List.map (mapsnd read) |> Merging.merge
 
     type stackReading with

--- a/VSharp.SILI/SILI.fs
+++ b/VSharp.SILI/SILI.fs
@@ -259,6 +259,13 @@ type public SILI(options : SiliOptions) =
                 let argsParameter = Array.head parameters
                 let argsParameterTerm = Memory.ReadArgument state argsParameter
                 AddConstraint state (!!(IsNullReference argsParameterTerm))
+                // Filling model with default args to match PC
+                let modelState =
+                    match state.model with
+                    | StateModel(modelState, _) -> modelState
+                    | _ -> __unreachable__()
+                let argsForModel = Memory.AllocateVectorArray modelState (MakeNumber 0) typeof<String>
+                Memory.WriteLocalVariable modelState (ParameterKey argsParameter) argsForModel
             Memory.InitializeStaticMembers state method.DeclaringType
             let initialState = makeInitialState method state
             [initialState]

--- a/VSharp.SILI/TestGenerator.fs
+++ b/VSharp.SILI/TestGenerator.fs
@@ -68,6 +68,7 @@ module TestGenerator =
 
     let private encodeArrayCompactly (state : state) (model : model) (encode : term -> obj) (test : UnitTest) arrayType cha typ lengths lowerBounds index =
         if state.concreteMemory.Contains cha then
+            // TODO: Use compact representation for big arrays
             test.MemoryGraph.AddArray typ (state.concreteMemory.VirtToPhys cha :?> Array |> Array.mapToOneDArray test.MemoryGraph.Encode) lengths lowerBounds index
         else
             let arrays =

--- a/VSharp.Test/Tests/Lists.cs
+++ b/VSharp.Test/Tests/Lists.cs
@@ -211,6 +211,47 @@ namespace IntegrationTests
             return a;
         }
 
+        [TestSvm(100)]
+        public static int[] CopySymbolicIndicesToConcreteArray(int srcI, int dstI, int len)
+        {
+            int[] arr = new int[5] {10, 2, 3, 4, 5};
+            int[] a = new int[5] {1, 1, 1, 1, 1};
+            Array.Copy(arr, srcI, a, dstI, len);
+            if (a[2] == 3)
+                return Array.Empty<int>();
+            return a;
+        }
+
+        [TestSvm(100)]
+        public static int[] CopySymbolicIndicesToConcreteArray1(int srcI1, int dstI1, int len1, int srcI2, int dstI2, int len2)
+        {
+            int[] arr = new int[5] {10, 2, 3, 4, 5};
+            int[] a = new int[5] {1, 1, 1, 1, 1};
+            Array.Copy(arr, srcI1, a, dstI1, len1);
+            if (a[2] == 3)
+                return a;
+            int[] b = new int[5] {1, 1, 1, 1, 1};
+            Array.Copy(a, srcI2, b, dstI2, len2);
+            if (b[2] == 3)
+                return Array.Empty<int>();
+            return a;
+        }
+
+        [TestSvm(100)]
+        public static int[] CopySymbolicIndicesToConcreteArray2(int srcI, int dstI, int len)
+        {
+            int[] arr = new int[5] {10, 2, 3, 4, 5};
+            int[] a = new int[5] {1, 1, 1, 1, 1};
+            arr[dstI + len] = len;
+            Array.Copy(arr, srcI, a, dstI, len);
+            int[] b = new int[5] {3, 3, 3, 3, 3};
+            Array.Copy(a, dstI, b, dstI, len + 1);
+            if (b[dstI + len] == len)
+                // Should be unreachable
+                return Array.Empty<int>();
+            return a;
+        }
+
         [TestSvm(86)]
         public static int TestSolvingCopy(int[] a, int[] b, int i)
         {

--- a/VSharp.TestRenderer/CodeRenderer.cs
+++ b/VSharp.TestRenderer/CodeRenderer.cs
@@ -68,6 +68,9 @@ internal class CodeRenderer
 
     private static readonly Dictionary<string, MockInfo> MocksInfo = new ();
 
+    // TODO: make non-static
+    public static Dictionary<object, CompactArrayRepr> CompactRepresentations = new ();
+
     public static void PrepareCache()
     {
         MocksInfo.Clear();

--- a/VSharp.TestRenderer/MethodRenderer.cs
+++ b/VSharp.TestRenderer/MethodRenderer.cs
@@ -360,6 +360,10 @@ internal class MethodRenderer : CodeRenderer
 
         private ExpressionSyntax RenderArray(System.Array obj, string? preferredName)
         {
+            CompactArrayRepr? compactRepr;
+            if (CompactRepresentations.TryGetValue(obj, out compactRepr))
+                return RenderCompactArray(compactRepr, preferredName);
+
             var type = (ArrayTypeSyntax) RenderType(obj.GetType());
             return RenderArray(type, obj, preferredName);
         }

--- a/VSharp.TestRenderer/MethodRenderer.cs
+++ b/VSharp.TestRenderer/MethodRenderer.cs
@@ -384,7 +384,7 @@ internal class MethodRenderer : CodeRenderer
                 var defaultValueName = preferredName + "Default";
                 var defaultId = RenderObject(defaultValue, defaultValueName, needExplicitType);
                 var call =
-                    RenderCall(AllocatorType(), "Fill", arrayId, defaultId);
+                    RenderCall(AllocatorType(), AllocatorFill, arrayId, defaultId);
                 AddExpression(call);
             }
             for (int i = 0; i < indices.Length; i++)

--- a/VSharp.TestRenderer/TestsRenderer.cs
+++ b/VSharp.TestRenderer/TestsRenderer.cs
@@ -585,6 +585,7 @@ public static class TestsRenderer
             {
                 var method = test.Method;
                 var methodType = method.DeclaringType;
+                CompactRepresentations = test.CompactRepresentations;
                 Debug.Assert(methodType != null &&
                     (methodType.IsGenericType && declaringType.IsGenericType &&
                      methodType.GetGenericTypeDefinition() == declaringType.GetGenericTypeDefinition() ||

--- a/VSharp.TestRenderer/TestsRenderer.cs
+++ b/VSharp.TestRenderer/TestsRenderer.cs
@@ -295,9 +295,11 @@ public static class TestsRenderer
         // Declaring arguments and 'this' of testing method
         IdentifierNameSyntax? thisArgId = null;
         string thisArgName = "thisArg";
+        Type? thisArgType = null;
         if (thisArg != null)
         {
             Debug.Assert(Reflection.hasThis(method));
+            thisArgType = thisArg.GetType();
             var needExplicitType = thisArg is Delegate;
             var renderedThis = mainBlock.RenderObject(thisArg, thisArgName, needExplicitType);
             if (renderedThis is IdentifierNameSyntax id)
@@ -332,7 +334,7 @@ public static class TestsRenderer
         f.HasArgs = mainBlock.StatementsCount() > 0;
 
         // Calling testing method
-        var callMethod = test.RenderCall(thisArgId, method, renderedArgs);
+        var callMethod = test.RenderCall(thisArgId, thisArgType, method, renderedArgs);
         f.CallingTest = callMethod.NormalizeWhitespace().ToString();
 
         var hasResult = Reflection.hasNonVoidResult(method) || method.IsConstructor;

--- a/VSharp.Utils/Reflection.fs
+++ b/VSharp.Utils/Reflection.fs
@@ -405,7 +405,9 @@ module public Reflection =
     let concretizeMethodParameters (declaringType : Type) (method : MethodBase) (values : Type[]) =
         match method with
         | :? MethodInfo as mi ->
-            let method = declaringType.GetMethods() |> Array.find (fun x -> x.MetadataToken = mi.MetadataToken)
+            let method =
+                declaringType.GetMethods(allBindingFlags)
+                |> Array.find (fun x -> x.MetadataToken = mi.MetadataToken)
             if method.IsGenericMethod then
                 assert(values.Length = method.GetGenericArguments().Length)
                 method.MakeGenericMethod(values) :> MethodBase

--- a/VSharp.Utils/UnitTest.fs
+++ b/VSharp.Utils/UnitTest.fs
@@ -65,6 +65,7 @@ type UnitTest private (m : MethodBase, info : testInfo, createCompactRepr : bool
     let isError = info.isError
     let errorMessage = info.errorMessage
     let expectedResult = memoryGraph.DecodeValue info.expectedResult
+    let compactRepresentations = memoryGraph.CompactRepresentations()
 //    let classTypeParameters = info.classTypeParameters |> Array.map Serialization.decodeType
 //    let methodTypeParameters = info.methodTypeParameters |> Array.map Serialization.decodeType
     let mutable extraAssemblyLoadDirs : string list = [Directory.GetCurrentDirectory()]
@@ -109,6 +110,8 @@ type UnitTest private (m : MethodBase, info : testInfo, createCompactRepr : bool
             p.SetValue(info, v)
 
     member x.TypeMocks with get() = typeMocks
+
+    member x.CompactRepresentations with get() = compactRepresentations
 
     member x.DefineTypeMock(name : string) =
         let mock = Mocking.Type(name)


### PR DESCRIPTION
- fixed calling non-public methods or methods of non-public type (https://github.com/VSharp-team/VSharp/issues/233)
- fixed deserialization of compact arrays
- command `--public-method-of-class` renamed to `--type`