### PR TITLE
Stabilization: part XIV

### DIFF
--- a/VSharp.CSharpUtils/ReflectionUtils.cs
+++ b/VSharp.CSharpUtils/ReflectionUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 
@@ -39,12 +40,18 @@ namespace VSharp.CSharpUtils
                     }
                 }
             }
-            return types.Where(t => t.IsPublic || t.IsNestedPublic);
+            return types.Where(IsPublic);
+        }
+
+        private static bool IsPublic(Type t)
+        {
+            Debug.Assert(t != null && t != t.DeclaringType);
+            return t.IsPublic || t.IsNestedPublic && IsPublic(t.DeclaringType);
         }
 
         public static IEnumerable<Type> GetExportedTypesChecked(this Assembly assembly)
         {
-            return assembly.GetTypesChecked().Where(t => t.IsPublic || t.IsNestedPublic);
+            return assembly.GetTypesChecked().Where(IsPublic);
         }
 
         public static IEnumerable<Type> GetTypesChecked(this Assembly assembly)

--- a/VSharp.InternalCalls/Loader.fs
+++ b/VSharp.InternalCalls/Loader.fs
@@ -107,6 +107,7 @@ module Loader =
             "System.RuntimeType System.RuntimeTypeHandle.GetBaseType(System.RuntimeType)"
             "System.TypeCode System.Type.GetTypeCode(System.Type)"
             "System.Reflection.CorElementType System.RuntimeTypeHandle.GetCorElementType(System.RuntimeType)"
+            "System.Reflection.CorElementType System.Enum.InternalGetCorElementType(this)"
             "System.String System.RuntimeType.ToString(this)"
 
             // EqualityComparer

--- a/VSharp.InternalCalls/Loader.fs
+++ b/VSharp.InternalCalls/Loader.fs
@@ -132,6 +132,7 @@ module Loader =
 
             // Environment
             "System.Int32 System.Environment.get_TickCount()"
+            "System.Boolean System.Numerics.Vector.get_IsHardwareAccelerated()"
 
             // VSharp
             "System.Int32 IntegrationTests.ExceptionsControlFlow.ConcreteThrow()"

--- a/VSharp.InternalCalls/Loader.fs
+++ b/VSharp.InternalCalls/Loader.fs
@@ -117,6 +117,7 @@ module Loader =
 
             // Thread
             "System.Threading.Thread System.Threading.Thread.get_CurrentThread()"
+            "System.Int32 System.Threading.Thread.get_OptimalMaxSpinWaitsPerSpinIteration()"
 
             // Interop
 //            "System.Int32 Interop+Sys.LChflagsCanSetHiddenFlag()"

--- a/VSharp.InternalCalls/Runtime.CompilerServices.RuntimeHelpers.fs
+++ b/VSharp.InternalCalls/Runtime.CompilerServices.RuntimeHelpers.fs
@@ -24,10 +24,16 @@ module Runtime_CompilerServices_RuntimeHelpers =
         | {term = Concrete(:? Type as typ, _)} -> MakeBool (Reflection.isReferenceOrContainsReferences typ)
         | _ -> __unreachable__()
 
-    let GetHashCode (state : state) (args : term list) : term =
+    let CommonGetHashCode (state : state) (args : term list) : term =
         assert(List.length args = 1)
         let object = List.head args
         GetHashCode object
+
+    let ValueTypeGetHashCode (state : state) (args : term list) : term =
+        assert(List.length args = 1)
+        let boxedThis = List.head args
+        let structValue = Memory.Read state boxedThis
+        GetHashCode structValue
 
     let Equals (state : state) (args : term list) : term =
         assert(List.length args = 2)

--- a/VSharp.InternalCalls/Runtime.CompilerServices.RuntimeHelpers.fsi
+++ b/VSharp.InternalCalls/Runtime.CompilerServices.RuntimeHelpers.fsi
@@ -13,7 +13,10 @@ module Runtime_CompilerServices_RuntimeHelpers =
     val IsReferenceOrContainsReferences : state -> term list -> term
 
     [<Implements("System.Int32 System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(System.Object)")>]
