### PR TITLE
Stabilization: part XII

### DIFF
--- a/VSharp.SILI.Core/API.fs
+++ b/VSharp.SILI.Core/API.fs
@@ -173,7 +173,13 @@ module API =
             | Union gvs -> gvs |> List.map (fun (g, v) -> (g, HeapReferenceToBoxReference v)) |> Merging.merge
             | _ -> internalfailf "Unboxing: expected heap reference, but got %O" reference
 
-        let AddConstraint conditionState condition = Memory.addConstraint conditionState condition
+        let AddConstraint conditionState condition =
+            Memory.addConstraint conditionState condition
+            match conditionState.model with
+            | StateModel(_, typeModel) ->
+                Seq.singleton condition |> TypeSolver.addTypeConstraints typeModel
+            | model -> internalfail $"AddConstraint: unexpected model {model}"
+
         let IsFalsePathCondition conditionState = PC.isFalse conditionState.pc
         let Contradicts state condition = PC.add state.pc condition |> PC.isFalse
         let PathConditionToSeq (pc : pathCondition) = PC.toSeq pc

--- a/VSharp.SILI.Core/API.fs
+++ b/VSharp.SILI.Core/API.fs
@@ -42,8 +42,8 @@ module API =
     let PerformBinaryOperation op left right k = simplifyBinaryOperation op left right k
     let PerformUnaryOperation op arg k = simplifyUnaryOperation op arg k
 
-    let SolveGenericMethodParameters (typeModel : typeModel) (method : IMethod) =
-        TypeSolver.solveMethodParameters typeModel method
+    let SolveGenericMethodParameters (typeStorage : typeStorage) (method : IMethod) =
+        TypeSolver.solveMethodParameters typeStorage method
     let ResolveCallVirt state thisAddress thisType ancestorMethod = TypeSolver.getCallVirtCandidates state thisAddress thisType ancestorMethod
 
     let mutable private reportError = fun _ _ -> ()
@@ -123,9 +123,9 @@ module API =
 
         let (|True|_|) t = (|True|_|) t
         let (|False|_|) t = (|False|_|) t
-        let (|Negation|_|) t = Terms.(|NegationT|_|) t
-        let (|Conjunction|_|) term = Terms.(|Conjunction|_|) term.term
-        let (|Disjunction|_|) term = Terms.(|Disjunction|_|) term.term
+        let (|Negation|_|) t = (|NegationT|_|) t
+        let (|Conjunction|_|) term = (|Conjunction|_|) term.term
+        let (|Disjunction|_|) term = (|Disjunction|_|) term.term
         let (|NullRef|_|) = function
             | {term = HeapRef(addr, t)} when addr = zeroAddress -> Some(t)
             | _ -> None
@@ -161,6 +161,7 @@ module API =
         let (|RefSubtypeTypeSource|_|) src = TypeCasting.(|RefSubtypeTypeSource|_|) src
         let (|TypeSubtypeRefSource|_|) src = TypeCasting.(|TypeSubtypeRefSource|_|) src
         let (|RefSubtypeRefSource|_|) src = TypeCasting.(|RefSubtypeRefSource|_|) src
+        let (|GetHashCodeSource|_|) s = Memory.(|GetHashCodeSource|_|) s
 
         let GetHeapReadingRegionSort src = Memory.getHeapReadingRegionSort src
 
@@ -175,10 +176,8 @@ module API =
 
         let AddConstraint conditionState condition =
             Memory.addConstraint conditionState condition
-            match conditionState.model with
-            | StateModel(_, typeModel) ->
-                Seq.singleton condition |> TypeSolver.addTypeConstraints typeModel
-            | model -> internalfail $"AddConstraint: unexpected model {model}"
+            let constraints = conditionState.typeStorage.Constraints
+            TypeStorage.addTypeConstraint constraints condition
 
         let IsFalsePathCondition conditionState = PC.isFalse conditionState.pc
         let Contradicts state condition = PC.add state.pc condition |> PC.isFalse
@@ -236,6 +235,7 @@ module API =
         let Sub x y = sub x y
         let Add x y = add x y
         let Rem x y = rem x y
+        let RemUn x y = remUn x y
         let IsZero term = checkEqualZero term id
 
         let Acos x = acos x
@@ -278,10 +278,10 @@ module API =
 
     module public Memory =
         let EmptyState() = Memory.makeEmpty false
-        let EmptyModel method typeModel =
+        let EmptyModel method =
             let modelState = Memory.makeEmpty true
             Memory.fillModelWithParametersAndThis modelState method
-            StateModel(modelState, typeModel)
+            StateModel modelState
 
         let PopFrame state = Memory.popFrame state
         let ForcePopFrames count state = Memory.forcePopFrames count state