-    val GetHashCode : state -> term list -> term
+    val CommonGetHashCode : state -> term list -> term
+
+    [<Implements("System.Int32 System.ValueType.GetHashCode(this)")>]
+    val ValueTypeGetHashCode : state -> term list -> term
 
     [<Implements("System.Boolean System.Runtime.CompilerServices.RuntimeHelpers.Equals(System.Object, System.Object)")>]
     val Equals : state -> term list -> term

--- a/VSharp.InternalCalls/Span.fs
+++ b/VSharp.InternalCalls/Span.fs
@@ -34,7 +34,7 @@ module ReadOnlySpan =
                 ArrayIndex(address, index, arrayType) |> Ref
             | None when t.IsSZArray || t = typeof<string> -> ptrToArray
             | None -> internalfail $"GetContentsRef: unexpected pointer to contents {ptrToArray}"
-        | _ -> internalfail $"GetContentsRef: unexpected pointer to contents {ptrToArray}"
+        | _ -> internalfail $"GetContentsRef: unexpected reference to contents {ptrToArray}"
 
     let internal GetItemFromReadOnlySpan (state : state) (args : term list) : term =
         assert(List.length args = 3)

--- a/VSharp.InternalCalls/Thread.fs
+++ b/VSharp.InternalCalls/Thread.fs
@@ -10,3 +10,19 @@ module Thread =
     let internal GetFastDomainInternal (_ : state) (_ : term list) = NullRef typeof<AppDomain>
 
     let internal GetDomainInternal state args = GetFastDomainInternal state args
+
+    let internal SpinWaitInternal (_ : state) (args : term list) =
+        assert(List.length args = 1)
+        Nop
+
+    let internal SpinOnce (_ : state) (args : term list) =
+        assert(List.length args = 1)
+        Nop
+
+    let internal Yield (_ : state) (args : term list) =
+        assert(List.length args = 0)
+        MakeBool true
+
+    let internal SleepInternal (_ : state) (args : term list) =
+        assert(List.length args = 1)
+        Nop

--- a/VSharp.InternalCalls/Thread.fsi
+++ b/VSharp.InternalCalls/Thread.fsi
@@ -12,4 +12,16 @@ module Thread =
     val internal GetFastDomainInternal : state -> term list -> term
 
     [<Implements("System.AppDomain System.Threading.Thread.GetDomainInternal()")>]
-    val internal GetDomainInternal : (state -> term list -> term)
+    val internal GetDomainInternal : state -> term list -> term
+
+    [<Implements("System.Void System.Threading.Thread.SpinWaitInternal(System.Int32)")>]
+    val internal SpinWaitInternal : state -> term list -> term
+
+    [<Implements("System.Void System.Threading.SpinWait.SpinOnce(this)")>]
+    val internal SpinOnce : state -> term list -> term
+
+    [<Implements("System.Boolean System.Threading.Thread.Yield()")>]
+    val internal Yield : state -> term list -> term
+
+    [<Implements("System.Void System.Threading.Thread.SleepInternal(System.Int32)")>]
+    val internal SleepInternal : state -> term list -> term

--- a/VSharp.InternalCalls/Unsafe.fs
+++ b/VSharp.InternalCalls/Unsafe.fs
@@ -70,3 +70,14 @@ module Unsafe =
         assert(List.length args = 3)
         let ptr1, ptr2 = args[1], args[2]
         ptr1 === ptr2
+
+    let internal GetRawData (state : state) (args : term list) : term =
+        assert(List.length args = 1)
+        let ref = args[0]
+        match ref.term with
+        | HeapRef(address, _) ->
+            let t = MostConcreteTypeOfHeapRef state ref
+            Ptr (HeapLocation(address, t)) typeof<byte> (MakeNumber 0)
+        | Ref(BoxedLocation(address, t)) ->
+            Ptr (HeapLocation(ConcreteHeapAddress address, t)) typeof<byte> (MakeNumber 0)
+        | _ -> internalfail $"GetRawData: unexpected ref {ref}"

--- a/VSharp.InternalCalls/Unsafe.fs
+++ b/VSharp.InternalCalls/Unsafe.fs
@@ -65,3 +65,8 @@ module Unsafe =
         assert(List.length args = 1)
         let typ = getTypeFromTerm args.[0]
         Types.SizeOf typ |> MakeNumber