--- a/VSharp.SILI.Core/API.fsi
+++ b/VSharp.SILI.Core/API.fsi
@@ -30,7 +30,7 @@ module API =
     val PerformBinaryOperation : OperationType -> term -> term -> (term -> 'a) -> 'a
     val PerformUnaryOperation : OperationType -> term -> (term -> 'a) -> 'a
 
-    val SolveGenericMethodParameters : typeModel -> IMethod -> (symbolicType[] * symbolicType[]) option
+    val SolveGenericMethodParameters : typeStorage -> IMethod -> (symbolicType[] * symbolicType[]) option
     val ResolveCallVirt : state -> term -> Type -> IMethod -> symbolicType seq
 
     val ConfigureErrorReporter : (state -> string -> unit) -> unit
@@ -108,6 +108,7 @@ module API =
         val (|RefSubtypeTypeSource|_|) : ISymbolicConstantSource -> option<heapAddress * Type>
         val (|TypeSubtypeRefSource|_|) : ISymbolicConstantSource -> option<Type * heapAddress>
         val (|RefSubtypeRefSource|_|) : ISymbolicConstantSource -> option<heapAddress * heapAddress>
+        val (|GetHashCodeSource|_|) : ISymbolicConstantSource -> option<term>
 
         val GetHeapReadingRegionSort : ISymbolicConstantSource -> regionSort
 
@@ -173,6 +174,7 @@ module API =
         val Sub : term -> term -> term
         val Add : term -> term -> term
         val Rem : term -> term -> term
+        val RemUn : term -> term -> term
         val IsZero : term -> term
 
         val Acos : term -> term
@@ -212,7 +214,7 @@ module API =
 
     module public Memory =
         val EmptyState : unit -> state
-        val EmptyModel : IMethod -> typeModel -> model
+        val EmptyModel : IMethod -> model
         val PopFrame : state -> unit
         val ForcePopFrames : int -> state -> unit
         val PopTypeVariables : state -> unit

--- a/VSharp.SILI.Core/Arithmetics.fs
+++ b/VSharp.SILI.Core/Arithmetics.fs
@@ -735,6 +735,9 @@ module internal Arithmetics =
     let rem x y =
         simplifyRemainder true (deduceArithmeticTargetType x y) x y id
 
+    let remUn x y =
+        simplifyRemainder false (deduceArithmeticTargetType x y) x y id
+
     let eq x y =
         simplifyEqual x y id
 

--- a/VSharp.SILI.Core/Arithmetics.fs
+++ b/VSharp.SILI.Core/Arithmetics.fs
@@ -286,12 +286,12 @@ module internal Arithmetics =
         match b.term, y with
         // (a << b) + (a << b) = 0            if unchecked, b = (size of a) * 8 - 1
         // (a << b) + (a << b) = a << (b + 1) if unchecked, b < (size of a) * 8 - 1
-        | Concrete(x, xt), ShiftLeft(c, ConcreteT(d, _), _) when a = c && x = d ->
-            let tooBigShift = Calculator1.Compare(x, ((sizeOf a) * 8) - 1) = 0
+        | Concrete(bval, bt), ShiftLeft(c, ConcreteT(d, _), _) when a = c && bval = d ->
+            let tooBigShift = Calculator1.Compare(bval, ((sizeOf a) * 8) - 1) = 0
             if tooBigShift then
                 castConcrete 0 t |> matched
             else
-                simplifyShift OperationType.ShiftLeft t a (castConcrete (Calculator1.Add(x, 1, xt)) xt) matched
+                simplifyShift OperationType.ShiftLeft t a (castConcrete (Calculator1.Add(bval, 1, bt)) bt) matched
         | _ -> unmatched ()
 
     and private simplifyAdditionToExpression x y t matched unmatched =
@@ -489,7 +489,7 @@ module internal Arithmetics =
                 | x, UnaryMinusT(y, _) when not <| isUnsigned t && x = y -> castConcrete -1 t |> k
                 // x / 2^n = x >> n if unchecked and x is unsigned
                 | _, ConcreteT(powOf2, _) when Calculator.IsPowOfTwo(powOf2) && not isSigned ->
-                    let n = Calculator.WhatPowerOf2(powOf2) |> makeNumber
+                    let n = Calculator.WhatPowerOf2(powOf2) |> int |> makeNumber
                     simplifyShift OperationType.ShiftRight_Un t x n k
                 // (a >> b) / 2^n = a >> (b + n) if unchecked, b is concrete, b + n < (size of a) * 8
                 // (a >> b) / 2^n = 0 if unchecked, b is concrete, b + n >= (size of a) * 8
@@ -597,8 +597,8 @@ module internal Arithmetics =
         // Simplifying (a op b) op y at this step
         match b.term, y.term, op with
         // (a op b) op y = a op (b + y) if unchecked, b and y are concrete, b + y < (size of a) * 8
-        | Concrete(x, xt), Concrete(c, _), _ when Calculator1.Compare(Calculator1.Add(x, c, t), bitSizeOf a t) = -1 ->
-            simplifyShift op t a (castConcrete (Calculator1.Add(x, c, xt)) xt) matched
+        | Concrete(bval, bt), Concrete(yval, _), _ when Calculator1.Compare(Calculator1.Add(bval, yval, t), bitSizeOf a t) = -1 ->
+            simplifyShift op t a (castConcrete (Calculator1.Add(bval, yval, bt)) bt) matched
         // (a op b) op y = 0 if unchecked, b and y are concrete, b + y >= (size of a) * 8
         | Concrete _, Concrete _, OperationType.ShiftLeft ->
             castConcrete 0 t |> matched
@@ -629,6 +629,7 @@ module internal Arithmetics =
         | _ -> unmatched ()
 
     and private simplifyShift operation (t : System.Type) (x : term) y (k : term -> 'a) =
+        assert(let t = typeOf y in t = typeof<int> || t = typeof<System.IntPtr>)
         let defaultCase () =
             makeShift operation t x y k
         simplifyGenericBinary "shift" x y k

--- a/VSharp.SILI.Core/Branching.fs
+++ b/VSharp.SILI.Core/Branching.fs
@@ -3,7 +3,8 @@ namespace VSharp.Core
 open VSharp
 
 module Branching =
-    let checkSat state condition = TypeSolver.checkSatWithSubtyping state condition
+
+    let checkSat state = SolverInteraction.checkSatWithSubtyping state
 
     let commonGuardedStatedApplyk f state term mergeResults k =
         match term.term with
@@ -39,59 +40,77 @@ module Branching =
         conditionInvocation state (fun (condition, conditionState) ->
         let pc = state.pc
         assert(PC.toSeq pc |> conjunction |> state.model.Eval |> isTrue)
+        let typeStorage = conditionState.typeStorage
         let evaled = state.model.Eval condition
+        let notCondition = !!condition
         if isTrue evaled then
-            let notCondition = !!condition
             assert(state.model.Eval notCondition |> isFalse)
             let elsePc = PC.add pc notCondition
             if PC.isFalse elsePc then
                 thenBranch conditionState (List.singleton >> k)
             elif not branchesReleased then
+                let typeStorageCopy = typeStorage.Copy()
                 conditionState.pc <- elsePc
-                match checkSat conditionState notCondition with
+                TypeStorage.addTypeConstraint typeStorage.Constraints notCondition
+                match checkSat conditionState with
                 | SolverInteraction.SmtUnsat _ ->
                     conditionState.pc <- pc
-                    TypeSolver.refineTypes conditionState condition
+                    TypeStorage.addTypeConstraint typeStorageCopy.Constraints condition
+                    conditionState.typeStorage <- typeStorageCopy
+                    TypeSolver.refineTypes conditionState
                     thenBranch conditionState (List.singleton >> k)
                 | SolverInteraction.SmtUnknown _ ->
                     conditionState.pc <- PC.add pc condition
-                    TypeSolver.refineTypes conditionState condition
+                    TypeStorage.addTypeConstraint typeStorageCopy.Constraints condition
+                    conditionState.typeStorage <- typeStorageCopy
+                    TypeSolver.refineTypes conditionState
                     thenBranch conditionState (List.singleton >> k)
                 | SolverInteraction.SmtSat model ->
                     let thenState = conditionState
                     let elseState = Memory.copy conditionState elsePc
                     elseState.model <- model.mdl
                     thenState.pc <- PC.add pc condition
-                    TypeSolver.refineTypes thenState condition
+                    TypeStorage.addTypeConstraint typeStorageCopy.Constraints condition
+                    thenState.typeStorage <- typeStorageCopy
+                    TypeSolver.refineTypes thenState
                     execution thenState elseState condition k
             else
                 conditionState.pc <- PC.add pc condition
+                TypeStorage.addTypeConstraint typeStorage.Constraints condition
                 thenBranch conditionState (List.singleton >> k)
         elif isFalse evaled then
-            let notCondition = !!condition
             assert(state.model.Eval notCondition |> isTrue)
             let thenPc = PC.add state.pc condition
             if PC.isFalse thenPc then
                 elseBranch conditionState (List.singleton >> k)
             elif not branchesReleased then
+                let typeStorageCopy = typeStorage.Copy()
                 conditionState.pc <- thenPc
-                match checkSat conditionState condition with
+                TypeStorage.addTypeConstraint typeStorage.Constraints condition
+                match checkSat conditionState with
                 | SolverInteraction.SmtUnsat _ ->
                     conditionState.pc <- pc
-                    TypeSolver.refineTypes conditionState notCondition
+                    TypeStorage.addTypeConstraint typeStorageCopy.Constraints notCondition
+                    conditionState.typeStorage <- typeStorageCopy
+                    TypeSolver.refineTypes conditionState
                     elseBranch conditionState (List.singleton >> k)
                 | SolverInteraction.SmtUnknown _ ->
                     conditionState.pc <- PC.add pc notCondition
-                    TypeSolver.refineTypes conditionState notCondition
+                    TypeStorage.addTypeConstraint typeStorageCopy.Constraints notCondition
+                    conditionState.typeStorage <- typeStorageCopy
+                    TypeSolver.refineTypes conditionState
                     elseBranch conditionState (List.singleton >> k)
                 | SolverInteraction.SmtSat model ->
                     let thenState = conditionState
                     let elseState = Memory.copy conditionState (PC.add pc notCondition)
                     thenState.model <- model.mdl
-                    TypeSolver.refineTypes elseState notCondition
+                    TypeStorage.addTypeConstraint typeStorageCopy.Constraints notCondition
+                    elseState.typeStorage <- typeStorageCopy
+                    TypeSolver.refineTypes elseState
                     execution thenState elseState condition k
             else
                 conditionState.pc <- PC.add pc notCondition
+                TypeStorage.addTypeConstraint typeStorage.Constraints notCondition
                 elseBranch conditionState (List.singleton >> k)
         else __unreachable__())
 

--- a/VSharp.SILI.Core/CallStack.fs
+++ b/VSharp.SILI.Core/CallStack.fs
@@ -61,7 +61,9 @@ module internal CallStack =
         | None -> findFrameAndRead frames key k
 
     let readStackLocation (stack : callStack) key makeSymbolic =
-        if stack.frames.Length = 1 && stack.frames.Head.func = None && (stack.frames.Head.entries |> PersistentDict.forall (fun (key', _) -> key <> key')) then
+        let isModel = stack.frames.Length = 1 && stack.frames.Head.func = None
+        let notContains = lazy (stack.frames.Head.entries |> PersistentDict.forall (fun (key', _) -> key <> key'))
+        if isModel && notContains.Value then
             // This state is formed by SMT solver model, just return the default value
             match key with
             | ParameterKey pi -> pi.ParameterType |> makeDefaultValue

--- a/VSharp.SILI.Core/ConcreteMemory.fs
+++ b/VSharp.SILI.Core/ConcreteMemory.fs
@@ -9,9 +9,6 @@ open VSharp
 
 type public ConcreteMemory private (physToVirt, virtToPhys) =
 
-    let mutable physToVirt = physToVirt
-    let mutable virtToPhys = virtToPhys
-
 // ----------------------------- Helpers -----------------------------
 
     static let nonCopyableTypes = [

--- a/VSharp.SILI.Core/MethodMock.fs
+++ b/VSharp.SILI.Core/MethodMock.fs
@@ -15,7 +15,7 @@ type functionResultConstantSource =
         args : term list
     }
 with
-    interface ISymbolicConstantSource with
+    interface INonComposableSymbolicConstantSource with
         override x.TypeOfLocation = x.mock.Method.ReturnType
         override x.SubTerms = []
         override x.Time = VectorTime.zero

--- a/VSharp.SILI.Core/State.fs
+++ b/VSharp.SILI.Core/State.fs
@@ -99,11 +99,11 @@ type arrayCopyInfo =
 
 type model =
     | PrimitiveModel of IDictionary<ISymbolicConstantSource, term>
-    | StateModel of state * typeModel
+    | StateModel of state
 with
     member x.Complete value =
         match x with
-        | StateModel(state, _) when state.complete ->
+        | StateModel state when state.complete ->
             // TODO: ideally, here should go the full-fledged substitution, but we try to improve the performance a bit...
             match value.term with
             | Constant(_, _, typ) -> makeDefaultValue typ
@@ -111,7 +111,7 @@ with
             | _ -> value
         | _ -> value
 
-    static member private EvalDict (subst : IDictionary<ISymbolicConstantSource, term>) source term typ complete =
+    static member EvalDict (subst : IDictionary<ISymbolicConstantSource, term>) source term typ complete =
         let value = ref Nop
         if subst.TryGetValue(source, value) then value.Value
         elif complete then makeDefaultValue typ
@@ -121,13 +121,13 @@ with
         Substitution.substitute (function
             | { term = Constant(_, (:? IStatedSymbolicConstantSource as source), typ) } as term ->
                 match x with
-                | StateModel(state, _) -> source.Compose state
+                | StateModel state -> source.Compose state
                 | PrimitiveModel subst -> model.EvalDict subst source term typ true
             | { term = Constant(_, source, typ) } as term ->
                 let subst, complete =
                     match x with
                     | PrimitiveModel dict -> dict, true
-                    | StateModel(state, _) ->
+                    | StateModel state ->
                         match state.model with
                         | PrimitiveModel dict -> dict, state.complete
                         | _ -> __unreachable__()
@@ -147,20 +147,48 @@ with
         let empty = List.empty
         { subtypes = empty; supertypes = empty; notSubtypes = empty; notSupertypes = empty }
 
-    static member FromSuperTypes(superTypes : Type list) =
+    static member FromSuperTypes (superTypes : Type list) =
         let empty = List.empty
         let superTypes = List.filter (fun t -> t <> typeof<obj>) superTypes |> List.distinct
         { subtypes = empty; supertypes = superTypes; notSubtypes = empty; notSupertypes = empty }
 
-    member x.Merge(other : typeConstraints) =
+    static member Create supertypes subtypes notSupertypes notSubtypes =
+        let supertypes = List.filter (fun t -> t <> typeof<obj>) supertypes |> List.distinct
+        let subtypes = List.distinct subtypes
+        let notSupertypes = List.distinct notSupertypes
+        let notSubtypes = List.distinct notSubtypes
+        { subtypes = subtypes; supertypes = supertypes; notSubtypes = notSubtypes; notSupertypes = notSupertypes }
+
+    member x.Merge(other : typeConstraints) : bool =
+        let mutable changed = false
         if x.supertypes <> other.supertypes then
+            changed <- true
             x.supertypes <- x.supertypes @ other.supertypes |> List.distinct
         if x.subtypes <> other.subtypes then
+            changed <- true
             x.subtypes <- x.subtypes @ other.subtypes |> List.distinct
         if x.notSubtypes <> other.notSubtypes then
+            changed <- true
             x.notSubtypes <- x.notSubtypes @ other.notSubtypes |> List.distinct
         if x.notSupertypes <> other.notSupertypes then
+            changed <- true
             x.notSupertypes <- x.notSupertypes @ other.notSupertypes |> List.distinct
+        changed
+
+    member x.IsContradicting() =
+        let nonComparable (t : Type) (u : Type) =
+            u.IsClass && t.IsClass && (not <| u.IsAssignableTo t) && (not <| u.IsAssignableFrom t)
+            || t.IsSealed && u.IsInterface && not (t.IsAssignableTo u)
+        // X <: u and u <: t and X </: t
+        x.supertypes |> List.exists (fun u -> x.notSupertypes |> List.exists u.IsAssignableTo)
+        || // u <: X and t <: u and t </: X
+        x.subtypes |> List.exists (fun u -> x.notSubtypes |> List.exists u.IsAssignableFrom)
+        || // u <: X and X <: t and u </: t
+        x.subtypes |> List.exists (fun u -> x.supertypes |> List.exists (u.IsAssignableTo >> not))
+        || // No multiple inheritance -- X <: u and X <: t and u </: t and t </: u and t, u are classes
+        x.supertypes |> List.exists (fun u -> x.supertypes |> List.exists (nonComparable u))
+        || // u </: X and X <: u when u is sealed
+        x.supertypes |> List.exists (fun u -> u.IsSealed && x.notSubtypes |> List.contains u)
 
     member x.AddSuperType(superType : Type) =
         if superType <> typeof<obj> then
@@ -177,20 +205,19 @@ with
 and typesConstraints private (newAddresses, constraints) =
 
     new () =
-        let newAddresses = ResizeArray<term>()
+        let newAddresses = HashSet<term>()
         let allConstraints = Dictionary<term, typeConstraints>()
         typesConstraints(newAddresses, allConstraints)
 
     member x.Copy() =
-        let copiedNewAddresses = ResizeArray<term>(newAddresses)
+        let copiedNewAddresses = HashSet<term>(newAddresses)
         let copiedConstraints = Dictionary<term, typeConstraints>()
         for entry in constraints do
             copiedConstraints.Add(entry.Key, entry.Value.Copy())
         typesConstraints(copiedNewAddresses, copiedConstraints)
 
     member private x.AddNewAddress address =
-        if newAddresses.Contains address |> not then
-            newAddresses.Add address
+        newAddresses.Add address |> ignore
 
     member x.ClearNewAddresses() =
         newAddresses.Clear()
@@ -198,24 +225,35 @@ and typesConstraints private (newAddresses, constraints) =
     member x.NewAddresses with get() = newAddresses
 
     member x.Add (address : term) (typeConstraint : typeConstraints) =
-        x.AddNewAddress address
         let current = ref (typeConstraints.Empty())
         if constraints.TryGetValue(address, current) then
-            current.Value.Merge typeConstraint
-        else constraints.Add(address, typeConstraint)
-
-    member x.Remove (address : term) =
-        newAddresses.Remove address |> ignore
-        constraints.Remove address |> ignore
-
-    member x.MergeConstraints (addresses : term seq) =
-        let resultConstraints = typeConstraints.Empty()
-        for address in addresses do
-            let constraints = constraints[address]
-            resultConstraints.Merge constraints
+            let changed = current.Value.Merge typeConstraint
+            if changed then x.AddNewAddress address
+        else
+            constraints.Add(address, typeConstraint)
             x.AddNewAddress address
-        for address in addresses do
-            constraints[address] <- resultConstraints
+
+    member x.AddSuperType address superType =
+        let typeConstraint = List.singleton superType |> typeConstraints.FromSuperTypes
+        x.Add address typeConstraint
+
+    member x.CheckInequality() =
+        let mutable isValid = true
+        let unequal = HashSet<term * term>()
+        for entry1 in constraints do
+            let address1 = entry1.Key
+            let typeConstraints1 = entry1.Value
+            for entry2 in constraints do
+                let address2 = entry2.Key
+                let typeConstraints2 = entry2.Value
+                let typeConstraints = typeConstraints1.Copy()
+                let different = address1 <> address2
+                if different then
+                    typeConstraints.Merge typeConstraints2 |> ignore
+                if typeConstraints.IsContradicting() then
+                    if different then unequal.Add(address1, address2) |> ignore
+                    else isValid <- false
+        isValid, Seq.map (fun (a1, a2) -> !!(a1 === a2)) unequal
 
     interface System.Collections.IEnumerable with
         member this.GetEnumerator() =
@@ -228,36 +266,37 @@ and typesConstraints private (newAddresses, constraints) =
     member x.Item(address : term) =
         constraints[address].Copy()
 
-and typeModel =
-    {
-        constraints : typesConstraints
-        addressesTypes : Dictionary<term, symbolicType seq>
-        mutable classesParams : symbolicType[]
-        mutable methodsParams : symbolicType[]
-        typeMocks : IDictionary<Type list, ITypeMock>
-    }
-with
-    static member CreateEmpty() =
-        {
-            constraints = typesConstraints()
-            addressesTypes = Dictionary()
-            classesParams = Array.empty
-            methodsParams = Array.empty
-            typeMocks = Dictionary()
-        }
+    member x.Count with get() = constraints.Count
 
-    member x.AddConstraint address typeConstraint =
-        x.constraints.Add address typeConstraint
+and typeStorage private (constraints, addressesTypes, typeMocks, classesParams, methodsParams) =
+    let mutable classesParams = classesParams
+    let mutable methodsParams = methodsParams
 
-    member x.AddSuperType address superType =
-        let typeConstraint = List.singleton superType |> typeConstraints.FromSuperTypes
-        x.AddConstraint address typeConstraint
+    new() =
+        let constraints = typesConstraints()
+        let addressesTypes = Dictionary<term, symbolicType seq>()
+        let typeMocks = Dictionary<Type list, ITypeMock>()
+        let classesParams : symbolicType[] = Array.empty
+        let methodsParams : symbolicType[] = Array.empty
+        typeStorage(constraints, addressesTypes, typeMocks, classesParams, methodsParams)
+
+    member x.Constraints with get() = constraints
+    member x.AddressesTypes with get() = addressesTypes
+    member x.TypeMocks with get() = typeMocks
+    member x.ClassesParams
+        with get() = classesParams
+        and set newClassesParams =
+            classesParams <- newClassesParams
+    member x.MethodsParams
+        with get() = methodsParams
+        and set newMethodsParams =
+            methodsParams <- newMethodsParams
 
     member x.Copy() =
-        let newConstraints = x.constraints.Copy()
+        let newConstraints = constraints.Copy()
         let newTypeMocks = Dictionary<Type list, ITypeMock>()
         let newAddressesTypes = Dictionary()
-        for entry in x.addressesTypes do
+        for entry in addressesTypes do
             let address = entry.Key
             let types = entry.Value
             let changeType = function
@@ -272,23 +311,23 @@ with
                         MockType newMock
             let newTypes = Seq.map changeType types
             newAddressesTypes.Add(address, newTypes)
-        {
-            constraints = newConstraints
-            addressesTypes = newAddressesTypes
-            classesParams = x.classesParams
-            methodsParams = x.methodsParams
-            typeMocks = newTypeMocks
-        }
+        typeStorage(newConstraints, newAddressesTypes, newTypeMocks, classesParams, methodsParams)
+
+    member x.AddConstraint address typeConstraint =
+        constraints.Add address typeConstraint
 
     member x.Item(address : term) =
         let types = ref null
-        if x.addressesTypes.TryGetValue(address, types) then Some types.Value
+        if addressesTypes.TryGetValue(address, types) then Some types.Value
         else None
+
+    member x.IsValid with get() = addressesTypes.Count = constraints.Count
 
 and
     [<ReferenceEquality>]
     state = {
         mutable pc : pathCondition
+        mutable typeStorage : typeStorage
         mutable evaluationStack : evaluationStack
         mutable stack : callStack                                          // Arguments and local variables
         mutable stackBuffers : pdict<stackKey, stackBufferRegion>          // Buffers allocated via stackAlloc

--- a/VSharp.SILI.Core/Terms.fs
+++ b/VSharp.SILI.Core/Terms.fs
@@ -721,60 +721,63 @@ module internal Terms =
         | _, Concrete(:? IComparable, _) -> 1
         | _ -> compare (toString t1) (toString t2)
 
-    let rec private foldChildren folder state term =
+    let rec private foldChildren folder state term k =
         match term.term with
         | Constant(_, source, _) ->
-            foldSeq folder source.SubTerms state
+            foldSeq folder source.SubTerms state k
         | Expression(_, args, _) ->
-            foldSeq folder args state
+            foldSeq folder args state k
         | Struct(fields, _) ->
-            foldSeq folder (PersistentDict.values fields) state
+            foldSeq folder (PersistentDict.values fields) state k
         | Ref address ->
-            foldAddress folder state address
+            foldAddress folder state address k
         | Ptr(address, _, indent) ->
-            let state = foldPointerBase folder state address
-            doFold folder state indent
+            foldPointerBase folder state address (fun state ->
+            doFold folder state indent k)
         | GuardedValues(gs, vs) ->
-            foldSeq folder gs state |> foldSeq folder vs
+            foldSeq folder gs state (fun state ->
+            foldSeq folder vs state k)
         | Slice(t, s, e, pos) ->
-            let state = folder state t
-            let state = folder state s
-            let state = folder state e
-            folder state pos
-        | _ -> state
+            folder state t (fun state ->
+            folder state s (fun state ->
+            folder state e (fun state ->
+            folder state pos k)))
+        | _ -> k state
 
-    and doFold folder state term =
-        let state = foldChildren folder state term
-        folder state term
+    and doFold folder state term k =
+        foldChildren folder state term (fun state ->
+        folder state term k)
 
-    and foldAddress folder state = function
+    and foldAddress folder state address k =
+        match address with
         | PrimitiveStackLocation _
         | StaticField _
-        | BoxedLocation _ -> state
-        | ClassField(addr, _) -> doFold folder state addr
+        | BoxedLocation _ -> k state
+        | ClassField(addr, _) -> doFold folder state addr k
         | ArrayIndex(addr, idcs, _) ->
-            let state = doFold folder state addr
-            foldSeq folder idcs state
-        | StructField(addr, _) -> foldAddress folder state addr
+            doFold folder state addr (fun state ->
+            foldSeq folder idcs state k)
+        | StructField(addr, _) -> foldAddress folder state addr k
         | ArrayLength(addr, idx, _)
         | ArrayLowerBound(addr, idx, _) ->
-            let state = doFold folder state addr
-            doFold folder state idx
-        | StackBufferIndex(_, idx) -> doFold folder state idx
+            doFold folder state addr (fun state ->
+            doFold folder state idx k)
+        | StackBufferIndex(_, idx) -> doFold folder state idx k
 
-    and foldPointerBase folder state = function
-        | HeapLocation(heapAddress, _) -> doFold folder state heapAddress
+    and foldPointerBase folder state pointerBase k =
+        match pointerBase with
+        | HeapLocation(heapAddress, _) -> doFold folder state heapAddress k
         | StackLocation _
-        | StaticLocation _ -> state
+        | StaticLocation _ -> k state
 
-    and private foldSeq folder terms state =
-        Seq.fold (doFold folder) state terms
+    and private foldSeq folder terms state k =
+        Cps.Seq.foldlk (doFold folder) state terms k
 
     let fold folder state terms =
-        foldSeq folder terms state
+        foldSeq folder terms state id
 
     let iter action term =
-        doFold (fun () -> action) () term
+        doFold (fun () t k -> k (action t)) () term id
 
     let discoverConstants terms =
         let result = HashSet<term>()

--- a/VSharp.SILI.Core/TypeSolver.fs
+++ b/VSharp.SILI.Core/TypeSolver.fs
@@ -31,7 +31,6 @@ type TypeMock(supertypes : Type seq) =
     member x.WithSupertypes(supertypes' : Type seq) : unit =
         supertypes <- supertypes'
 
-
 // ------------------------------------------------- Type constraints -------------------------------------------------
 
 module TypeStorage =

--- a/VSharp.SILI.Core/TypeSolver.fs
+++ b/VSharp.SILI.Core/TypeSolver.fs
@@ -32,10 +32,75 @@ type TypeMock(supertypes : Type seq) =
         supertypes <- supertypes'
 
 
+// ------------------------------------------------- Type constraints -------------------------------------------------
+
+module TypeStorage =
+
+    // TODO: move this to SolverInteraction and parse all pc at once
+    let addTypeConstraints (typesConstraints : typesConstraints) conditions =
+        let supertypeConstraints = Dictionary<term, HashSet<Type>>()
+        let subtypeConstraints = Dictionary<term, HashSet<Type>>()
+        let notSupertypeConstraints = Dictionary<term, HashSet<Type>>()
+        let notSubtypeConstraints = Dictionary<term, HashSet<Type>>()
+        let addresses = ResizeArray<term>()
+
+        // Creating type constraints from path condition
+        let add (dict : Dictionary<term, HashSet<Type>>) address typ =
+            let types =
+                let types = ref null
+                if dict.TryGetValue(address, types) then types.Value
+                else
+                    let typesSet = HashSet<_>()
+                    dict.Add(address, typesSet)
+                    addresses.Add address
+                    typesSet
+            types.Add typ |> ignore
+
+        let addConstraints _ term next into =
+            match term.term with
+            | Constant(_, TypeCasting.TypeSubtypeTypeSource _, _) ->
+                internalfail "TypeSolver is not fully implemented"
+            | Constant(_, TypeCasting.RefSubtypeTypeSource(address, typ), _) ->
+                add supertypeConstraints address typ |> next
+            | Constant(_, TypeCasting.TypeSubtypeRefSource(typ, address), _) ->
+                add subtypeConstraints address typ |> next
+            | Constant(_, TypeCasting.RefSubtypeRefSource _, _) ->
+                internalfail "TypeSolver is not fully implemented"
+            | Negation({term = Constant(_, TypeCasting.TypeSubtypeTypeSource _, _)}) ->
+                internalfail "TypeSolver is not fully implemented"
+            | Negation({term = Constant(_, TypeCasting.RefSubtypeTypeSource(address, typ), _)}) ->
+                add notSupertypeConstraints address typ |> next
+            | Negation({term = Constant(_, TypeCasting.TypeSubtypeRefSource(typ, address), _)}) ->
+                add notSubtypeConstraints address typ |> next
+            | Negation({term = Constant(_, TypeCasting.RefSubtypeRefSource _, _)}) ->
+                internalfail "TypeSolver is not fully implemented"
+            | Constant(_, (Memory.HeapAddressSource _ as source), _) ->
+                // Adding super types from testing function info
+                add supertypeConstraints term source.TypeOfLocation |> next
+            | _ -> into ()
+        iterSeq addConstraints conditions
+
+        let toList (d : Dictionary<term, HashSet<Type>>) address =
+            let set = ref null
+            if d.TryGetValue(address, set) then List.ofSeq set.Value
+            else List.empty
+        // Adding type constraints
+        for address in addresses do
+            let typeConstraints =
+                typeConstraints.Create
+                    (toList supertypeConstraints address)
+                    (toList subtypeConstraints address)
+                    (toList notSupertypeConstraints address)
+                    (toList notSubtypeConstraints address)
+            typesConstraints.Add address typeConstraints
+
+    let addTypeConstraint (typesConstraints : typesConstraints) condition =
+        List.singleton condition |> addTypeConstraints typesConstraints
+
 // ------------------------------------------------- Type solver core -------------------------------------------------
 
 type typeSolvingResult =
-    | TypeSat of typeModel
+    | TypeSat
     | TypeUnsat
 
 module TypeSolver =
@@ -47,40 +112,34 @@ module TypeSolver =
             let supertypes = enumerateNonAbstractSupertypes predicate typ.BaseType
             if predicate typ then typ::supertypes else supertypes
 
+    let private hasSubtypes (t : Type) =
+        not t.IsSealed && not t.IsArray
+
+    let private canBeMocked (t : Type) =
+        (hasSubtypes t && TypeUtils.isPublic t) || TypeUtils.isDelegate t
+
     let private enumerateTypes (supertypes : Type list) (mock : Type list -> ITypeMock) validate (assemblies : Assembly seq) =
         seq {
-            let mutable hasPrivateSuperType = false
-            yield! supertypes |> Seq.filter validate |> Seq.map ConcreteType
-            let assemblies =
-                match supertypes |> Seq.tryFind (TypeUtils.isPublic >> not) with
-                | Some u -> hasPrivateSuperType <- true; Seq.singleton u.Assembly
-                | None ->
-                    // Dynamic mock assemblies may appear here
-                    assemblies |> Seq.filter (fun a -> not a.IsDynamic)
-            for assembly in assemblies do
-                let types = assembly.GetExportedTypesChecked()
-                yield! types |> Seq.filter (fun t -> not t.ContainsGenericParameters && validate t) |> Seq.map ConcreteType
-            if not hasPrivateSuperType then
+            if List.isEmpty supertypes && validate typeof<obj> then
+                yield ConcreteType typeof<obj>
+            else
+                yield! supertypes |> Seq.filter validate |> Seq.map ConcreteType
+            if List.forall hasSubtypes supertypes then
+                let assemblies =
+                    match supertypes |> Seq.tryFind (TypeUtils.isPublic >> not) with
+                    | Some u -> Seq.singleton u.Assembly
+                    | None ->
+                        // Dynamic mock assemblies may appear here
+                        assemblies |> Seq.filter (fun a -> not a.IsDynamic)
+                for assembly in assemblies do
+                    let types = assembly.GetExportedTypesChecked()
+                    yield! types |> Seq.filter (fun t -> not t.ContainsGenericParameters && validate t) |> Seq.map ConcreteType
+            if List.forall canBeMocked supertypes then
                 yield mock supertypes |> MockType
         }
 
     let private enumerateNonAbstractTypes supertypes mock validate (assemblies : Assembly seq) =
         enumerateTypes supertypes mock (fun t -> not t.IsAbstract && validate t) assemblies
-
-    // TODO: move to 'typeConstraints' member? #type
-    let private isContradicting (c : typeConstraints) =
-        let nonComparable (t : Type) (u : Type) =
-            u.IsClass && t.IsClass && (not <| u.IsAssignableTo t) && (not <| u.IsAssignableFrom t)
-        // X <: u and u <: t and X </: t
-        c.supertypes |> List.exists (fun u -> c.notSupertypes |> List.exists u.IsAssignableTo)
-        || // u <: X and t <: u and t </: X
-        c.subtypes |> List.exists (fun u -> c.notSubtypes |> List.exists u.IsAssignableFrom)
-        || // u <: X and X <: t and u </: t
-        c.subtypes |> List.exists (fun u -> c.supertypes |> List.exists (u.IsAssignableTo >> not))
-        || // No multiple inheritance -- X <: u and X <: t and u </: t and t </: u and t, u are classes
-        c.supertypes |> List.exists (fun u -> c.supertypes |> List.exists (nonComparable u))
-        || // u </: X and X <: u when u is sealed
-        c.supertypes |> List.exists (fun u -> u.IsSealed && c.notSubtypes |> List.contains u)
 
     let rec private substitute (subst : substitution) (t : Type) =
         let substFunction t =
@@ -158,103 +217,6 @@ module TypeSolver =
                 mock
             | Some _  -> __unreachable__()
 
-    let private addressInModel (model : model) address =
-        match model.Eval address with
-        | {term = ConcreteHeapAddress address} -> address
-        | address -> internalfail $"[Type solver] evaluating address in model: unexpected address {address}"
-
-    let addTypeConstraints (typeModel : typeModel) conditions =
-        let supertypeConstraints = Dictionary<term, HashSet<Type>>()
-        let subtypeConstraints = Dictionary<term, HashSet<Type>>()
-        let notSupertypeConstraints = Dictionary<term, HashSet<Type>>()
-        let notSubtypeConstraints = Dictionary<term, HashSet<Type>>()
-        let addresses = ResizeArray<term>()
-
-        // Creating type constraints from path condition
-        let add (dict : Dictionary<term, HashSet<Type>>) address typ =
-            let types =
-                let types = ref null
-                if dict.TryGetValue(address, types) then types.Value
-                else
-                    let typesSet = HashSet<_>()
-                    dict.Add(address, typesSet)
-                    addresses.Add address
-                    typesSet
-            types.Add typ |> ignore
-
-        let addConstraints _ term next into =
-            match term.term with
-            | Constant(_, TypeCasting.TypeSubtypeTypeSource _, _) ->
-                internalfail "TypeSolver is not fully implemented"
-            | Constant(_, TypeCasting.RefSubtypeTypeSource(address, typ), _) ->
-                add supertypeConstraints address typ |> next
-            | Constant(_, TypeCasting.TypeSubtypeRefSource(typ, address), _) ->
-                add subtypeConstraints address typ |> next
-            | Constant(_, TypeCasting.RefSubtypeRefSource _, _) ->
-                internalfail "TypeSolver is not fully implemented"
-            | Negation({term = Constant(_, TypeCasting.TypeSubtypeTypeSource _, _)}) ->
-                internalfail "TypeSolver is not fully implemented"
-            | Negation({term = Constant(_, TypeCasting.RefSubtypeTypeSource(address, typ), _)}) ->
-                add notSupertypeConstraints address typ |> next
-            | Negation({term = Constant(_, TypeCasting.TypeSubtypeRefSource(typ, address), _)}) ->
-                add notSubtypeConstraints address typ |> next
-            | Negation({term = Constant(_, TypeCasting.RefSubtypeRefSource _, _)}) ->
-                internalfail "TypeSolver is not fully implemented"
-            | Constant(_, (Memory.HeapAddressSource _ as source), _) ->
-                // Adding super types from testing function info
-                add supertypeConstraints term source.TypeOfLocation |> next
-            | _ -> into ()
-        iterSeq addConstraints conditions
-
-        let toList (d : Dictionary<term, HashSet<Type>>) address =
-            let set = ref null
-            if d.TryGetValue(address, set) then List.ofSeq set.Value
-            else List.empty
-        // Adding type constraints to type model
-        for address in addresses do
-            let typeConstraint =
-                {
-                    supertypes = toList supertypeConstraints address
-                    subtypes = toList subtypeConstraints address
-                    notSupertypes = toList notSupertypeConstraints address
-                    notSubtypes = toList notSubtypeConstraints address
-                }
-            typeModel.AddConstraint address typeConstraint
-
-    let private mergeConstraints model typeModel =
-        // Clustering type constraints with same address in model
-        let eqInModel = Dictionary<concreteHeapAddress, List<term>>()
-        let currentConstraints = typeModel.constraints
-        for entry in currentConstraints do
-            let address = entry.Key
-            let concreteAddress = addressInModel model address
-            if concreteAddress <> VectorTime.zero then
-                let current = ref null
-                if eqInModel.TryGetValue(concreteAddress, current) then
-                    let same = current.Value
-                    same.Add(address)
-                else
-                    let same = List()
-                    same.Add(address)
-                    eqInModel.Add(concreteAddress, same)
-            else
-                currentConstraints.Remove address
-
-        // Merging constraints with same address in model
-        for entry in eqInModel do
-            let same = entry.Value
-            if same.Count > 1 then
-                currentConstraints.MergeConstraints same
-
-    let private generateConstraints (model : model) conditions =
-        match model with
-        | StateModel(_, typeModel) ->
-            // Parsing constraints from path condition, adding them to 'typeModel.constraints'
-            addTypeConstraints typeModel conditions
-            // Merging constraints of same addresses in model
-            mergeConstraints model typeModel
-        | PrimitiveModel _ -> __unreachable__()
-
     let private generateGenericConstraints (typeVars : Type list) =
         // TODO: divide dependent constraints into groups by dependence
         let isIndependent (t : Type) =
@@ -281,7 +243,10 @@ module TypeSolver =
             assert(numOfSuperTypes >= numOfMockSuperTypes)
             let changedSupertypes = numOfSuperTypes <> numOfMockSuperTypes
             let mockConstraints = {constraints with supertypes = supertypes}
-            let satisfies = List.isEmpty constraints.subtypes && (isContradicting mockConstraints |> not)
+            let satisfies =
+                List.isEmpty constraints.subtypes
+                && (mockConstraints.IsContradicting() |> not)
+                && List.forall canBeMocked constraints.supertypes
             if satisfies && changedSupertypes then getMock (Some mock) supertypes |> Some
             elif satisfies then Some mock
             else None
@@ -314,7 +279,7 @@ module TypeSolver =
         Array.map getSubst typeParameters
 
     let rec private solve (getMock : ITypeMock option -> Type list -> ITypeMock) (inputConstraints : typeConstraints list) (typeParameters : Type[]) =
-        if List.exists isContradicting inputConstraints then None
+        if inputConstraints |> List.exists (fun c -> c.IsContradicting()) then None
         else
             let decodeTypeSubst (subst : substitution) = decodeTypeSubst subst typeParameters
             let collectVars acc constraints =
@@ -356,29 +321,38 @@ module TypeSolver =
         let methodGenericArguments = m.GenericArguments
         typeGenericArguments, methodGenericArguments
 
-    let solveMethodParameters (typeModel : typeModel) (m : IMethod) =
+    let solveMethodParameters (typeStorage : typeStorage) (m : IMethod) =
         let declaringType = m.DeclaringType
         let methodBase = m.MethodBase
         let needToSolve =
-            declaringType.IsGenericType && Array.isEmpty typeModel.classesParams
-            || methodBase.IsGenericMethod && Array.isEmpty typeModel.methodsParams
-        if not needToSolve then Some(typeModel.classesParams, typeModel.methodsParams)
+            declaringType.IsGenericType && Array.isEmpty typeStorage.ClassesParams
+            || methodBase.IsGenericMethod && Array.isEmpty typeStorage.MethodsParams
+        if not needToSolve then Some(typeStorage.ClassesParams, typeStorage.MethodsParams)
         else
             let typeParams, methodParams = getGenericParameters m
             let genericParams = Array.append typeParams methodParams
-            let solvingResult = solve (getMock typeModel.typeMocks) List.empty genericParams
+            let solvingResult = solve (getMock typeStorage.TypeMocks) List.empty genericParams
             match solvingResult with
             | Some (_, genericParams) ->
                 let classParams, methodParams = Array.splitAt typeParams.Length genericParams
-                typeModel.classesParams <- classParams
-                typeModel.methodsParams <- methodParams
+                typeStorage.ClassesParams <- classParams
+                typeStorage.MethodsParams <- methodParams
                 Some(classParams, methodParams)
             | None -> None
 
-    let private refineModel getMock (typeModel : typeModel) typeGenericArguments methodGenericArguments =
+    let private refineTypeSeq getMock typeConstraint types =
+        let refineType symbolicType =
+            match symbolicType with
+            | ConcreteType typ ->
+                if satisfiesConstraints typeConstraint (pdict.Empty()) typ then Some symbolicType
+                else None
+            | MockType mock -> refineMock getMock typeConstraint mock |> Option.map MockType
+        Seq.choose refineType types
+
+    let private refineStorage getMock (typeStorage : typeStorage) typeGenericArguments methodGenericArguments =
         let mutable emptyCandidates = false
-        let addressesTypes = typeModel.addressesTypes
-        let constraints = typeModel.constraints
+        let constraints = typeStorage.Constraints
+        let addressesTypes = typeStorage.AddressesTypes
         let newAddresses = Dictionary<term, typeConstraints>()
 
         for address in constraints.NewAddresses do
@@ -386,13 +360,7 @@ module TypeSolver =
                 let typeConstraint = constraints[address]
                 let types = ref null
                 if addressesTypes.TryGetValue(address, types) then
-                    let refineType symbolicType =
-                        match symbolicType with
-                        | ConcreteType typ ->
-                            if satisfiesConstraints typeConstraint (pdict.Empty()) typ then Some symbolicType
-                            else None
-                        | MockType mock -> refineMock getMock typeConstraint mock |> Option.map MockType
-                    let types = Seq.choose refineType types.Value
+                    let types = refineTypeSeq getMock typeConstraint types.Value
                     if Seq.isEmpty types then emptyCandidates <- true
                     addressesTypes[address] <- types
                 else newAddresses.Add(address, typeConstraint)
@@ -400,7 +368,9 @@ module TypeSolver =
         constraints.ClearNewAddresses()
         let addresses = newAddresses.Keys
         if emptyCandidates then TypeUnsat
-        elif addresses.Count = 0 then TypeSat typeModel
+        elif addresses.Count = 0 then
+            assert typeStorage.IsValid
+            TypeSat
         else
             let addresses = List.ofSeq addresses
             let constraints = List.ofSeq newAddresses.Values
@@ -408,76 +378,109 @@ module TypeSolver =
             match solve getMock constraints genericParams with
             | None -> TypeUnsat
             | Some (candidates, typeParams) ->
-                let addToModel address types = typeModel.addressesTypes.Add(address, types)
-                List.iter2 addToModel addresses candidates
+                let addCandidates address types = addressesTypes.Add(address, types)
+                List.iter2 addCandidates addresses candidates
+                assert typeStorage.IsValid
                 if Array.isEmpty genericParams |> not then
                     let classParams, methodParams = Array.splitAt typeGenericArguments.Length typeParams
-                    typeModel.classesParams <- classParams
-                    typeModel.methodsParams <- methodParams
-                TypeSat typeModel
+                    typeStorage.ClassesParams <- classParams
+                    typeStorage.MethodsParams <- methodParams
+                TypeSat
 
-    let private refineTypesInModel modelState model typeModel =
-        for entry in typeModel.addressesTypes do
+    let private addressInModel (model : model) address =
+        match model.Eval address with
+        | {term = ConcreteHeapAddress address} -> address
+        | _ -> internalfail $"[Type solver] evaluating address in model: unexpected address {address}"
+
+    let mergeConstraints (constraints : typesConstraints) (addresses : term seq) =
+        let resultConstraints = typeConstraints.Empty()
+        for address in addresses do
+            let constraints = constraints[address]
+            resultConstraints.Merge constraints |> ignore
+        resultConstraints
+
+    let private evalInModel model (typeStorage : typeStorage) =
+        // Clustering addresses, which are equal in model
+        let eqInModel = Dictionary<concreteHeapAddress, List<term>>()
+        let addressesTypes = typeStorage.AddressesTypes
+        for entry in addressesTypes do
             let address = entry.Key
-            let types = entry.Value
-            assert(Seq.isEmpty types |> not)
-            let addressForModel = addressInModel model address
-            let typeForModel = Seq.head types
-            match typeForModel with
-            | ConcreteType t when t.IsValueType ->
-                let value = makeDefaultValue t
-                modelState.boxedLocations <- PersistentDict.add addressForModel value modelState.boxedLocations
-            | _ -> ()
-            modelState.allocatedTypes <- PersistentDict.add addressForModel typeForModel modelState.allocatedTypes
+            let concreteAddress = addressInModel model address
+            if concreteAddress <> VectorTime.zero then
+                let current = ref null
+                if eqInModel.TryGetValue(concreteAddress, current) then
+                    let same = current.Value
+                    same.Add(address)
+                else
+                    let same = List()
+                    same.Add(address)
+                    eqInModel.Add(concreteAddress, same)
 
-    let solveTypes (model : model) (state : state) condition =
+        // Intersecting type candidates for same addresses in model
+        let evaledTypes = Dictionary<concreteHeapAddress, symbolicType>()
+        let constraints = typeStorage.Constraints
+        // Configuring 'getMock' to create only new mocks (not refining existing)
+        let getMock _ supertypes = getMock typeStorage.TypeMocks None supertypes
+        for entry in eqInModel do
+            let same = entry.Value
+            let evaledType =
+                let address = Seq.head same
+                let types = addressesTypes[address]
+                assert(Seq.isEmpty types |> not)
+                if same.Count > 1 then
+                    let merged = mergeConstraints constraints same
+                    let refined = refineTypeSeq getMock merged types
+                    assert(Seq.isEmpty refined |> not)
+                    Seq.head refined
+                else Seq.head types
+            evaledTypes.Add(entry.Key, evaledType)
+        evaledTypes
+
+    let private refineTypesInModel model (typeStorage : typeStorage) =
         match model with
-        | StateModel(modelState, typeModel) ->
-            let m = CallStack.stackTrace state.stack |> List.last
-            Seq.singleton condition |> generateConstraints model
-            let typeParams, methodParams = getGenericParameters m
-            let getMock = getMock typeModel.typeMocks
-            let result = refineModel getMock typeModel typeParams methodParams
-            match result with
-            | TypeSat _ -> refineTypesInModel modelState model typeModel
-            | _ -> ()
-            result
-        | PrimitiveModel _ -> internalfail "Solving types: got primitive model"
+        | StateModel modelState ->
+            for entry in evalInModel model typeStorage do
+                let address = entry.Key
+                let typeForModel = entry.Value
+                match typeForModel with
+                | ConcreteType t when t.IsValueType ->
+                    let value = makeDefaultValue t
+                    modelState.boxedLocations <- PersistentDict.add address value modelState.boxedLocations
+                | _ -> ()
+                modelState.allocatedTypes <- PersistentDict.add address typeForModel modelState.allocatedTypes
+        | PrimitiveModel _ -> internalfail "Refining types in model: got primitive model"
 
-    let checkSatWithSubtyping state condition =
-        match SolverInteraction.checkSat state with
-        | SolverInteraction.SmtSat ({mdl = StateModel(modelState, _) as model} as satInfo) ->
-            try
-                match solveTypes model state condition with
-                | TypeUnsat -> SolverInteraction.SmtUnsat {core = Array.empty}
-                | TypeSat typeModel ->
-                    SolverInteraction.SmtSat {satInfo with mdl = StateModel(modelState, typeModel)}
-            with :? InsufficientInformationException as e ->
-                SolverInteraction.SmtUnknown e.Message
-        | result -> result
+    let solveTypes (model : model) (state : state) =
+        let m = CallStack.stackTrace state.stack |> List.last
+        let typeParams, methodParams = getGenericParameters m
+        let typeStorage = state.typeStorage
+        let getMock = getMock typeStorage.TypeMocks
+        let result = refineStorage getMock typeStorage typeParams methodParams
+        match result with
+        | TypeSat -> refineTypesInModel model typeStorage
+        | _ -> ()
+        result
 
-    let refineTypes (state : state) condition =
-        match solveTypes state.model state condition with
+    let refineTypes (state : state) =
+        match solveTypes state.model state with
         | TypeSat _ -> ()
         | TypeUnsat -> internalfail "Refining types: branch is unreachable"
 
     let getCallVirtCandidates state (thisRef : heapAddress) (thisType: Type) (ancestorMethod : IMethod) =
         match thisRef.term with
-        | HeapRef({term = ConcreteHeapAddress thisAddress}, _) when VectorTime.less VectorTime.zero thisAddress ->
+        | HeapRef({term = ConcreteHeapAddress thisAddress}, _) when VectorTime.less state.startingTime thisAddress ->
             state.allocatedTypes[thisAddress] |> Seq.singleton
         | HeapRef(thisAddress, _) ->
-            match state.model with
-            | StateModel(_, typeModel) ->
-                let thisConstraints = List.singleton thisType |> typeConstraints.FromSuperTypes
-                typeModel.AddConstraint thisAddress thisConstraints
-                let ancestorMethod = ancestorMethod.MethodBase :?> MethodInfo
-                let checkOverrides = function
-                    | ConcreteType t -> Reflection.canOverrideMethod t ancestorMethod
-                    | MockType _ -> true
-                let getMock = getMock typeModel.typeMocks
-                let result = refineModel getMock typeModel Array.empty Array.empty
-                match result with
-                | TypeSat typeModel -> typeModel[thisAddress].Value |> Seq.filter checkOverrides
-                | TypeUnsat -> Seq.empty
-            | PrimitiveModel _ -> internalfail "Getting callvirt candidates: got primitive model"
+            let thisConstraints = List.singleton thisType |> typeConstraints.FromSuperTypes
+            let typeStorage = state.typeStorage
+            typeStorage.AddConstraint thisAddress thisConstraints
+            let ancestorMethod = ancestorMethod.MethodBase :?> MethodInfo
+            let checkOverrides = function
+                | ConcreteType t -> Reflection.canOverrideMethod t ancestorMethod
+                | MockType _ -> true
+            let getMock = getMock typeStorage.TypeMocks
+            let result = refineStorage getMock typeStorage Array.empty Array.empty
+            match result with
+            | TypeSat -> typeStorage[thisAddress].Value |> Seq.filter checkOverrides
+            | TypeUnsat -> Seq.empty
         | _ -> internalfail $"Getting callvirt candidates: unexpected this {thisRef}"

--- a/VSharp.SILI.Core/TypeSolver.fs
+++ b/VSharp.SILI.Core/TypeSolver.fs
@@ -217,7 +217,7 @@ module TypeSolver =
                 | ConcreteHeapAddress a ->
                     match state.allocatedTypes[a] with
                     | ConcreteType t -> t
-                    | MockType m ->  internalfail $"Generating constraints: unexpected mock from allocatedTypes {m}"
+                    | MockType m -> internalfail $"Generating constraints: unexpected mock from allocatedTypes {m}"
                 | _ -> internalfail $"Generating constraints: unexpected address {address}"
 
             let toList (d : Dictionary<concreteHeapAddress, HashSet<Type>>) address =

--- a/VSharp.SILI.Core/VSharp.SILI.Core.fsproj
+++ b/VSharp.SILI.Core/VSharp.SILI.Core.fsproj
@@ -32,12 +32,12 @@
         <Compile Include="CallStack.fs" />
         <Compile Include="State.fs" />
         <Compile Include="ConcreteMemory.fs" />
-        <Compile Include="SolverInteraction.fs" />
         <Compile Include="Memory.fs" />
         <Compile Include="MethodMock.fs" />
         <Compile Include="ArrayInitialization.fs" />
         <Compile Include="TypeCasting.fs" />
         <Compile Include="TypeSolver.fs" />
+        <Compile Include="SolverInteraction.fs" />
         <Compile Include="Copying.fs" />
         <Compile Include="Branching.fs" />
         <Compile Include="API.fsi" />

--- a/VSharp.SILI/CILState.fs
+++ b/VSharp.SILI/CILState.fs
@@ -271,7 +271,7 @@ module internal CilStateOperations =
 
     let addTarget (state : cilState) target =
         match state.targets with
-        | Some targets -> state.targets <- Some <| Set.add target targets
+        | Some targets -> state.targets <- Some (Set.add target targets)
         | None -> state.targets <- Some (Set.add target Set.empty)
 
     let removeTarget (state : cilState) target =

--- a/VSharp.SILI/CILState.fs
+++ b/VSharp.SILI/CILState.fs
@@ -298,8 +298,8 @@ module internal CilStateOperations =
             let nextTargets = MethodBody.findNextInstructionOffsetAndEdges opCode m.ILBytes offset
             match nextTargets with
             | UnconditionalBranch nextInstruction
-            | FallThrough nextInstruction -> instruction m nextInstruction :: []
-            | Return -> exit m :: []
+            | FallThrough nextInstruction -> instruction m nextInstruction |> List.singleton
+            | Return -> exit m |> List.singleton
             | ExceptionMechanism ->
                 // TODO: use ExceptionMechanism? #do
 //                let toObserve = __notImplemented__()

--- a/VSharp.SILI/CILState.fs
+++ b/VSharp.SILI/CILState.fs
@@ -102,7 +102,7 @@ module internal CilStateOperations =
     let isExecutable (s : cilState) =
         match s.ipStack with
         | [] -> __unreachable__()
-        | Exit _ :: [] -> false
+        | [ Exit _ ] -> false
         | _ -> true
 
     let isError (s : cilState) =

--- a/VSharp.SILI/SILI.fs
+++ b/VSharp.SILI/SILI.fs
@@ -374,12 +374,9 @@ type public SILI(options : SiliOptions) =
                 concolicMachines.Add(initialState, machine))
             let machine =
                 if concolicMachines.Count = 1 then Seq.head concolicMachines.Values
-                else __notImplemented'__ "Forking in concolic mode"
-            while machine.State.suspended && machine.ExecCommand() do // TODO: make better interaction between concolic and SILI #do
+                else __notImplemented__()
+            while machine.State.suspended && machine.ExecCommand() do
                 x.BidirectionalSymbolicExecution()
-            // TODO: need to report? #do
-//            Logger.error "result state = %O" machine.State
-//            reportFinished.Invoke machine.State
         | SymbolicMode ->
             x.BidirectionalSymbolicExecution()
         searcher.Statuses() |> Seq.iter (fun (pob, status) ->

--- a/VSharp.SILI/TestGenerator.fs
+++ b/VSharp.SILI/TestGenerator.fs
@@ -13,29 +13,36 @@ module TestGenerator =
     let mutable private maxBufferSize = 128
     let internal setMaxBufferSize size = maxBufferSize <- size
 
-    let private addMockToMemoryGraph (indices : Dictionary<concreteHeapAddress, int>) (encodeMock : ITypeMock -> obj) (test : UnitTest) addr mock =
+    let private addMockToMemoryGraph (indices : Dictionary<concreteHeapAddress, int>) encodeMock evalField (test : UnitTest) addr (mock : ITypeMock) =
         let index = test.MemoryGraph.ReserveRepresentation()
-        // TODO: can mock be already added? #type
         indices.Add(addr, index)
-        let repr = test.MemoryGraph.AddMockedClass (encodeMock mock) index
-        repr :> obj
+        let mock : Mocking.Type = encodeMock mock
+        let baseClass = mock.BaseClass
+        let fields =
+            match evalField with
+            | Some evalField when baseClass <> null && not (TypeUtils.isDelegate baseClass) ->
+                Reflection.fieldsOf false baseClass
+                |> Array.map (fst >> evalField)
+            | _ -> Array.empty
+        test.MemoryGraph.AddMockedClass mock fields index :> obj
 
-    let private obj2test eval encodeArr (indices : Dictionary<concreteHeapAddress, int>) (encodeMock : ITypeMock -> obj) (test : UnitTest) addr typ =
+    let private obj2test eval encodeArr (indices : Dictionary<concreteHeapAddress, int>) encodeMock (test : UnitTest) addr typ =
         let index = ref 0
         if indices.TryGetValue(addr, index) then
             let referenceRepr : referenceRepr = {index = index.Value}
             referenceRepr :> obj
         else
+            let memoryGraph = test.MemoryGraph
+            let cha = ConcreteHeapAddress addr
             match typ with
             | ConcreteType typ when TypeUtils.isDelegate typ ->
                 // Obj is a delegate which mock hasn't been created yet
                 let mock = TypeMock(Seq.singleton typ)
-                addMockToMemoryGraph indices encodeMock test addr mock
+                addMockToMemoryGraph indices encodeMock None test addr mock
             | ConcreteType typ ->
-                let cha = ConcreteHeapAddress addr
                 match typ with
                 | TypeUtils.ArrayType(elemType, dim) ->
-                    let index = test.MemoryGraph.ReserveRepresentation()
+                    let index = memoryGraph.ReserveRepresentation()
                     indices.Add(addr, index)
                     let arrayType, (lengths : int array), (lowerBounds : int array) =
                         match dim with
@@ -60,19 +67,24 @@ module TestGenerator =
                     let contents : char array = Array.init length (fun i -> ArrayIndex(cha, [MakeNumber i], (typeof<char>, 1, true)) |> eval |> unbox)
                     String(contents) :> obj
                 | _ ->
-                    let index = test.MemoryGraph.ReserveRepresentation()
+                    let index = memoryGraph.ReserveRepresentation()
                     indices.Add(addr, index)
                     let fields = typ |> Reflection.fieldsOf false |> Array.map (fun (field, _) ->
                         ClassField(cha, field) |> eval)
-                    let repr = test.MemoryGraph.AddClass typ fields index
+                    let repr = memoryGraph.AddClass typ fields index
                     repr :> obj
-            | MockType mock when mock.IsValueType -> encodeMock mock
-            | MockType mock -> addMockToMemoryGraph indices encodeMock test addr mock
+            | MockType mock when mock.IsValueType -> memoryGraph.RepresentMockedStruct (encodeMock mock) Array.empty
+            | MockType mock ->
+                let evalField field = ClassField(cha, field) |> eval
+                addMockToMemoryGraph indices encodeMock (Some evalField) test addr mock
 
     let private encodeArrayCompactly (state : state) (model : model) (encode : term -> obj) (test : UnitTest) arrayType cha typ lengths lowerBounds index =
         if state.concreteMemory.Contains cha then
             // TODO: Use compact representation for big arrays
-            test.MemoryGraph.AddArray typ (state.concreteMemory.VirtToPhys cha :?> Array |> Array.mapToOneDArray test.MemoryGraph.Encode) lengths lowerBounds index
+            let contents =
+                state.concreteMemory.VirtToPhys cha :?> Array
+                |> Array.mapToOneDArray test.MemoryGraph.Encode
+            test.MemoryGraph.AddArray typ contents lengths lowerBounds index
         else
             let arrays =
                 if VectorTime.less cha VectorTime.zero then
@@ -154,7 +166,7 @@ module TestGenerator =
                     let eval address =
                         address |> Ref |> Memory.Read modelState |> model.Complete |> term2obj model state indices mockCache implementations test
                     let arr2Obj = encodeArrayCompactly state model (term2obj model state indices mockCache implementations test)
-                    let encodeMock = encodeTypeMock model state indices mockCache implementations test >> test.AllocateMockObject
+                    let encodeMock = encodeTypeMock model state indices mockCache implementations test
                     obj2test eval arr2Obj indices encodeMock test addr typ
                 // If address is not in the 'allocatedTypes', it should not be allocated, so result is 'null'
                 | None -> null
@@ -165,19 +177,19 @@ module TestGenerator =
                 address |> Ref |> Memory.Read state |> term2Obj
             let arr2Obj = encodeArrayCompactly state model term2Obj
             let typ = state.allocatedTypes[addr]
-            let encodeMock = encodeTypeMock model state indices mockCache implementations test >> test.AllocateMockObject
+            let encodeMock = encodeTypeMock model state indices mockCache implementations test
             obj2test eval arr2Obj indices encodeMock test addr typ
         | Combined(terms, t) ->
             let slices = List.map model.Eval terms
             ReinterpretConcretes slices t
         | term -> internalfailf "creating object from term: unexpected term %O" term
 
-    and private encodeTypeMock (model : model) state indices (mockCache : Dictionary<ITypeMock, Mocking.Type>) (implementations : IDictionary<MethodInfo, term[]>) (test : UnitTest) mock =
+    and private encodeTypeMock (model : model) state indices (mockCache : Dictionary<ITypeMock, Mocking.Type>) (implementations : IDictionary<MethodInfo, term[]>) (test : UnitTest) mock : Mocking.Type =
         let mockedType = ref Mocking.Type.Empty
         if mockCache.TryGetValue(mock, mockedType) then mockedType.Value
         else
             let eval = model.Eval >> term2obj model state indices mockCache implementations test
-            let freshMock = test.DefineTypeMock(mock.Name)
+            let freshMock = Mocking.Type(mock.Name)
             mockCache.Add(mock, freshMock)
             for t in mock.SuperTypes do
                 freshMock.AddSuperType t
@@ -185,10 +197,9 @@ module TestGenerator =
                     let method = methodMock.Key
                     let values = methodMock.Value
                     let methodType = method.ReflectedType
-                    let alreadyMocked = Seq.contains method freshMock.MethodsInfo
                     let mockedBaseInterface() =
                         t.IsInterface && Seq.contains methodType (TypeUtils.getBaseInterfaces t)
-                    if not alreadyMocked && (methodType = t || mockedBaseInterface()) then
+                    if methodType = t || mockedBaseInterface() then
                         freshMock.AddMethod(method, Array.map eval values)
             freshMock
 

--- a/VSharp.Solver/Z3.fs
+++ b/VSharp.Solver/Z3.fs
@@ -892,10 +892,10 @@ module internal Z3 =
                 | _ -> ())
 
             let frame = stackEntries |> Seq.map (fun kvp ->
-                    let key = kvp.Key
-                    let term = kvp.Value.Value
-                    let typ = TypeOf term
-                    (key, Some term, typ))
+                let key = kvp.Key
+                let term = kvp.Value.Value
+                let typ = TypeOf term
+                (key, Some term, typ))
             Memory.NewStackFrame state None (List.ofSeq frame)
 
             let defaultValues = Dictionary<regionSort, term ref>()

--- a/VSharp.Solver/Z3.fs
+++ b/VSharp.Solver/Z3.fs
@@ -940,14 +940,14 @@ module internal Z3 =
 
             encodingCache.heapAddresses.Clear()
             state.model <- PrimitiveModel subst
-            StateModel(state, typeModel.CreateEmpty())
+            StateModel state
 
 
     let private ctx = new Context()
     let private builder = Z3Builder(ctx)
 
     type internal Z3Solver(timeoutMs : uint option) =
-        let solver = ctx.MkOptimize()
+        let solver = ctx.MkSolver()
 
         do
             match timeoutMs with
@@ -969,13 +969,6 @@ module internal Z3 =
                                 yield! (Seq.cast<_> assumptions)
                                 yield query.expr
                             } |> Array.ofSeq
-
-                        let constants = builder.AddressesConstants
-                        for address1 in constants do
-                            for address2 in constants do
-                                if address1 <> address2 then
-                                    let cond = ctx.MkNot(ctx.MkEq(address1, address2))
-                                    solver.AssertSoft(cond, 1u, "addresses") |> ignore
 
                         let result = solver.Check assumptions
                         match result with

--- a/VSharp.Test/Tests/ClassesSimple.cs
+++ b/VSharp.Test/Tests/ClassesSimple.cs
@@ -345,6 +345,12 @@ namespace IntegrationTests
         }
 
         [TestSvm]
+        public int NonStaticClassTest()
+        {
+            return 1;
+        }
+
+        [TestSvm]
         public void TestProperty1()
         {
             var st = new ClassesSimplePropertyAccess();

--- a/VSharp.Test/Tests/Lists.cs
+++ b/VSharp.Test/Tests/Lists.cs
@@ -619,6 +619,60 @@ namespace IntegrationTests
             return l.Contains('a');
         }
 
+        [TestSvm]
+        public static int TypeSolverCheck(int i, object[] l)
+        {
+            if (l[i] is int[] a)
+                return a[0];
+
+            return -12;
+        }
+
+        [TestSvm]
+        public static int TypeSolverCheck2(int i, object a, object b)
+        {
+            var d = new Dictionary<object, int>();
+            d[a] = i;
+            if (a is int[])
+            {
+                if (d[b] == i)
+                    return 1;
+                return 0;
+            }
+
+            return -12;
+        }
+
+        [TestSvm]
+        public static int TypeSolverCheck3(object a, object b)
+        {
+            var d = new Dictionary<object, int>();
+            d[a] = 0;
+            if (a is int[])
+            {
+                if (d[b] != 0)
+                    return 1;
+                return 0;
+            }
+
+            return -12;
+        }
+
+        [Ignore("Support rendering recursive arrays")]
+        public static object[] ConcreteRecursiveArray()
+        {
+            object[] a = new object[1];
+            a[0] = a;
+            return a;
+        }
+
+        [TestSvm]
+        public static object SymbolicRecursiveArray(object[] a)
+        {
+            Array.Fill(a, a);
+            return a[0];
+        }
+
         public static Array RetSystemArray1(Array arr)
         {
             if (arr is int[])
@@ -1603,7 +1657,7 @@ namespace IntegrationTests
             return result;
         }
     }
-    
+
     [TestSvmFixture]
     public sealed class InnerPrivateContentArray
     {
@@ -1614,7 +1668,7 @@ namespace IntegrationTests
 
         private readonly Content[] _arr = new Content[10];
 
-        
+
         [TestSvm]
         public int GetValue(int index)
         {
@@ -1631,7 +1685,7 @@ namespace IntegrationTests
             _arr[index].X = value;
         }
     }
-    
+
     [TestSvmFixture]
     public sealed class InnerPrivateContentArrayMultiDimensional
     {
@@ -1642,7 +1696,7 @@ namespace IntegrationTests
 
         private readonly Content[,] _arr = new Content[1,1];
 
-        
+
         [TestSvm]
         public int GetValue(int index1, int index2)
         {

--- a/VSharp.Test/Tests/Mocking.cs
+++ b/VSharp.Test/Tests/Mocking.cs
@@ -129,6 +129,19 @@ public class Mocking
     }
 
     [TestSvm(100)]
+    public int ComputeWithDependence3()
+    {
+        if (!ReferenceEquals(this, _dependence))
+            return 3;
+
+        var x = _dependence.F();
+        var y = _dependence.F();
+        if (x > y)
+            return 1;
+        return 2;
+    }
+
+    [TestSvm(100)]
     public int ReadAllFromNetwork([DisallowNull] byte[] buffer, [DisallowNull] INetwork network)
     {
         int next;
@@ -145,6 +158,15 @@ public class Mocking
     public bool Enumerable(IEnumerable<int> enumerable)
     {
         var enumerator = enumerable.GetEnumerator();
+        return enumerator.MoveNext();
+    }
+
+    [TestSvm(100)]
+    public bool? Enumerable2(IEnumerable<int> enumerable)
+    {
+        var enumerator = enumerable.GetEnumerator();
+        if (ReferenceEquals(enumerable, enumerator))
+            return null;
         return enumerator.MoveNext();
     }
 
@@ -185,6 +207,11 @@ public class Mocking
         {
             n += 12;
             return n;
+        }
+
+        if (n == 199)
+        {
+            n += 11;
         }
 
         return n;

--- a/VSharp.Test/Tests/Tree.cs
+++ b/VSharp.Test/Tests/Tree.cs
@@ -29,7 +29,7 @@ namespace IntegrationTests
             return t.Depth == 3 && t.Size == 7;
         }
 
-        [TestSvm(100)]
+        [TestSvm(100, timeout:2)]
         public static bool CheckGeneratedDepthSymbolic(int d, int s)
         {
             if (d < 0 | d > 10)

--- a/VSharp.Test/Utils/DummyTypeInfo.cs
+++ b/VSharp.Test/Utils/DummyTypeInfo.cs
@@ -10,12 +10,12 @@ namespace VSharp.Test.Utils
         /* Filter for exploring all possible methods */
         public bool IsMatch(Type type)
         {
-            return true;
+            return Attribute.IsDefined(type, typeof(TestSvmFixtureAttribute), false);
         }
 
         public bool IsMatch(Type type, MethodInfo method)
         {
-            return true;
+            return IsMatch(type);
         }
     }
 

--- a/VSharp.Test/VSharp.Test.csproj
+++ b/VSharp.Test/VSharp.Test.csproj
@@ -3,24 +3,9 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp6.0</TargetFramework>
         <IsPackable>false</IsPackable>
-        <Configurations>Debug;Release;DebugTailRec</Configurations>
+        <Configurations>Release</Configurations>
         <Platforms>AnyCPU</Platforms>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-      <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-      <Optimize>true</Optimize>
-      <DebugSymbols>false</DebugSymbols>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-      <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    </PropertyGroup>
-
-    <PropertyGroup Condition=" '$(Configuration)' == 'DebugTailRec' ">
-      <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-      <DebugSymbols>true</DebugSymbols>
-      <DefineConstants>TRACE;DEBUG</DefineConstants>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/VSharp.TestExtensions/Allocator.cs
+++ b/VSharp.TestExtensions/Allocator.cs
@@ -200,12 +200,16 @@ public class Allocator<T>
         set
         {
             var allBindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+            // Basic field case
             var field = _objectType.GetField(fieldName, allBindingFlags);
-            var property = _objectType.GetField($"<{fieldName}>k__BackingField", allBindingFlags);
-            Debug.Assert(field != null || property != null);
-            field ??= property;
-            if (field != null)
-                field.SetValue(_toAllocate, value);
+            // Property case
+            field ??= _objectType.GetField($"<{fieldName}>k__BackingField", allBindingFlags);
+            // Mock field case
+            field ??= _objectType.BaseType?.GetField(fieldName, allBindingFlags);
+            // Mock property case
+            field ??= _objectType.BaseType?.GetField($"<{fieldName}>k__BackingField", allBindingFlags);
+            Debug.Assert(field != null);
+            field.SetValue(_toAllocate, value);
         }
     }
 

--- a/VSharp.TestExtensions/ObjectsComparer.cs
+++ b/VSharp.TestExtensions/ObjectsComparer.cs
@@ -67,15 +67,15 @@ public static class ObjectsComparer
                 return got.Equals(expected);
             }
 
-            if (expected is global::System.Array array)
-                return ContentwiseEqual(array, got as global::System.Array);
-
             if (_comparedObjects.Contains((expected, got)))
             {
                 return true;
             }
 
             _comparedObjects.Add((expected, got));
+
+            if (expected is global::System.Array array)
+                return ContentwiseEqual(array, got as global::System.Array);
 
             return StructurallyEqual(expected, got);
         }

--- a/VSharp.TestRenderer/CodeRenderer.cs
+++ b/VSharp.TestRenderer/CodeRenderer.cs
@@ -20,12 +20,17 @@ internal class CodeRenderer
     internal class MockInfo
     {
         public readonly SimpleNameSyntax MockName;
+        public readonly Mocking.Type TypeMock;
         // TODO: need to save type of clauses from mock definition?
         public readonly List<(MethodInfo, Type, SimpleNameSyntax)> SetupClauses;
 
-        public MockInfo(SimpleNameSyntax mockName, List<(MethodInfo, Type, SimpleNameSyntax)> setupClauses)
+        public MockInfo(
+            SimpleNameSyntax mockName,
+            Mocking.Type typeMock,
+            List<(MethodInfo, Type, SimpleNameSyntax)> setupClauses)
         {
             MockName = mockName;
+            TypeMock = typeMock;
             SetupClauses = setupClauses;
         }
 
@@ -57,9 +62,10 @@ internal class CodeRenderer
 
         public DelegateMockInfo(
             SimpleNameSyntax mockName,
+            Mocking.Type typeMock,
             List<(MethodInfo, Type, SimpleNameSyntax)> setupClauses,
             SimpleNameSyntax delegateMethod,
-            Type delegateType) : base(mockName, setupClauses)
+            Type delegateType) : base(mockName, typeMock, setupClauses)
         {
             DelegateMethod = delegateMethod;
             DelegateType = delegateType;

--- a/VSharp.TestRenderer/CodeRenderer.cs
+++ b/VSharp.TestRenderer/CodeRenderer.cs
@@ -494,6 +494,7 @@ internal class CodeRenderer
     {
         var type = e.GetType();
         var typeExpr = RenderType(type);
+        // TODO: handle masks, for example 'BindingFlags.Public | BindingFlags.NonPublic' (value will be 'null')
         var value = Enum.GetName(type, e);
         Debug.Assert(value != null);
 

--- a/VSharp.TestRenderer/MethodRenderer.cs
+++ b/VSharp.TestRenderer/MethodRenderer.cs
@@ -112,6 +112,7 @@ internal class MethodRenderer : CodeRenderer
         var methodIdCache = new IdentifiersCache(cache);
         // Creating rendered objects cache
         var methodObjectsCache = new Dictionary<physicalAddress, ExpressionSyntax>();
+        var methodMocksCache = new Dictionary<physicalAddress, ExpressionSyntax>();
         // Marking, that method was not already rendered
         _finished = false;
         // Creating method declaration
@@ -164,7 +165,7 @@ internal class MethodRenderer : CodeRenderer
             _declaration
                 .AddModifiers(modifiers)
                 .WithParameterList(parameterList);
-        _body = new BlockBuilder(methodIdCache, referenceManager, methodObjectsCache);
+        _body = new BlockBuilder(methodIdCache, referenceManager, methodObjectsCache, methodMocksCache);
     }
 
     public void CallBaseConstructor(IEnumerable<ExpressionSyntax> args)
@@ -220,19 +221,24 @@ internal class MethodRenderer : CodeRenderer
         private readonly IReferenceManager _referenceManager;
         // Rendering objects cache
         private readonly Dictionary<physicalAddress, ExpressionSyntax> _renderedObjects;
+        private readonly Dictionary<physicalAddress, ExpressionSyntax> _renderedMocks;
         private readonly HashSet<physicalAddress> _startToRender;
+        private readonly HashSet<physicalAddress> _startToRenderMock;
 
         private readonly List<StatementSyntax> _statements = new();
 
         public BlockBuilder(
             IdentifiersCache idCache,
             IReferenceManager referenceManager,
-            Dictionary<physicalAddress, ExpressionSyntax> renderedObjects) : base(referenceManager)
+            Dictionary<physicalAddress, ExpressionSyntax> renderedObjects,
+            Dictionary<physicalAddress, ExpressionSyntax> renderedMocks) : base(referenceManager)
         {
             _idCache = idCache;
             _referenceManager = referenceManager;
             _renderedObjects = renderedObjects;
+            _renderedMocks = renderedMocks;
             _startToRender = new HashSet<physicalAddress>();
+            _startToRenderMock = new HashSet<physicalAddress>();
         }
 
         public IdentifierNameSyntax NewIdentifier(string idName)
@@ -242,7 +248,7 @@ internal class MethodRenderer : CodeRenderer
 
         public IBlock NewBlock()
         {
-            return new BlockBuilder(new IdentifiersCache(_idCache), _referenceManager, _renderedObjects);
+            return new BlockBuilder(new IdentifiersCache(_idCache), _referenceManager, _renderedObjects, _renderedMocks);
         }
 
         public IdentifierNameSyntax AddDecl(
@@ -385,9 +391,13 @@ internal class MethodRenderer : CodeRenderer
             string? preferredName = null,
             object? defaultValue = null)
         {
+            var indexedElems =
+                elems
+                    .Select(elem => (new[] { elem.Item1 }, elem.Item2))
+                    .ToArray();
             return RenderPrivateElemArray(
                 obj,
-                elems.Select(elem => (new[] { elem.Item1 }, elem.Item2)).ToArray(),
+                indexedElems,
                 new[] { length },
                 preferredName,
                 defaultValue);
@@ -424,7 +434,6 @@ internal class MethodRenderer : CodeRenderer
 
         private ExpressionSyntax RenderArray(ArrayTypeSyntax type, System.Array obj, string? preferredName)
         {
-            // TODO: use compact array representation, if array is big enough?
             var rank = obj.Rank;
             var elemType = obj.GetType().GetElementType();
             Debug.Assert(elemType != null);
@@ -435,12 +444,15 @@ internal class MethodRenderer : CodeRenderer
             var lowerBound = obj.GetLowerBound(0);
             var upperBound = obj.GetUpperBound(0);
 
+            if (lowerBound != 0)
+                // TODO: if lower bound != 0, use Array.CreateInstance
+                throw new NotImplementedException("implement rendering for non zero lower bound arrays");
+
             for (int i = lowerBound; i <= upperBound; i++)
             {
                 var elementPreferredName = (preferredName ?? "array") + "_Elem" + i;
                 var value = obj.GetValue(i);
                 var needExplicitType = NeedExplicitType(value, elemType);
-                // TODO: if lower bound != 0, use Array.CreateInstance
                 initializer.Add(RenderObject(value, elementPreferredName, needExplicitType));
             }
 
@@ -575,6 +587,7 @@ internal class MethodRenderer : CodeRenderer
                 if (index > 0)
                     name = name[1 .. index];
                 var fieldName = RenderObject(name);
+                // TODO: do not render default values?
                 var value = fieldInfo.GetValue(obj);
                 var needExplicitType = NeedExplicitType(value, typeof(object));
                 var validName = CorrectNameGenerator.GetVariableName(name);
@@ -586,13 +599,16 @@ internal class MethodRenderer : CodeRenderer
             return fieldsWithValues;
         }
 
-        private ExpressionSyntax RenderFields(object obj, string? preferredName)
+        private ExpressionSyntax RenderFields(
+            object obj,
+            Type? type,
+            bool isPublicType,
+            TypeSyntax typeExpr,
+            string? preferredName)
         {
             var physAddress = new physicalAddress(obj);
 
-            var type = obj.GetType();
-            var isPublicType = TypeUtils.isPublic(type);
-            var typeExpr = RenderType(isPublicType ? type : typeof(object));
+            type ??= obj.GetType();
 
             // Rendering field values of object
             (ExpressionSyntax, ExpressionSyntax)[] fieldsWithValues;
@@ -628,20 +644,24 @@ internal class MethodRenderer : CodeRenderer
             var allocator =
                 RenderObjectCreation(AllocatorType(typeExpr), args, fieldsWithValues);
             var resultObject = RenderMemberAccess(allocator, AllocatorObject);
-            // If object was not rendered already, declaring new variable for it
-            var objId =
-                wasRendered
-                    ? resultObject
-                    : AddDecl(preferredName ?? "obj", typeExpr, resultObject);
-            return objId;
+
+            return AddDecl(preferredName ?? "obj", typeExpr, resultObject);
         }
 
-        private void RenderClausesSetup(
+        private ExpressionSyntax RenderFields(object obj, string? preferredName)
+        {
+            var type = obj.GetType();
+            var isPublicType = TypeUtils.isPublic(type);
+            var typeExpr = RenderType(isPublicType ? type : typeof(object));
+
+            return RenderFields(obj, type, isPublicType, typeExpr, preferredName);
+        }
+
+        private List<(SimpleNameSyntax, ExpressionSyntax)> RenderClausesSetup(
             Type typeOfMock,
-            SimpleNameSyntax mockId,
             List<(MethodInfo, Type, SimpleNameSyntax)> clauses)
         {
-            if (clauses.Count == 0) return;
+            var setupValues = new List<(SimpleNameSyntax, ExpressionSyntax)>();
 
             foreach (var (method, valuesType, setupMethod) in clauses)
             {
@@ -657,24 +677,40 @@ internal class MethodRenderer : CodeRenderer
                     var values = RenderArray(renderedType, storage, "values");
                     var renderedValues =
                         storage.Length <= 5 ? values : AddDecl("values", null, values);
-                    AddExpression(RenderCall(mockId, setupMethod, renderedValues));
+                    setupValues.Add((setupMethod, renderedValues));
                 }
             }
+
+            return setupValues;
         }
 
-        private ExpressionSyntax RenderMock(Type? typeOfMock, string? preferredName, bool explicitType = false)
+        private ExpressionSyntax RenderMock(
+            object mock,
+            Type? typeOfMock,
+            string? preferredName,
+            bool explicitType = false)
         {
             Debug.Assert(typeOfMock != null);
+
+            var physAddress = new physicalAddress(mock);
+
             var mockInfo = GetMockInfo(typeOfMock.Name);
             var mockType = mockInfo.MockName;
-            var empty = System.Array.Empty<ExpressionSyntax>();
-            var allocator = RenderObjectCreation(AllocatorType(mockType), empty, empty);
-            var resultObject = RenderMemberAccess(allocator, AllocatorObject);
-            var mockId = AddDecl(preferredName ?? "mock", mockType, resultObject);
+            var fieldsOf = mockInfo.TypeMock.BaseClass;
+            ExpressionSyntax mockId;
+            if (TypeUtils.isDelegate(fieldsOf))
+            {
+                var empty = System.Array.Empty<ExpressionSyntax>();
+                var allocator = RenderObjectCreation(AllocatorType(mockType), empty, empty);
+                var resultObject = RenderMemberAccess(allocator, AllocatorObject);
+                mockId = AddDecl(preferredName ?? "mock", mockType, resultObject);
+            }
+            else
+            {
+                mockId = RenderFields(mock, fieldsOf, true, mockType, preferredName ?? "mock");
+            }
 
-            // TODO: handle recursive mocks! #do
-            RenderClausesSetup(typeOfMock, mockId, mockInfo.SetupClauses);
-
+            ExpressionSyntax renderedResult;
             switch (mockInfo)
             {
                 case DelegateMockInfo delegateMockInfo when explicitType:
@@ -685,14 +721,26 @@ internal class MethodRenderer : CodeRenderer
                     var createdDelegate =
                         RenderObjectCreation(delegateType, new [] {invokeMethod}, emptyInit);
                     var delegateName = preferredName == null ? "mock" : preferredName + "Mock";
-                    var delegateId = AddDecl(delegateName, null, createdDelegate);
-                    return delegateId;
+                    renderedResult = AddDecl(delegateName, null, createdDelegate);
+                    break;
                 }
                 case DelegateMockInfo delegateMockInfo:
-                    return RenderMemberAccess(mockId, delegateMockInfo.DelegateMethod);
+                    renderedResult = RenderMemberAccess(mockId, delegateMockInfo.DelegateMethod);
+                    break;
                 default:
-                    return mockId;
+                    renderedResult = mockId;
+                    break;
             }
+
+            if (!_renderedObjects.ContainsKey(physAddress))
+            {
+                _renderedObjects.Add(physAddress, renderedResult);
+                var setupValues = RenderClausesSetup(typeOfMock, mockInfo.SetupClauses);
+                foreach (var (setupMethod, renderedValues) in setupValues)
+                    AddExpression(RenderCall(mockId, setupMethod, renderedValues));
+            }
+
+            return renderedResult;
         }
 
         private ExpressionSyntax RenderComplexObject(
@@ -712,22 +760,15 @@ internal class MethodRenderer : CodeRenderer
                 Pointer => throw new NotImplementedException("RenderObject: implement rendering of pointers"),
                 ValueType => RenderFields(obj, preferredName),
                 Delegate d when HasMockInfo(d.Method.DeclaringType?.Name) =>
-                    RenderMock(d.Method.DeclaringType, preferredName, explicitType),
+                    RenderMock(obj, d.Method.DeclaringType, preferredName, explicitType),
                 Delegate =>
                     throw new NotImplementedException("rendering of not mocked delegates is not implemented"),
-                _ when HasMockInfo(obj.GetType().Name) => RenderMock(obj.GetType(), preferredName),
+                _ when HasMockInfo(obj.GetType().Name) => RenderMock(obj, obj.GetType(), preferredName),
                 _ when obj.GetType().IsClass => RenderFields(obj, preferredName),
                 _ => throw new NotImplementedException($"RenderObject: unexpected object {obj}")
             };
 
-            // For recursive objects: if (while rendering object) it was already added, assigning new value to it
-            if (_renderedObjects.TryGetValue(physAddress, out var rendered))
-            {
-                AddAssignment(RenderAssignment(rendered, result));
-                return rendered;
-            }
-
-            // Otherwise adding it to rendered objects
+            // Adding rendered expression to '_renderedObjects'
             _renderedObjects[physAddress] = result;
 
             return result;

--- a/VSharp.TestRenderer/MethodRenderer.cs
+++ b/VSharp.TestRenderer/MethodRenderer.cs
@@ -672,6 +672,7 @@ internal class MethodRenderer : CodeRenderer
             var resultObject = RenderMemberAccess(allocator, AllocatorObject);
             var mockId = AddDecl(preferredName ?? "mock", mockType, resultObject);
 
+            // TODO: handle recursive mocks! #do
             RenderClausesSetup(typeOfMock, mockId, mockInfo.SetupClauses);
 
             switch (mockInfo)

--- a/VSharp.TestRenderer/RendererTool.cs
+++ b/VSharp.TestRenderer/RendererTool.cs
@@ -497,7 +497,6 @@ public static class Renderer
         bool wrapErrors = false,
         bool singleFile = false)
     {
-
         var unitTests = DeserializeTests(tests);
         if (unitTests.Count == 0)
             throw new Exception("No *.vst files were generated, nothing to render");

--- a/VSharp.TestRenderer/TestsRenderer.cs
+++ b/VSharp.TestRenderer/TestsRenderer.cs
@@ -488,7 +488,7 @@ public static class TestsRenderer
 
         SimpleNameSyntax? methodId = null;
 
-        foreach (var method in typeMock.Methods)
+        foreach (var method in typeMock.MethodMocks)
         {
             var m = method.BaseMethod;
             if (Reflection.hasNonVoidResult(m))
@@ -508,12 +508,12 @@ public static class TestsRenderer
         if (isDelegate)
         {
             var baseClass = typeMock.BaseClass;
-            Debug.Assert(typeMock.Methods.Count() == 1 && methodId != null && baseClass != null);
-            info = new DelegateMockInfo(mock.TypeId, methodsInfo, methodId, baseClass);
+            Debug.Assert(typeMock.MethodMocks.Count() == 1 && methodId != null && baseClass != null);
+            info = new DelegateMockInfo(mock.TypeId, typeMock, methodsInfo, methodId, baseClass);
         }
         else
         {
-            info = new MockInfo(mock.TypeId, methodsInfo);
+            info = new MockInfo(mock.TypeId, typeMock, methodsInfo);
         }
         AddMockInfo(typeMock.Id, info);
     }
@@ -597,6 +597,7 @@ public static class TestsRenderer
 
                 // Rendering mocked types
                 foreach (var mock in test.TypeMocks)
+                    // TODO: cache mocks among all generated tests
                     RenderMockedType(mocksProgram, mock);
 
                 // Rendering test

--- a/VSharp.Utils/MemoryGraph.fs
+++ b/VSharp.Utils/MemoryGraph.fs
@@ -227,6 +227,7 @@ and MemoryGraph(repr : memoryRepr, mocker : ITypeMockSerializer, createCompactRe
         (t.IsPrimitive && not t.IsEnum) || t = typeof<string> || (t.IsArray && (x.IsSerializable <| t.GetElementType()))
 
     member private x.EncodeArray (arr : Array) =
+        // TODO: handle recursive arrays! #do
         let contents =
             seq {
                 for elem in arr do

--- a/VSharp.Utils/Prelude.fs
+++ b/VSharp.Utils/Prelude.fs
@@ -19,7 +19,6 @@ module public Prelude =
     let undefinedBehaviour reason = internalfailf "Undefined behaviour: %s" reason
 
     let inline public __notImplemented__() = raise (NotImplementedException())
-    let inline public __notImplemented'__ message = raise (NotImplementedException (message + " is not implemented yet"))
     let inline public __unreachable__() = raise (UnreachableException "unreachable branch hit!")
     let public __insufficientInformation__ format = Printf.ksprintf (fun reason -> InsufficientInformationException ("Insufficient information! " + reason) |> raise) format
     let public createInsufficientInformation format = Printf.ksprintf (fun reason -> InsufficientInformationException ("Insufficient information! " + reason)) format

--- a/VSharp.Utils/TypeUtils.fs
+++ b/VSharp.Utils/TypeUtils.fs
@@ -26,7 +26,8 @@ module TypeUtils =
 
     let private unsignedTypes =
         HashSet<Type>([typedefof<byte>; typedefof<uint16>;
-                       typedefof<uint32>; typedefof<uint64>;])
+                       typedefof<uint32>; typedefof<uint64>
+                       typeof<UIntPtr>])
 
     let private realTypes = HashSet<Type>([typedefof<single>; typedefof<double>])
 

--- a/VSharp.Utils/UnitTest.fs
+++ b/VSharp.Utils/UnitTest.fs
@@ -14,7 +14,6 @@ open VSharp
 [<XmlInclude(typeof<referenceRepr>)>]
 [<XmlInclude(typeof<pointerRepr>)>]
 [<XmlInclude(typeof<enumRepr>)>]
-[<XmlInclude(typeof<Mocking.mockObject>)>]
 type testInfo = {
     assemblyName : string
     moduleFullyQualifiedName : string
@@ -27,11 +26,11 @@ type testInfo = {
     throwsException : typeRepr
     classTypeParameters : typeRepr array
     methodTypeParameters : typeRepr array
-    mockClassTypeParameters : typeMockRepr array
-    mockMethodTypeParameters : typeMockRepr array
+    mockClassTypeParameters : Nullable<int> array
+    mockMethodTypeParameters : Nullable<int> array
     memory : memoryRepr
-    extraAssemblyLoadDirs : string array
     typeMocks : typeMockRepr array
+    extraAssemblyLoadDirs : string array
 }
 with
     static member OfMethod(m : MethodBase) = {
@@ -49,30 +48,26 @@ with
         mockMethodTypeParameters = Array.empty
         throwsException = {assemblyName = null; moduleFullyQualifiedName = null; name = null; genericArgs = null}
         memory = {objects = Array.empty; types = Array.empty}
-        extraAssemblyLoadDirs = Array.empty
         typeMocks = Array.empty
+        extraAssemblyLoadDirs = Array.empty
     }
 
-type UnitTest private (m : MethodBase, info : testInfo, createCompactRepr : bool) =
-    let mocker = Mocking.Mocker(info.typeMocks)
-    let typeMocks = info.typeMocks |> Array.map Mocking.Type |> ResizeArray
-    let memoryGraph = MemoryGraph(info.memory, mocker, createCompactRepr)
+type UnitTest private (m : MethodBase, info : testInfo, mockStorage : MockStorage, createCompactRepr : bool) =
+    let memoryGraph = MemoryGraph(info.memory, mockStorage, createCompactRepr)
     let exceptionInfo = info.throwsException
     let throwsException =
         if exceptionInfo = {assemblyName = null; moduleFullyQualifiedName = null; name = null; genericArgs = null} then null
-        else Serialization.decodeType exceptionInfo
+        else exceptionInfo.Decode()
     let thisArg = memoryGraph.DecodeValue info.thisArg
     let args = if info.args = null then null else info.args |> Array.map memoryGraph.DecodeValue
     let isError = info.isError
     let errorMessage = info.errorMessage
     let expectedResult = memoryGraph.DecodeValue info.expectedResult
     let compactRepresentations = memoryGraph.CompactRepresentations()
-//    let classTypeParameters = info.classTypeParameters |> Array.map Serialization.decodeType
-//    let methodTypeParameters = info.methodTypeParameters |> Array.map Serialization.decodeType
     let mutable extraAssemblyLoadDirs : string list = [Directory.GetCurrentDirectory()]
 
     new(m : MethodBase) =
-        UnitTest(m, testInfo.OfMethod m, false)
+        UnitTest(m, testInfo.OfMethod m, MockStorage(), false)
 
     member x.Method with get() = m
     member x.ThisArg
@@ -107,45 +102,35 @@ type UnitTest private (m : MethodBase, info : testInfo, createCompactRepr : bool
         and set (e : Type) =
             let t = typeof<testInfo>
             let p = t.GetProperty("throwsException")
-            let v = Serialization.encodeType e
+            let v = typeRepr.Encode e
             p.SetValue(info, v)
 
-    member x.TypeMocks with get() = typeMocks
+    member x.TypeMocks with get() : ResizeArray<Mocking.Type> = mockStorage.TypeMocks
 
     member x.CompactRepresentations with get() = compactRepresentations
 
-    member x.DefineTypeMock(name : string) =
-        let mock = Mocking.Type(name)
-        typeMocks.Add mock
-        mock
-
-    member x.AllocateMockObject (typ : Mocking.Type) =
-        let index = typeMocks.IndexOf typ
-        mocker.MakeMockObject index :> obj
+    member private x.SerializeMock (m : Mocking.Type option) =
+        match m with
+        | Some m -> Nullable(mockStorage.RegisterMockedType m)
+        | None -> Nullable()
 
     // @concreteParameters and @mockedParameters should have equal lengths and be complementary:
     // if @concreteParameters[i] is null, then @mockedParameters[i] is non-null and vice versa
     member x.SetTypeGenericParameters (concreteParameters : Type array) (mockedParameters : Mocking.Type option array) =
         let t = typeof<testInfo>
         let cp = t.GetProperty("classTypeParameters")
-        cp.SetValue(info, concreteParameters |> Array.map Serialization.encodeType)
+        cp.SetValue(info, concreteParameters |> Array.map typeRepr.Encode)
         let mp = t.GetProperty("mockClassTypeParameters")
-        mp.SetValue(info, mockedParameters |> Array.map (fun m ->
-            match m with
-            | Some m -> m.Serialize memoryGraph.Encode
-            | None -> typeMockRepr.NullRepr))
+        mp.SetValue(info, mockedParameters |> Array.map x.SerializeMock)
 
     // @concreteParameters and @mockedParameters should have equal lengths and be complementary:
     // if @concreteParameters[i] is null, then @mockedParameters[i] is non-null and vice versa
     member x.SetMethodGenericParameters (concreteParameters : Type array) (mockedParameters : Mocking.Type option array) =
         let t = typeof<testInfo>
         let cp = t.GetProperty("methodTypeParameters")
-        cp.SetValue(info, concreteParameters |> Array.map Serialization.encodeType)
+        cp.SetValue(info, concreteParameters |> Array.map typeRepr.Encode)
         let mp = t.GetProperty("mockMethodTypeParameters")
-        mp.SetValue(info, mockedParameters |> Array.map (fun m ->
-            match m with
-            | Some m -> m.Serialize memoryGraph.Encode
-            | None -> typeMockRepr.NullRepr))
+        mp.SetValue(info, mockedParameters |> Array.map x.SerializeMock)
 
     member x.MemoryGraph with get() = memoryGraph
 
@@ -157,7 +142,7 @@ type UnitTest private (m : MethodBase, info : testInfo, createCompactRepr : bool
             let p = t.GetProperty("args")
             p.SetValue(info, Array.zeroCreate <| m.GetParameters().Length)
         let value = memoryGraph.Encode value
-        info.args.[arg.Position] <- value
+        info.args[arg.Position] <- value
 
     member x.AddExtraAssemblySearchPath path =
         if not <| List.contains path extraAssemblyLoadDirs then
@@ -169,12 +154,15 @@ type UnitTest private (m : MethodBase, info : testInfo, createCompactRepr : bool
         let extraAssempliesProperty = t.GetProperty("extraAssemblyLoadDirs")
         extraAssempliesProperty.SetValue(info, Array.ofList extraAssemblyLoadDirs)
         let typeMocksProperty = t.GetProperty("typeMocks")
-        typeMocksProperty.SetValue(info, typeMocks.ToArray() |> Array.map (fun m -> m.Serialize memoryGraph.Encode))
+        let typeMocks =
+            mockStorage.TypeMocks.ToArray()
+            |> Array.map (fun m -> typeMockRepr.Encode m memoryGraph.Encode)
+        typeMocksProperty.SetValue(info, typeMocks)
         let serializer = XmlSerializer t
         use stream = File.Create(destination)
         serializer.Serialize(stream, info)
 
-    static member DeserializeTestInfo(stream : FileStream) = // TODO: fix style #style
+    static member DeserializeTestInfo(stream : FileStream) =
         let serializer = XmlSerializer(typeof<testInfo>)
         try
             serializer.Deserialize(stream) :?> testInfo
@@ -187,11 +175,15 @@ type UnitTest private (m : MethodBase, info : testInfo, createCompactRepr : bool
             let mdle = Reflection.resolveModule ti.assemblyName ti.moduleFullyQualifiedName
             if mdle = null then
                 raise <| InvalidOperationException(sprintf "Could not resolve module %s!" ti.moduleFullyQualifiedName)
-            let mocker = Mocking.Mocker([||])
-            let decodeTypeParameter (concrete : typeRepr) (mock : typeMockRepr) =
-                let t = Serialization.decodeType concrete
-                if t = null then mocker.BuildDynamicType mock |> snd
-                else t
+            let mockStorage = MockStorage()
+            mockStorage.Deserialize ti.typeMocks
+            let decodeTypeParameter (concrete : typeRepr) (mockIndex : Nullable<int>) =
+                if mockIndex.HasValue then
+                    mockStorage[mockIndex.Value] |> snd
+                else
+                    let res = concrete.Decode()
+                    assert(res <> null)
+                    res
             let mp = Array.map2 decodeTypeParameter ti.methodTypeParameters ti.mockMethodTypeParameters
             let method = mdle.ResolveMethod(ti.token)
             let declaringType = method.DeclaringType
@@ -201,17 +193,17 @@ type UnitTest private (m : MethodBase, info : testInfo, createCompactRepr : bool
 
             // Ensure that parameters are substituted in memoryRepr
             if not method.IsStatic && declaringType.IsGenericType && ti.memory.types.Length > 0 then
-                let getGenericTypeDefinition typ =
-                    let decoded = Serialization.decodeType typ
+                let getGenericTypeDefinition (typ : typeRepr) =
+                    let decoded = typ.Decode()
                     if decoded <> null && decoded.IsGenericType then
                         decoded.GetGenericTypeDefinition()
                     else decoded
                 let typeDefinitions = ti.memory.types |> Array.map getGenericTypeDefinition
                 let declaringTypeIndex = Array.IndexOf(typeDefinitions, declaringType)
                 Debug.Assert(declaringTypeIndex >= 0)
-                ti.memory.types[declaringTypeIndex] <- Serialization.encodeType concreteDeclaringType
+                ti.memory.types[declaringTypeIndex] <- typeRepr.Encode concreteDeclaringType
 
-            UnitTest(method, ti, createCompactRepr)
+            UnitTest(method, ti, mockStorage, createCompactRepr)
         with child ->
             let exn = InvalidDataException("Input test is incorrect", child)
             raise exn

--- a/VSharp.Utils/VSharp.Utils.fsproj
+++ b/VSharp.Utils/VSharp.Utils.fsproj
@@ -38,8 +38,8 @@
         <Compile Include="RegionTree.fs" />
         <Compile Include="PrettyPrinting.fs" />
         <Compile Include="FileSystem.fs" />
-        <Compile Include="MemoryGraph.fs" />
         <Compile Include="Mocking.fs" />
+        <Compile Include="MemoryGraph.fs" />
         <Compile Include="UnitTest.fs" />
         <Compile Include="UnitTests.fs" />
         <Compile Include="TestResultsChecker.fs" />

--- a/VSharp.Utils/VectorTime.fs
+++ b/VSharp.Utils/VectorTime.fs
@@ -1,11 +1,18 @@
 namespace VSharp
 
+open System.Runtime.CompilerServices
+
 type vectorTime = int32 list
 
 module VectorTime =
+
     let zero = [0]
     let infty = [System.Int32.MaxValue]
     let minfty = [System.Int32.MinValue]
+
+    let hash (time : vectorTime) =
+        if time = zero then RuntimeHelpers.GetHashCode null
+        else time.GetHashCode()
 
     let rec compare (t1 : vectorTime) (t2 : vectorTime) =
         List.compareWith (fun (v1 : int32) (v2 : int32) -> v1.CompareTo(v2)) t1 t2


### PR DESCRIPTION
- fixed Type Sovler: `typeStorage` moved from `model` to `state`
- fixed symbolic `GetHashCode`: changed to `NonComposableConstantSource`
- fixed `MemoryGraph`: supported recursive objects
- fixed type of shift argument in `Arithmetics.fs`
- fixed mocks: supported recursive mocks, mocking type instead of objects (many mock objects may have one mocked type), supported fields' init for mocked types
- disabled inheritance of TestFixtureAttribute for rendered mocks classes (some mocks may be inherited from classes with `TestSvmFixtureAttribute`)