+
+    let internal AreSame (_ : state) (args : term list) : term =
+        assert(List.length args = 3)
+        let ptr1, ptr2 = args[1], args[2]
+        ptr1 === ptr2

--- a/VSharp.InternalCalls/Unsafe.fsi
+++ b/VSharp.InternalCalls/Unsafe.fsi
@@ -38,3 +38,6 @@ module internal Unsafe =
 
     [<Implements("System.Boolean Internal.Runtime.CompilerServices.Unsafe.AreSame(T&, T&)")>]
     val internal AreSame : state -> term list -> term
+
+    [<Implements("System.Byte& System.Runtime.CompilerServices.RuntimeHelpers.GetRawData(System.Object)")>]
+    val internal GetRawData : state -> term list -> term

--- a/VSharp.InternalCalls/Unsafe.fsi
+++ b/VSharp.InternalCalls/Unsafe.fsi
@@ -35,3 +35,6 @@ module internal Unsafe =
 
     [<Implements("System.Int32 Internal.Runtime.CompilerServices.Unsafe.SizeOf()")>]
     val internal SizeOf : state -> term list -> term
+
+    [<Implements("System.Boolean Internal.Runtime.CompilerServices.Unsafe.AreSame(T&, T&)")>]
+    val internal AreSame : state -> term list -> term

--- a/VSharp.SILI.Core/ConcreteMemory.fs
+++ b/VSharp.SILI.Core/ConcreteMemory.fs
@@ -7,16 +7,14 @@ open System.Runtime.CompilerServices
 open System.Threading
 open VSharp
 
+type private Box(v : ValueType) =
+    member internal x.Value = v
+
 type public ConcreteMemory private (physToVirt, virtToPhys) =
 
 // ----------------------------- Helpers -----------------------------
 
-    static let nonCopyableTypes = [
-        typeof<Type>
-        typeof<Thread>
-    ]
-
-    let cannotBeCopied (typ : Type) = List.exists typ.IsAssignableTo nonCopyableTypes
+    let boxValue (v : ValueType) = Box(v)
 
     let indexedArrayElemsCommon (arr : Array) =
         let ubs = Array.init arr.Rank arr.GetUpperBound
@@ -61,6 +59,15 @@ type public ConcreteMemory private (physToVirt, virtToPhys) =
         | :? array<double> as a -> Array.mapi (fun i x -> (List.singleton i, x :> obj)) a :> seq<int list * obj>
         | _ when array.GetType().IsSZArray -> indexedArrayElemsLin array
         | _ -> indexedArrayElemsCommon array
+
+// -------------------------------- Copying --------------------------------
+
+    static let nonCopyableTypes = [
+        typeof<Type>
+        typeof<Thread>
+    ]
+
+    let cannotBeCopied (typ : Type) = List.exists typ.IsAssignableTo nonCopyableTypes
 
     let copiedObjects = Dictionary<physicalAddress, physicalAddress>()
 
@@ -142,11 +149,19 @@ type public ConcreteMemory private (physToVirt, virtToPhys) =
         override x.Copy() =
             let physToVirt' = Dictionary<physicalAddress, concreteHeapAddress>()
             let virtToPhys' = Dictionary<concreteHeapAddress, physicalAddress>()
+            // Need to copy all addresses from physToVirt, because:
+            // 1. let complex object (A) contains another object (B),
+            // if object (B) was unmarshalled, physToVirt will contain mapping
+            // between old object (B) and virtual address of it (addr);
+            // symbolic memory will contain info of symbolic object (B) by it's address (addr)
+            // So, reading from object (A) object (B) will result in HeapRef (addr),
+            // which will be read from symbolic memory
             copiedObjects.Clear()
             for kvp in physToVirt do
                 let phys, virt = kvp.Key, kvp.Value
                 let phys' = deepCopyObject phys
-                if virtToPhys.ContainsKey virt then
+                let exists, oldPhys = virtToPhys.TryGetValue(virt)
+                if exists && oldPhys = phys then
                     virtToPhys'.Add(virt, phys')
                 physToVirt'.Add(phys', virt)
             ConcreteMemory(physToVirt', virtToPhys')
@@ -160,9 +175,11 @@ type public ConcreteMemory private (physToVirt, virtToPhys) =
         override x.VirtToPhys virtAddress = x.ReadObject virtAddress
 
         override x.TryVirtToPhys virtAddress =
-            let result = ref {object = null}
-            if virtToPhys.TryGetValue(virtAddress, result) then
-                Some result.Value.object
+            let exists, result = virtToPhys.TryGetValue(virtAddress)
+            if exists then
+                match result.object with
+                | :? Box as b -> Some b.Value
+                | obj -> Some obj
             else None
 
         override x.PhysToVirt physAddress =
@@ -180,13 +197,20 @@ type public ConcreteMemory private (physToVirt, virtToPhys) =
 // ----------------------------- Allocation -----------------------------
 
         override x.Allocate address (obj : obj) =
+            assert(obj <> null)
             assert(virtToPhys.ContainsKey address |> not)
+            let obj =
+                match obj with
+                // Creating object of type 'Box' to avoid interning of boxed value types
+                | :? ValueType as v -> boxValue v :> obj
+                | _ -> obj
             // Suppressing finalize, because 'obj' may implement 'Dispose()' method, which should not be invoked,
             // because object may be in incorrect state (statics, for example)
             GC.SuppressFinalize(obj)
             let physicalAddress = {object = obj}
             virtToPhys.Add(address, physicalAddress)
-            if obj = String.Empty then physToVirt[physicalAddress] <- address
+            if obj = String.Empty then
+                physToVirt[physicalAddress] <- address
             else physToVirt.Add(physicalAddress, address)
 
 // ------------------------------- Reading -------------------------------
@@ -300,5 +324,7 @@ type public ConcreteMemory private (physToVirt, virtToPhys) =
     // ------------------------------- Remove -------------------------------
 
         override x.Remove address =
+            // No need to remove physical addresses from physToVirt, because
+            // all objects must contain virtual address, even if they were unmarshalled
             let removed = virtToPhys.Remove address
             assert removed

--- a/VSharp.SILI.Core/State.fs
+++ b/VSharp.SILI.Core/State.fs
@@ -253,7 +253,7 @@ and typesConstraints private (newAddresses, constraints) =
                 if typeConstraints.IsContradicting() then
                     if different then unequal.Add(address1, address2) |> ignore
                     else isValid <- false
-        isValid, Seq.map (fun (a1, a2) -> !!(a1 === a2)) unequal
+        isValid, unequal
 
     interface System.Collections.IEnumerable with
         member this.GetEnumerator() =

--- a/VSharp.SILI.Core/TypeSolver.fs
+++ b/VSharp.SILI.Core/TypeSolver.fs
@@ -149,14 +149,15 @@ module TypeSolver =
 
     let private satisfiesTypeParameterConstraints (parameter : Type) subst (t : Type) =
         let (&&&) = Microsoft.FSharp.Core.Operators.(&&&)
-        let isReferenceType = parameter.GenericParameterAttributes &&& GenericParameterAttributes.ReferenceTypeConstraint = GenericParameterAttributes.ReferenceTypeConstraint
-        let isNotNullableValueType = parameter.GenericParameterAttributes &&& GenericParameterAttributes.NotNullableValueTypeConstraint = GenericParameterAttributes.NotNullableValueTypeConstraint
-        let hasDefaultConstructor = parameter.GenericParameterAttributes &&& GenericParameterAttributes.DefaultConstructorConstraint = GenericParameterAttributes.NotNullableValueTypeConstraint
+        let specialConstraints = parameter.GenericParameterAttributes &&& GenericParameterAttributes.SpecialConstraintMask
+        let isReferenceType = specialConstraints &&& GenericParameterAttributes.ReferenceTypeConstraint = GenericParameterAttributes.ReferenceTypeConstraint
+        let isNotNullableValueType = specialConstraints &&& GenericParameterAttributes.NotNullableValueTypeConstraint = GenericParameterAttributes.NotNullableValueTypeConstraint
+        let hasDefaultConstructor = specialConstraints &&& GenericParameterAttributes.DefaultConstructorConstraint = GenericParameterAttributes.DefaultConstructorConstraint
         // TODO: check 'managed' constraint
         (not t.ContainsGenericParameters) &&
         (not isReferenceType || not t.IsValueType) &&
-        (not isNotNullableValueType || (t.IsValueType && Nullable.GetUnderlyingType t = null)) &&
-        (not hasDefaultConstructor || t.GetConstructor(Type.EmptyTypes) <> null) &&
+        (not isNotNullableValueType || (t.IsValueType && Nullable.GetUnderlyingType t = null && not t.IsByRefLike)) &&
+        (not hasDefaultConstructor || t.IsValueType || not t.IsAbstract && t.GetConstructor(Type.EmptyTypes) <> null) &&
         (parameter.GetGenericParameterConstraints() |> Array.forall (substitute subst >> t.IsAssignableTo))
 
     let private satisfiesConstraints (constraints : typeConstraints) subst (candidate : Type) =

--- a/VSharp.SILI/Interpreter.fs
+++ b/VSharp.SILI/Interpreter.fs
@@ -247,6 +247,7 @@ module internal InstructionsSet =
     let transform2BooleanTerm pc (term : term) =
         let check term =
             match TypeOf term with
+            | _ when IsReference term -> !!(IsNullReference term)
             | Types.Bool -> term
             | t when t = TypeUtils.charType -> term !== TypeUtils.Char.Zero
             | t when t = TypeUtils.int8Type -> term !== TypeUtils.Int8.Zero
@@ -257,9 +258,7 @@ module internal InstructionsSet =
             | t when t = TypeUtils.uint32Type -> term !== TypeUtils.UInt32.Zero
             | t when t = TypeUtils.int64Type -> term !== TypeUtils.Int64.Zero
             | t when t = TypeUtils.uint64Type -> term !== TypeUtils.UInt64.Zero
-            | t when t.IsEnum ->
-                term !== MakeNumber (Activator.CreateInstance t)
-            | _ when IsReference term -> !!(IsNullReference term)
+            | t when t.IsEnum -> term !== MakeNumber (Activator.CreateInstance t)
             | _ -> __notImplemented__()
         GuardedApplyExpressionWithPC pc term check
 

--- a/VSharp.Test/Tests/LinqTest.cs
+++ b/VSharp.Test/Tests/LinqTest.cs
@@ -204,6 +204,15 @@ namespace IntegrationTests
             return newList.Select(i => i.Length);
         }
 
+        [TestSvm(100)]
+        public static int OrderByTest(int value)
+        {
+            var list = new List<Order>();
+            var order = new Order { Id = value, Cost = value };
+            list.Add(order);
+            return list.OrderBy(o => o.Id).First().Id;
+        }
+
         [Ignore("takes too much time")]
         public static int SequenceLinqTest()
         {

--- a/VSharp.Test/Tests/Lists.cs
+++ b/VSharp.Test/Tests/Lists.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -191,6 +192,7 @@ namespace IntegrationTests
             a[2] = 42;
             return a;
         }
+
         [TestSvm(100)]
         public static int CopyAndBranch(int[] a, int i)
         {
@@ -656,6 +658,25 @@ namespace IntegrationTests
             }
 
             return -12;
+        }
+
+        [Ignore("Fix core")]
+        public static int HashtableTest(int a)
+        {
+            Hashtable dataHashtable = new Hashtable();
+            dataHashtable[0] = 0;
+            dataHashtable[1] = 1;
+            dataHashtable[2] = a;
+            dataHashtable[a] = 0;
+            int data = (int) dataHashtable[2];
+            int[] array = null;
+            if (data > 0)
+            {
+                array = new int[data];
+            }
+
+            array[0] = 5;
+            return array[0];
         }
 
         [Ignore("Support rendering recursive arrays")]

--- a/VSharp.TestExtensions/Allocator.cs
+++ b/VSharp.TestExtensions/Allocator.cs
@@ -185,11 +185,15 @@ public class Allocator<T>
 
     public Allocator(object allocated)
     {
+        Debug.Assert(allocated != null);
+        _objectType = allocated.GetType();
         _toAllocate = allocated;
     }
 
     public Allocator(object allocated, object defaultValue)
     {
+        Debug.Assert(allocated != null);
+        _objectType = allocated.GetType();
         Debug.Assert(_objectType.IsArray);
         _toAllocate = allocated;
         Allocator.Fill(_toAllocate as Array, defaultValue);

--- a/VSharp.TestRenderer/CodeRenderer.cs
+++ b/VSharp.TestRenderer/CodeRenderer.cs
@@ -801,8 +801,8 @@ internal class CodeRenderer
             return RenderObjectCreation(RenderType(method.DeclaringType), functionArgs, init);
         }
 
-        if (!method.IsPublic || thisType is { IsPublic: false, IsNestedPublic: false } ||
-            thisArg == null && method.DeclaringType is { IsPublic: false, IsNestedPublic: false })
+        if (!method.IsPublic || thisType != null && !TypeUtils.isPublic(thisType) ||
+            thisArg == null && method.DeclaringType != null && !TypeUtils.isPublic(method.DeclaringType))
             return RenderPrivateCall(thisArg, method, functionArgs);
 
         if (IsGetItem(method))

--- a/VSharp.TestRenderer/MethodRenderer.cs
+++ b/VSharp.TestRenderer/MethodRenderer.cs
@@ -644,6 +644,12 @@ internal class MethodRenderer : CodeRenderer
                 RenderObjectCreation(AllocatorType(typeExpr), args, fieldsWithValues);
             var resultObject = RenderMemberAccess(allocator, AllocatorObject);
 
+            if (wasRendered && rendered is IdentifierNameSyntax renderedId)
+            {
+                AddAssignment(RenderAssignment(renderedId, resultObject));
+                return renderedId;
+            }
+
             return AddDecl(preferredName ?? "obj", typeExpr, resultObject);
         }
 

--- a/VSharp.TestRenderer/RendererTool.cs
+++ b/VSharp.TestRenderer/RendererTool.cs
@@ -7,8 +7,6 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace VSharp.TestRenderer;
 
-
-
 public static class Renderer
 {
     private static readonly string NewLine = Environment.NewLine;

--- a/VSharp.Utils/TypeUtils.fs
+++ b/VSharp.Utils/TypeUtils.fs
@@ -45,8 +45,9 @@ module TypeUtils =
 
     // ---------------------------------- Basic type predicates ----------------------------------
 
-    let isPublic (x : Type) =
-        x.IsPublic || x.IsNestedPublic
+    let rec isPublic (x : Type) =
+        assert(x <> null)
+        x.IsPublic || x.IsNestedPublic && isPublic x.DeclaringType
 
     let isGround (x : Type) =
         (not x.IsGenericType && not x.IsGenericParameter) || x.IsConstructedGenericType

--- a/VSharp.Utils/TypeUtils.fs
+++ b/VSharp.Utils/TypeUtils.fs
@@ -189,11 +189,13 @@ module TypeUtils =
         else [||]
 
     let (|StructType|_|) = function
-        | (t : Type) when t.IsValueType && not (isPrimitive t) && not t.IsGenericParameter -> Some(getGenericDefinition t, getGenericArguments t)
+        | (t : Type) when t.IsValueType && not (isPrimitive t) && not t.IsEnum && not t.IsGenericParameter ->
+            Some(getGenericDefinition t, getGenericArguments t)
         | _ -> None
 
     let (|ClassType|_|) = function
-        | (t : Type) when t.IsClass && not t.IsByRef && not t.IsArray && t <> typeof<Array> -> Some(getGenericDefinition t, getGenericArguments t)
+        | (t : Type) when t.IsClass && not t.IsByRef && not t.IsArray && t <> typeof<Array> ->
+            Some(getGenericDefinition t, getGenericArguments t)
         | _ -> None
 
     let (|InterfaceType|_|) = function


### PR DESCRIPTION
- fixed decoding: supported lambda predicate case
- fixed renrerer
- fixed 'isPublic' predicate
- fixed CFG: DFS rewritten in CPS
- fixed concrete memory: unsafe reading, allocating boxed locations
- added internal calls
- fixed test extension 'Allocator'
- fixed type solver and SMT solver interaction