### PR TITLE
Stabilization: part XVIII

### DIFF
--- a/VSharp.CSharpUtils/Calculator.cs
+++ b/VSharp.CSharpUtils/Calculator.cs
@@ -8,14 +8,6 @@ namespace VSharp.CSharpUtils
     /// </summary>
     public static class Calculator // TODO: use opcode emit for all concrete operations
     {
-        /// <summary>
-        /// Returns true if <paramref name="x"/> is fuzzy equal to zero with the given precision <paramref name="eps"/>.
-        /// </summary>
-        private static bool IsZero(object x, double eps = 1e-8)
-        {
-            dynamic val = x;
-            return val < eps && val > -eps;
-        }
 
         /// <summary>
         /// Returns which power of two value <paramref name="x"/> is.
@@ -40,14 +32,6 @@ namespace VSharp.CSharpUtils
                 Enum e => (uint)Math.Log2((double)Convert.ChangeType(e, typeof(double))),
                 _ => throw new ArgumentException($"WhatPowerOf2: unexpected argument {x}")
             };
-        }
-
-        /// <summary>
-        /// Returns true if numeric value <paramref name="x"/> is fuzzy equal to numeric value <paramref name="y"/> with the given precision <paramref name="eps"/>.
-        /// </summary>
-        public static bool FuzzyEqual(object x, object y, double eps = 1e-8)
-        {
-            return IsZero((dynamic) x - (dynamic) y, eps);
         }
 
         public static int GetDeterministicHashCode(this string str)

--- a/VSharp.CSharpUtils/LayoutUtils.cs
+++ b/VSharp.CSharpUtils/LayoutUtils.cs
@@ -45,6 +45,7 @@ namespace VSharp.CSharpUtils
             return GetFieldDescForFieldInfo(fi)->Offset;
         }
 
+        // Works correctly only for class (value types are boxed)
         public static int ClassSize(Type t)
         {
             return Marshal.ReadInt32(t.TypeHandle.Value, 4);

--- a/VSharp.CoverageRunner/CoverageRunner.cs
+++ b/VSharp.CoverageRunner/CoverageRunner.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Runtime.Loader;
 using System.Text;
 using Microsoft.FSharp.Core;
 
@@ -112,26 +111,21 @@ namespace VSharp.CoverageRunner
             IReadOnlySet<BasicBlock> visited,
             MethodInfo methodInfo)
         {
-            string ToString()
+            var sb = new StringBuilder();
+            sb.AppendLine($"Coverage for method {methodInfo}:");
+            var allCovered = true;
+            foreach (var block in allBlocks)
             {
-                var sb = new StringBuilder();
-                sb.AppendLine($"Coverage for method {methodInfo}:");
-                var allCovered = true;
-                foreach (var block in allBlocks)
+                if (!visited.Contains(block))
                 {
-                    if (!visited.Contains(block))
-                    {
-                        allCovered = false;
-                        sb.AppendLine($"Block [0x{block.StartOffset:X} .. 0x{block.FinalOffset:X}] not covered");
-                    }
+                    allCovered = false;
+                    sb.AppendLine($"Block [0x{block.StartOffset:X} .. 0x{block.FinalOffset:X}] not covered");
                 }
-                if (allCovered)
-                    sb.AppendLine("All blocks are covered");
-
-                return sb.ToString();
             }
+            if (allCovered)
+                sb.AppendLine("All blocks are covered");
 
-            Logger.printLogLazyString(Logger.Trace, ToString);
+            Logger.writeLine(sb.ToString());
         }
 
         private static int ComputeCoverage(CfgInfo cfg, CoverageLocation[][] visited, MethodInfo methodInfo)

--- a/VSharp.IL/CFG.fs
+++ b/VSharp.IL/CFG.fs
@@ -499,7 +499,7 @@ type ApplicationGraph() =
         ()
 
     let getShortestDistancesToGoals (states : array<codeLocation>) =
-        __notImplemented__()    
+        __notImplemented__()
 
     member this.RegisterMethod (method: Method) =
         assert method.HasBody

--- a/VSharp.InternalCalls/PlatformHelper.fs
+++ b/VSharp.InternalCalls/PlatformHelper.fs
@@ -7,3 +7,9 @@ module internal PlatformHelper =
 
     let get_ProcessorCount (_ : state) (_ : term list) : term =
         MakeNumber 1
+
+    let lzcntIsSupported (_ : state) (_ : term list) : term =
+        MakeBool false
+
+    let armIsSupported (_ : state) (_ : term list) : term =
+        MakeBool false

--- a/VSharp.InternalCalls/PlatformHelper.fsi
+++ b/VSharp.InternalCalls/PlatformHelper.fsi
@@ -8,3 +8,9 @@ module internal PlatformHelper =
 
     [<Implements("System.Int32 System.Threading.PlatformHelper.get_ProcessorCount()")>]
     val internal get_ProcessorCount : state -> term list -> term
+
+    [<Implements("System.Boolean System.Runtime.Intrinsics.X86.Lzcnt.get_IsSupported()")>]
+    val internal lzcntIsSupported : state -> term list -> term
+
+    [<Implements("System.Boolean System.Runtime.Intrinsics.Arm.ArmBase.get_IsSupported()")>]
+    val internal armIsSupported : state -> term list -> term

--- a/VSharp.InternalCalls/Unsafe.fs
+++ b/VSharp.InternalCalls/Unsafe.fs
@@ -31,9 +31,10 @@ module Unsafe =
     let internal TFromAsTTo (_ : state) (args : term list) : term =
         assert(List.length args = 3)
         let toType = getTypeFromTerm args[1]
+        let pointerType = toType.MakePointerType()
         let ref = args[2]
         assert(IsReference ref || IsPtr ref)
-        Types.Cast ref toType
+        Types.Cast ref pointerType
 
     let internal NullRef (_ : state) (args : term list) : term =
         match args with
@@ -92,3 +93,6 @@ module Unsafe =
         | Ref(BoxedLocation(address, t)) ->
             Ptr (HeapLocation(address, t)) typeof<byte> (MakeNumber 0)
         | _ -> internalfail $"GetRawData: unexpected ref {ref}"
+
+    let internal SkipInit (_ : state) (_ : term list) : term =
+        Nop

--- a/VSharp.InternalCalls/Unsafe.fsi
+++ b/VSharp.InternalCalls/Unsafe.fsi
@@ -56,3 +56,7 @@ module internal Unsafe =
 
     [<Implements("System.Byte& System.Runtime.CompilerServices.RuntimeHelpers.GetRawData(System.Object)")>]
     val internal GetRawData : state -> term list -> term
+
+    [<Implements("System.Void Internal.Runtime.CompilerServices.Unsafe.SkipInit(T&)")>]
+    [<Implements("System.Void System.Runtime.CompilerServices.Unsafe.SkipInit(T&)")>]
+    val internal SkipInit : state -> term list -> term

--- a/VSharp.SILI.Core/API.fs
+++ b/VSharp.SILI.Core/API.fs
@@ -74,7 +74,6 @@ module API =
         let Struct fields typ = Struct fields typ
         let Ref address = Ref address
         let Ptr baseAddress typ offset = Ptr baseAddress typ offset
-        let Slice term first termSize pos = Slice term first termSize pos
         let HeapRef address baseType = HeapRef address baseType
         let Union gvs = Union gvs
 

--- a/VSharp.SILI.Core/API.fs
+++ b/VSharp.SILI.Core/API.fs
@@ -337,7 +337,7 @@ module API =
             | HeapRef(address, typ) when isSuitableField address typ |> not ->
                 // TODO: check this case with casting via "is"
                 Logger.trace "[WARNING] unsafe cast of term %O in safe context" reference
-                let offset = Reflection.getFieldOffset fieldId |> MakeNumber
+                let offset = Reflection.getFieldIdOffset fieldId |> MakeNumber
                 Ptr (HeapLocation(address, typ)) fieldId.typ offset
             | HeapRef(address, typ) when fieldId.declaringType.IsValueType ->
                 // TODO: Need to check mostConcreteTypeOfHeapRef using pathCondition?
@@ -352,7 +352,7 @@ module API =
                 assert fieldId.declaringType.IsValueType
                 StructField(address, fieldId) |> Ref
             | Ptr(baseAddress, _, offset) ->
-                let fieldOffset = Reflection.getFieldOffset fieldId |> makeNumber
+                let fieldOffset = Reflection.getFieldIdOffset fieldId |> makeNumber
                 Ptr baseAddress fieldId.typ (add offset fieldOffset)
             | Union gvs -> gvs |> List.map (fun (g, v) -> (g, ReferenceField state v fieldId)) |> Merging.merge
             | _ -> internalfailf "Referencing field: expected reference, but got %O" reference

--- a/VSharp.SILI.Core/API.fsi
+++ b/VSharp.SILI.Core/API.fsi
@@ -49,7 +49,6 @@ module API =
         val Struct : pdict<fieldId, term> -> Type -> term
         val Ref : address -> term
         val Ptr : pointerBase -> Type -> term -> term
-        val Slice : term -> term -> term -> term -> term
         val HeapRef : heapAddress -> Type -> term
         val Union : (term * term) list -> term
 

--- a/VSharp.SILI.Core/Arithmetics.fs
+++ b/VSharp.SILI.Core/Arithmetics.fs
@@ -51,6 +51,21 @@ module ILCalculator =
         let addOvf = addOvf.CreateDelegate(typeof<binaryDelegateType>) :?> binaryDelegateType
         addOvf.Invoke(x, y)
 
+    let addOvfUn(x : obj, y : obj, t : System.Type) =
+        assert(isNumeric <| x.GetType() && isNumeric <| y.GetType())
+        let args = [| typeof<obj>; typeof<obj> |]
+        let addOvfUn = DynamicMethod("AddOvf_Un", typeof<obj>, args)
+        let il = addOvfUn.GetILGenerator(256)
+        il.Emit(OpCodes.Ldarg_0)
+        il.Emit(OpCodes.Unbox_Any, x.GetType())
+        il.Emit(OpCodes.Ldarg_1)
+        il.Emit(OpCodes.Unbox_Any, y.GetType())
+        il.Emit(OpCodes.Add_Ovf_Un)
+        il.Emit(OpCodes.Box, t)
+        il.Emit(OpCodes.Ret)
+        let addOvfUn = addOvfUn.CreateDelegate(typeof<binaryDelegateType>) :?> binaryDelegateType
+        addOvfUn.Invoke(x, y)
+
     let sub(x : obj, y : obj, t : System.Type) =
         assert(isNumeric <| x.GetType() && isNumeric <| y.GetType())
         let args = [| typeof<obj>; typeof<obj> |]
@@ -65,6 +80,36 @@ module ILCalculator =
         il.Emit(OpCodes.Ret)
         let sub = sub.CreateDelegate(typeof<binaryDelegateType>) :?> binaryDelegateType
         sub.Invoke(x, y)
+
+    let subOvf(x : obj, y : obj, t : System.Type) =
+        assert(isNumeric <| x.GetType() && isNumeric <| y.GetType())
+        let args = [| typeof<obj>; typeof<obj> |]
+        let subOvf = DynamicMethod("SubOvf", typeof<obj>, args)
+        let il = subOvf.GetILGenerator(256)
+        il.Emit(OpCodes.Ldarg_0)
+        il.Emit(OpCodes.Unbox_Any, x.GetType())
+        il.Emit(OpCodes.Ldarg_1)
+        il.Emit(OpCodes.Unbox_Any, y.GetType())
+        il.Emit(OpCodes.Sub_Ovf)
+        il.Emit(OpCodes.Box, t)
+        il.Emit(OpCodes.Ret)
+        let subOvf = subOvf.CreateDelegate(typeof<binaryDelegateType>) :?> binaryDelegateType
+        subOvf.Invoke(x, y)
+
+    let subOvfUn(x : obj, y : obj, t : System.Type) =
+        assert(isNumeric <| x.GetType() && isNumeric <| y.GetType())
+        let args = [| typeof<obj>; typeof<obj> |]
+        let subOvfUn = DynamicMethod("SubOvf_Un", typeof<obj>, args)
+        let il = subOvfUn.GetILGenerator(256)
+        il.Emit(OpCodes.Ldarg_0)
+        il.Emit(OpCodes.Unbox_Any, x.GetType())
+        il.Emit(OpCodes.Ldarg_1)
+        il.Emit(OpCodes.Unbox_Any, y.GetType())
+        il.Emit(OpCodes.Sub_Ovf_Un)
+        il.Emit(OpCodes.Box, t)
+        il.Emit(OpCodes.Ret)
+        let subOvfUn = subOvfUn.CreateDelegate(typeof<binaryDelegateType>) :?> binaryDelegateType
+        subOvfUn.Invoke(x, y)
 
     let mul(x : obj, y : obj, t : System.Type) =
         assert(isNumeric <| x.GetType() && isNumeric <| y.GetType())
@@ -96,6 +141,21 @@ module ILCalculator =
         let mulOvf = mulOvf.CreateDelegate(typeof<binaryDelegateType>) :?> binaryDelegateType
         mulOvf.Invoke(x, y)
 
+    let mulOvfUn(x : obj, y : obj, t : System.Type) =
+        assert(isNumeric <| x.GetType() && isNumeric <| y.GetType())
+        let args = [| typeof<obj>; typeof<obj> |]
+        let mulOvfUn = DynamicMethod("MulOvf_Un", typeof<obj>, args)
+        let il = mulOvfUn.GetILGenerator(256)
+        il.Emit(OpCodes.Ldarg_0)
+        il.Emit(OpCodes.Unbox_Any, x.GetType())
+        il.Emit(OpCodes.Ldarg_1)
+        il.Emit(OpCodes.Unbox_Any, y.GetType())
+        il.Emit(OpCodes.Mul_Ovf_Un)
+        il.Emit(OpCodes.Box, t)
+        il.Emit(OpCodes.Ret)
+        let mulOvfUn = mulOvfUn.CreateDelegate(typeof<binaryDelegateType>) :?> binaryDelegateType
+        mulOvfUn.Invoke(x, y)
+
     let div(x : obj, y : obj, t : System.Type) =
         assert(isNumeric <| x.GetType() && isNumeric <| y.GetType())
         let args = [| typeof<obj>; typeof<obj> |]
@@ -111,6 +171,21 @@ module ILCalculator =
         let div = div.CreateDelegate(typeof<binaryDelegateType>) :?> binaryDelegateType
         div.Invoke(x, y)
 
+    let divUn(x : obj, y : obj, t : System.Type) =
+        assert(isNumeric <| x.GetType() && isNumeric <| y.GetType())
+        let args = [| typeof<obj>; typeof<obj> |]
+        let divUn = DynamicMethod("Div_Un", typeof<obj>, args)
+        let il = divUn.GetILGenerator(256)
+        il.Emit(OpCodes.Ldarg_0)
+        il.Emit(OpCodes.Unbox_Any, x.GetType())
+        il.Emit(OpCodes.Ldarg_1)
+        il.Emit(OpCodes.Unbox_Any, y.GetType())
+        il.Emit(OpCodes.Div_Un)
+        il.Emit(OpCodes.Box, t)
+        il.Emit(OpCodes.Ret)
+        let divUn = divUn.CreateDelegate(typeof<binaryDelegateType>) :?> binaryDelegateType
+        divUn.Invoke(x, y)
+
     let rem(x : obj, y : obj, t : System.Type) =
         assert(isNumeric <| x.GetType() && isNumeric <| y.GetType())
         let args = [| typeof<obj>; typeof<obj> |]
@@ -125,6 +200,21 @@ module ILCalculator =
         il.Emit(OpCodes.Ret)
         let rem = rem.CreateDelegate(typeof<binaryDelegateType>) :?> binaryDelegateType
         rem.Invoke(x, y)
+
+    let remUn(x : obj, y : obj, t : System.Type) =
+        assert(isNumeric <| x.GetType() && isNumeric <| y.GetType())
+        let args = [| typeof<obj>; typeof<obj> |]
+        let remUn = DynamicMethod("Rem_Un", typeof<obj>, args)
+        let il = remUn.GetILGenerator(256)
+        il.Emit(OpCodes.Ldarg_0)
+        il.Emit(OpCodes.Unbox_Any, x.GetType())
+        il.Emit(OpCodes.Ldarg_1)
+        il.Emit(OpCodes.Unbox_Any, y.GetType())
+        il.Emit(OpCodes.Rem_Un)
+        il.Emit(OpCodes.Box, t)
+        il.Emit(OpCodes.Ret)
+        let remUn = remUn.CreateDelegate(typeof<binaryDelegateType>) :?> binaryDelegateType
+        remUn.Invoke(x, y)
 
     let shiftLeft(x : obj, y : obj, t : System.Type) =
         assert(isNumeric <| x.GetType() && isNumeric <| y.GetType())
@@ -155,6 +245,21 @@ module ILCalculator =
         il.Emit(OpCodes.Ret)
         let shr = shr.CreateDelegate(typeof<binaryDelegateType>) :?> binaryDelegateType
         shr.Invoke(x, y)
+
+    let shiftRightUn(x : obj, y : obj, t : System.Type) =
+        assert(isNumeric <| x.GetType() && isNumeric <| y.GetType())
+        let args = [| typeof<obj>; typeof<obj> |]
+        let shrUn = DynamicMethod("ShiftRight", typeof<obj>, args)
+        let il = shrUn.GetILGenerator(256)
+        il.Emit(OpCodes.Ldarg_0)
+        il.Emit(OpCodes.Unbox_Any, x.GetType())
+        il.Emit(OpCodes.Ldarg_1)
+        il.Emit(OpCodes.Unbox_Any, y.GetType())
+        il.Emit(OpCodes.Shr_Un)
+        il.Emit(OpCodes.Box, t)
+        il.Emit(OpCodes.Ret)
+        let shrUn = shrUn.CreateDelegate(typeof<binaryDelegateType>) :?> binaryDelegateType
+        shrUn.Invoke(x, y)
 
     let compare(x : obj, y : obj) : int =
         assert(isValidOperand x && isValidOperand y)
@@ -208,14 +313,44 @@ module ILCalculator =
         let compare = compare.CreateDelegate(typeof<compareDelegateType>) :?> compareDelegateType
         compare.Invoke(x, y)
 
-    let isZero x =
+    let private floatIsZero x =
         assert(isValidOperand x)
+        let typ = x.GetType()
+        assert(isReal typ)
+        let args = [| typeof<obj> |]
+        let fuzzyIsZero = DynamicMethod("FuzzyIsZero", typeof<int>, args)
+        let il = fuzzyIsZero.GetILGenerator(256)
+        let greater = il.DefineLabel()
+        let less = il.DefineLabel()
+        il.Emit(OpCodes.Ldarg_0)
+        il.Emit(OpCodes.Unbox_Any, typ)
+        il.Emit(OpCodes.Dup)
+        il.Emit(OpCodes.Ldc_R8, 1e-8)
+        il.Emit(OpCodes.Bgt, greater)
+        il.Emit(OpCodes.Ldc_R8, -1e-8)
+        il.Emit(OpCodes.Blt, less)
+        il.Emit(OpCodes.Ldc_I4_1)
+        il.Emit(OpCodes.Ret)
+        il.MarkLabel(less)
+        il.Emit(OpCodes.Ldc_I4_0)
+        il.Emit(OpCodes.Ret)
+        il.MarkLabel(greater)
+        il.Emit(OpCodes.Pop)
+        il.Emit(OpCodes.Ldc_I4_0)
+        il.Emit(OpCodes.Ret)
+        let fuzzyIsZero = fuzzyIsZero.CreateDelegate(typeof<unaryToIntDelegateType>) :?> unaryToIntDelegateType
+        fuzzyIsZero.Invoke(x) = 1
+
+    let private integralIsZero x =
+        assert(isValidOperand x)
+        let typ = x.GetType()
+        assert(isReal typ |> not)
         let args = [| typeof<obj> |]
         let isZero = DynamicMethod("IsZero", typeof<int>, args)
         let il = isZero.GetILGenerator(256)
         let zeroCase = il.DefineLabel()
         il.Emit(OpCodes.Ldarg_0)
-        il.Emit(OpCodes.Unbox_Any, x.GetType())
+        il.Emit(OpCodes.Unbox_Any, typ)
         il.Emit(OpCodes.Brfalse, zeroCase)
         il.Emit(OpCodes.Ldc_I4_0)
         il.Emit(OpCodes.Ret)
@@ -224,6 +359,15 @@ module ILCalculator =
         il.Emit(OpCodes.Ret)
         let isZero = isZero.CreateDelegate(typeof<unaryToIntDelegateType>) :?> unaryToIntDelegateType
         isZero.Invoke(x) = 1
+
+    let isZero (x : obj) =
+        match x with
+        | :? double
+        | :? single -> floatIsZero x
+        | _ -> integralIsZero x
+
+    let equal (x : obj) (y : obj) =
+        sub(x, y, x.GetType()) |> isZero
 
     let isPowOfTwo (x : obj) =
         assert(isNumeric <| x.GetType())
@@ -553,11 +697,11 @@ module internal Arithmetics =
         match x.term, y.term with
         | Concrete(xval, _), _ when ILCalculator.isZero(xval) -> castConcrete 0 t |> matched
         | _, Concrete(yval, _) when ILCalculator.isZero(yval) -> castConcrete 0 t |> matched
-        | Concrete(x, _), _ when Calculator.FuzzyEqual(x, convert 1 t) -> matched y
-        | _, Concrete(y, _) when Calculator.FuzzyEqual(y, convert 1 t) -> matched x
-        | Concrete(x, _), _ when not <| isUnsigned t && Calculator.FuzzyEqual(x, convert -1 t) ->
+        | Concrete(x, _), _ when ILCalculator.equal x (convert 1 t) -> matched y
+        | _, Concrete(y, _) when ILCalculator.equal y (convert 1 t) -> matched x
+        | Concrete(x, _), _ when not <| isUnsigned t && ILCalculator.equal x (convert -1 t) ->
             simplifyUnaryMinus t y matched
-        | _, Concrete(y, _) when not <| isUnsigned t && Calculator.FuzzyEqual(y, convert -1 t) ->
+        | _, Concrete(y, _) when not <| isUnsigned t && ILCalculator.equal y (convert -1 t) ->
             simplifyUnaryMinus t x matched
         | Expression _, Expression _ ->
             simplifyMultiplicationOfExpression t x y matched (fun () ->
@@ -577,21 +721,23 @@ module internal Arithmetics =
 
 // ------------------------------- Simplification of "/" -------------------------------
 
-    and simplifyConcreteDivision t x y =
-        let result = ILCalculator.div(x, y, t)
+    and simplifyConcreteDivision isSigned t x y =
+        let result =
+            if isSigned then ILCalculator.div(x, y, t)
+            else ILCalculator.divUn(x, y, t)
         castConcrete result t
 
     and private simplifyDivision isSigned t x y k =
         simplifyGenericBinary "division" x y k
-            (simplifyConcreteBinary simplifyConcreteDivision t)
+            (simplifyConcreteBinary (simplifyConcreteDivision isSigned) t)
             (fun x y k ->
                 match x, y with
                 // 0 / y = 0
                 | ConcreteT(xval, _), _ when ILCalculator.isZero(xval) -> x |> k
                 // x / 1 = x
-                | _, ConcreteT(yval, _) when Calculator.FuzzyEqual(yval, convert 1 (typeOf y)) -> x |> k
+                | _, ConcreteT(yval, _) when ILCalculator.equal yval (convert 1 (typeOf y)) -> x |> k
                 // x / -1 = -x
-                | _, ConcreteT(yval, _) when not <| isUnsigned t && Calculator.FuzzyEqual(yval, convert -1 (typeOf y)) ->
+                | _, ConcreteT(yval, _) when not <| isUnsigned t && ILCalculator.equal yval (convert -1 (typeOf y)) ->
                     simplifyUnaryMinus t x k
                 // x / x = 1 if unchecked
                 | x, y when x = y -> castConcrete 1 t |> k
@@ -620,33 +766,39 @@ module internal Arithmetics =
 
 // ------------------------------- Simplification of "%" -------------------------------
 
-    and private simplifyConcreteRemainder t x y =
+    and private simplifyConcreteRemainder isSigned t x y =
         let success = ref true
-        let result = ILCalculator.rem(x, y, t)
+        let result =
+            if isSigned then
+                ILCalculator.rem(x, y, t)
+            else ILCalculator.remUn(x, y, t)
         assert success.Value
         castConcrete result t
 
-    and private divides t x y =
-        ILCalculator.isZero(ILCalculator.rem(x, y, t))
+    and private divides isSigned t x y =
+        let res =
+            if isSigned then ILCalculator.rem(x, y, t)
+            else ILCalculator.remUn(x, y, t)
+        ILCalculator.isZero res
 
     and simplifyRemainder isSigned t x y k =
         simplifyGenericBinary "remainder" x y k
-            (simplifyConcreteBinary simplifyConcreteRemainder t)
+            (simplifyConcreteBinary (simplifyConcreteRemainder isSigned) t)
             (fun x y k ->
                 match x, y with
                 // 0 % y = 0
                 | ConcreteT(xval, _), _ when ILCalculator.isZero(xval) -> x |> k
                 // x % 1 = 0
-                | _, ConcreteT(y, _) when Calculator.FuzzyEqual(y, convert 1 t) -> castConcrete 0 t |> k
+                | _, ConcreteT(y, _) when ILCalculator.equal y (convert 1 t) -> castConcrete 0 t |> k
                 // x % -1 = 0
-                | _, ConcreteT(y, _) when not <| isUnsigned t && Calculator.FuzzyEqual(y, convert -1 t) ->
+                | _, ConcreteT(y, _) when not <| isUnsigned t && ILCalculator.equal y (convert -1 t) ->
                     castConcrete 0 t |> k
                 // x % x = 0
                 | x, y when x = y -> castConcrete 0 t |> k
                 // x % -x = 0 if unchecked
                 | x, UnaryMinusT(y, _) when x = y -> castConcrete 0 t |> k
                 // (a * b) % y = 0 if unchecked, b and y concrete and a % y = 0
-                | Mul(ConcreteT(a, _), _, _), ConcreteT(y, _) when divides t a y ->
+                | Mul(ConcreteT(a, _), _, _), ConcreteT(y, _) when divides isSigned t a y ->
                      castConcrete 0 t |> k
                 | _ ->
                     let op = if isSigned then OperationType.Remainder else OperationType.Remainder_Un
@@ -658,8 +810,8 @@ module internal Arithmetics =
     and private simplifyConcreteShift operation t x y =
         match operation with
         | OperationType.ShiftLeft -> castConcrete (ILCalculator.shiftLeft(x, y, t)) t
-        | OperationType.ShiftRight
-        | OperationType.ShiftRight_Un -> castConcrete (ILCalculator.shiftRight(x, y, t)) t
+        | OperationType.ShiftRight -> castConcrete (ILCalculator.shiftRight(x, y, t)) t
+        | OperationType.ShiftRight_Un -> castConcrete (ILCalculator.shiftRightUn(x, y, t)) t
         | _ -> __unreachable__()
 
     and private simplifyShiftLeftMul t a b y matched unmatched =
@@ -746,15 +898,15 @@ module internal Arithmetics =
             (fun x y k -> simplifyShiftExt operation t x y k defaultCase)
             (simplifyShift operation t)
 
-    and private simplifyBitwise (op : OperationType) x y t resType k =
+    and private simplifyBitwise (op : OperationType) x y t k =
         match x.term, y.term with
         | Concrete(x, _), Concrete(y, _) ->
             match op with
-            | OperationType.BitwiseAnd -> k <| Concrete (ILCalculator.bitwiseAnd(x, y, t)) resType
-            | OperationType.BitwiseOr -> k <| Concrete (ILCalculator.bitwiseOr(x, y, t)) resType
-            | OperationType.BitwiseXor -> k <| Concrete (ILCalculator.bitwiseXor(x, y, t)) resType
+            | OperationType.BitwiseAnd -> k <| Concrete (ILCalculator.bitwiseAnd(x, y, t)) t
+            | OperationType.BitwiseOr -> k <| Concrete (ILCalculator.bitwiseOr(x, y, t)) t
+            | OperationType.BitwiseXor -> k <| Concrete (ILCalculator.bitwiseXor(x, y, t)) t
             | _ -> __notImplemented__()
-        | _ -> k (Expression (Operator op) [x; y] resType)
+        | _ -> k (Expression (Operator op) [x; y] t)
 
 // ------------------------------- Simplification of "=", "!=", "<", ">", ">=", "<=" -------------------------------
 
@@ -803,7 +955,11 @@ module internal Arithmetics =
             let mutable noOverflow = true
             assert(isNumeric t1 && isNumeric t2)
             try
-                ILCalculator.addOvf(x, y, t1) |> ignore
+                if isUnsigned t1 then
+                    ILCalculator.addOvfUn(x, y, t1) |> ignore
+                elif isUnsigned t2 then
+                    ILCalculator.addOvfUn(x, y, t2) |> ignore
+                else ILCalculator.addOvf(x, y, t1) |> ignore
             with :? System.OverflowException ->
                 noOverflow <- false
             makeBool noOverflow
@@ -815,7 +971,11 @@ module internal Arithmetics =
             let mutable noOverflow = true
             assert(isNumeric t1 && isNumeric t2)
             try
-                ILCalculator.mulOvf(x, y, t1) |> ignore
+                if isUnsigned t1 then
+                    ILCalculator.mulOvfUn(x, y, t1) |> ignore
+                elif isUnsigned t2 then
+                    ILCalculator.mulOvfUn(x, y, t2) |> ignore
+                else ILCalculator.mulOvf(x, y, t1) |> ignore
             with :? System.OverflowException ->
                 noOverflow <- false
             makeBool noOverflow
@@ -875,7 +1035,7 @@ module internal Arithmetics =
         | OperationType.LessOrEqual_Un -> simplifyLessOrEqualUn x y k
         | OperationType.BitwiseAnd
         | OperationType.BitwiseOr
-        | OperationType.BitwiseXor -> simplifyBitwise op x y t (typeOf x) k
+        | OperationType.BitwiseXor -> simplifyBitwise op x y t k
         | OperationType.AddNoOvf -> simplifyAddNoOvf x y |> k
         | OperationType.MultiplyNoOvf -> simplifyMultiplyNoOvf x y |> k
         | _ -> internalfailf "%O is not a binary arithmetical operator" op

--- a/VSharp.SILI.Core/Branching.fs
+++ b/VSharp.SILI.Core/Branching.fs
@@ -69,6 +69,7 @@ module Branching =
                     let thenState = conditionState
                     let elseState = Memory.copy conditionState elsePc
                     elseState.model <- model.mdl
+                    assert(PC.toSeq elsePc |> conjunction |> elseState.model.Eval |> isTrue)
                     thenState.pc <- PC.add pc condition
                     TypeStorage.addTypeConstraint typeStorageCopy.Constraints condition
                     thenState.typeStorage <- typeStorageCopy
@@ -104,6 +105,7 @@ module Branching =
                     let thenState = conditionState
                     let elseState = Memory.copy conditionState (PC.add pc notCondition)
                     thenState.model <- model.mdl
+                    assert(PC.toSeq thenPc |> conjunction |> thenState.model.Eval |> isTrue)
                     TypeStorage.addTypeConstraint typeStorageCopy.Constraints notCondition
                     elseState.typeStorage <- typeStorageCopy
                     TypeSolver.refineTypes elseState

--- a/VSharp.SILI.Core/Memory.fs
+++ b/VSharp.SILI.Core/Memory.fs
@@ -810,7 +810,7 @@ module internal Memory =
         let failCondition = simplifyGreater endByte blockSize id ||| simplifyLess startByte (makeNumber 0) id
         // NOTE: disables overflow in solver
         let noOvf = makeExpressionNoOvf failCondition
-        // TODO: move noOvf to failCondition (failCondition = failCondition || !noOvf) ?
+        // TODO: move noOvf to failCondition (failCondition = failCondition || !noOvf)
         state.pc <- PC.add state.pc noOvf
         reportError state failCondition
 
@@ -820,22 +820,50 @@ module internal Memory =
         | Concrete(:? int as s, _), Concrete(:? int as e, _) when s = 0 && size = e -> List.singleton address
         | _ -> sprintf "reading: reinterpreting %O" address |> undefinedBehaviour
 
-    // NOTE: returns list of slices
-    let rec private readTermUnsafe term startByte endByte =
+    let sliceTerm term startByte endByte pos stablePos =
         match term.term with
-        | Struct(fields, t) -> readStructUnsafe fields t startByte endByte
+        | Slice(term, cuts) when stablePos ->
+            assert(List.isEmpty cuts |> not)
+            let _, _, p = List.head cuts
+            createSlice term ((startByte, endByte, p) :: cuts)
+        | Slice(term, cuts) ->
+            assert(List.isEmpty cuts |> not)
+            let _, _, p = List.head cuts
+            createSlice term ((startByte, endByte, add pos p) :: cuts)
+        | _ -> createSlice term (List.singleton (startByte, endByte, pos))
+
+    // NOTE: returns list of slices
+    // TODO: return empty? #combine
+    let rec private commonReadTermUnsafe term startByte endByte pos stablePos =
+        match term.term with
+        | Struct(fields, t) -> commonReadStructUnsafe fields t startByte endByte pos stablePos
         | HeapRef _
         | Ref _
         | Ptr _ -> readAddressUnsafe term startByte endByte
+        | Combined([t], _) -> commonReadTermUnsafe t startByte endByte pos stablePos
+        | Combined(slices, _) ->
+            List.collect (fun part -> commonReadTermUnsafe part startByte endByte pos stablePos) slices
+        | Slice _
         | Concrete _
         | Constant _
-        // TODO: make simplification for 'Combine' term
-        | Expression _ -> Slice term startByte endByte startByte |> List.singleton
+        | Expression _ ->
+            sliceTerm term startByte endByte pos stablePos |> List.singleton
         | _ -> internalfailf "readTermUnsafe: unexpected term %O" term
 
+    and private readTermUnsafe term startByte endByte =
+        commonReadTermUnsafe term startByte endByte (neg startByte) false
+
+    and private readTermPartUnsafe term startByte endByte =
+        commonReadTermUnsafe term startByte endByte startByte true
+
+    and private commonReadStructUnsafe fields structType startByte endByte pos stablePos =
+        let readField fieldId = fields[fieldId]
+        let state = makeEmpty false
+        let reportError _ = __unreachable__()
+        commonReadFieldsUnsafe state reportError readField false structType startByte endByte pos stablePos
+
     and private readStructUnsafe fields structType startByte endByte =
-        let readField fieldId = fields.[fieldId]
-        readFieldsUnsafe (makeEmpty false) (fun _ -> __unreachable__()) readField false structType startByte endByte
+        commonReadStructUnsafe fields structType startByte endByte (neg startByte) false
 
     and private getAffectedFields state reportError readField isStatic (blockType : Type) startByte endByte =
         let blockSize = CSharpUtils.LayoutUtils.ClassSize blockType
@@ -863,7 +891,7 @@ module internal Memory =
             let fieldOffset = makeNumber fieldOffset
             let startByte = sub startByte fieldOffset
             let endByte = sub endByte fieldOffset
-            fieldId, fieldValue, startByte, endByte
+            fieldId, fieldOffset, fieldValue, startByte, endByte
         match startByte.term, endByte.term with
         | Concrete(:? int as s, _), Concrete(:? int as e, _) ->
             let concreteGetField (_, fieldOffset, fieldSize as field) affectedFields =
@@ -873,9 +901,12 @@ module internal Memory =
             List.foldBack concreteGetField allFields List.empty
         | _ -> List.map getField allFields
 
-    and private readFieldsUnsafe state reportError readField isStatic (blockType : Type) startByte endByte =
+    and private commonReadFieldsUnsafe state reportError readField isStatic (blockType : Type) startByte endByte pos stablePos =
         let affectedFields = getAffectedFields state reportError readField isStatic blockType startByte endByte
-        List.collect (fun (_, v, s, e) -> readTermUnsafe v s e) affectedFields
+        List.collect (fun (_, o, v, s, e) -> commonReadTermUnsafe v s e (add pos o) stablePos) affectedFields
+
+    and private readFieldsUnsafe state reportError readField isStatic (blockType : Type) startByte endByte =
+        commonReadFieldsUnsafe state reportError readField isStatic blockType startByte endByte (neg startByte) false
 
     // TODO: Add undefined behaviour:
     // TODO: 1. when reading info between fields
@@ -1205,27 +1236,30 @@ module internal Memory =
             let termSize = internalSizeOf termType
             let valueSize = sizeOf value
             match startByte.term with
-            | Concrete(:? int as startByte, _) when startByte = 0 && valueSize = termSize -> value
+            | Concrete(:? int as startByte, _) when startByte = 0 && valueSize = termSize ->
+                combine (List.singleton value) termType
             | _ ->
                 let zero = makeNumber 0
-                let termSize = internalSizeOf termType |> makeNumber
-                let valueSize = sizeOf value |> makeNumber
-                let left = Slice term zero startByte zero
+                let termSize = makeNumber termSize
+                let valueSize = makeNumber valueSize
+                let left = readTermPartUnsafe term zero startByte
                 let valueSlices = readTermUnsafe value (neg startByte) (sub termSize startByte)
-                let right = Slice term (add startByte valueSize) termSize zero
-                combine ([left] @ valueSlices @ [right]) termType
+                let right = readTermPartUnsafe term (add startByte valueSize) termSize
+                combine (left @ valueSlices @ right) termType
         | _ -> internalfailf "writeTermUnsafe: unexpected term %O" term
 
     and private writeStructUnsafe structTerm fields structType startByte value =
-        let readField fieldId = fields.[fieldId]
-        let updatedFields = writeFieldsUnsafe (makeEmpty false) (fun _ -> __unreachable__()) readField false structType startByte value
+        let readField fieldId = fields[fieldId]
+        let state = makeEmpty false
+        let reportError _ = __unreachable__()
+        let updatedFields = writeFieldsUnsafe state reportError readField false structType startByte value
         let writeField structTerm (fieldId, value) = writeStruct structTerm fieldId value
         List.fold writeField structTerm updatedFields
 
     and private writeFieldsUnsafe state reportError readField isStatic (blockType : Type) startByte value =
         let endByte = sizeOf value |> makeNumber |> add startByte
         let affectedFields = getAffectedFields state reportError readField isStatic blockType startByte endByte
-        List.map (fun (id, v, s, _) -> id, writeTermUnsafe v s value) affectedFields
+        List.map (fun (id, _, v, s, _) -> id, writeTermUnsafe v s value) affectedFields
 
     let writeClassUnsafe state reportError address typ offset value =
         let readField fieldId = readClassField state address fieldId
@@ -1265,8 +1299,7 @@ module internal Memory =
         let updatedTerm = writeTermUnsafe term offset value
         writeStackLocation state loc updatedTerm
 
-    let private writeUnsafe state reportError baseAddress offset sightType value =
-        assert(sightType = typeof<Void> && isConcrete offset || int (internalSizeOf sightType) = sizeOf value)
+    let private writeUnsafe state reportError baseAddress offset value =
         match baseAddress with
         | HeapLocation(loc, sightType) ->
             let typ = mostConcreteTypeOfHeapRef state loc sightType
@@ -1287,7 +1320,7 @@ module internal Memory =
         let baseAddress, offset = Pointers.addressToBaseAndOffset address
         let ptr = Ptr baseAddress field.typ offset
         match ptr.term with
-        | Ptr(baseAddress, sightType, offset) -> writeUnsafe state (fun _ _ -> ()) baseAddress offset sightType value
+        | Ptr(baseAddress, _, offset) -> writeUnsafe state (fun _ _ -> ()) baseAddress offset value
         | _ -> internalfailf "expected to get ptr, but got %O" ptr
 
     let rec private writeSafe state address value =
@@ -1313,7 +1346,7 @@ module internal Memory =
     let write state reportError reference value =
         match reference.term with
         | Ref address -> writeSafe state address value
-        | Ptr(address, sightType, offset) -> writeUnsafe state reportError address offset sightType value
+        | Ptr(address, _, offset) -> writeUnsafe state reportError address offset value
         | _ -> internalfailf "Writing: expected reference, but got %O" reference
         state
 

--- a/VSharp.SILI.Core/Operations.fs
+++ b/VSharp.SILI.Core/Operations.fs
@@ -159,6 +159,7 @@ module internal Operations =
         | OperationType.LogicalOr -> " | "
         | OperationType.BitwiseNot -> "~%s"
         | OperationType.LogicalNot -> "!%s"
+        | OperationType.BitwiseXor -> " ^^ "
         | OperationType.LogicalXor -> " ^ "
         | OperationType.Multiply -> " * "
         | OperationType.Remainder

--- a/VSharp.SILI.Core/Pointers.fs
+++ b/VSharp.SILI.Core/Pointers.fs
@@ -20,7 +20,7 @@ module internal Pointers =
         | _ -> __unreachable__()
 
     let private getFieldOffset fieldId =
-        Reflection.getFieldOffset fieldId |> makeNumber
+        Reflection.getFieldIdOffset fieldId |> makeNumber
 
     let rec addressToBaseAndOffset (address : address) =
         match address with

--- a/VSharp.SILI.Core/State.fs
+++ b/VSharp.SILI.Core/State.fs
@@ -64,23 +64,22 @@ type symbolicType =
 
 // TODO: is it good idea to add new constructor for recognizing cilStates that construct RuntimeExceptions?
 type exceptionRegister =
-    | Unhandled of term * bool // Exception term * is runtime exception
-    | Caught of term
+    | Unhandled of term * bool * string // Exception term * is runtime exception * stack trace
+    | Caught of term * string // Exception term * stack trace
     | NoException
     with
     member x.GetError () =
         match x with
-        | Unhandled(error, _) -> error
-        | Caught error -> error
+        | Unhandled(error, _, _) -> error
+        | Caught(error, _) -> error
         | _ -> internalfail "no error"
-
     member x.TransformToCaught () =
         match x with
-        | Unhandled(e, _) -> Caught e
+        | Unhandled(e, _, s) -> Caught(e, s)
         | _ -> internalfail "unable TransformToCaught"
     member x.TransformToUnhandled () =
         match x with
-        | Caught e -> Unhandled(e, false)
+        | Caught(e, s) -> Unhandled(e, false, s)
         | _ -> internalfail "unable TransformToUnhandled"
     member x.UnhandledError =
         match x with
@@ -88,13 +87,18 @@ type exceptionRegister =
         | _ -> false
     member x.ExceptionTerm =
         match x with
-        | Unhandled (error, _)
-        | Caught error -> Some error
+        | Unhandled (error, _, _)
+        | Caught(error, _) -> Some error
+        | _ -> None
+    member x.StackTrace =
+        match x with
+        | Unhandled (_, _, s)
+        | Caught(_, s) -> Some s
         | _ -> None
     static member map f x =
         match x with
-        | Unhandled(e, isRuntime) -> Unhandled(f e, isRuntime)
-        | Caught e -> Caught <| f e
+        | Unhandled(e, isRuntime, s) -> Unhandled(f e, isRuntime, s)
+        | Caught(e, s) -> Caught(f e, s)
         | NoException -> NoException
 
 type arrayCopyInfo =

--- a/VSharp.SILI.Core/Substitution.fs
+++ b/VSharp.SILI.Core/Substitution.fs
@@ -59,9 +59,9 @@ module Substitution =
         | Ptr(address, typ, shift) ->
             let address' = substitutePointerBase recur typeSubst address
             Ptr address' (typeSubst typ) (recur shift)
-        | Slice(term, slices) ->
+        | Slice(part, slices) ->
             let slices' = List.map (fun (s, e, pos) -> recur s, recur e, recur pos) slices
-            createSlice (recur term) slices'
+            createSlice (recur part) slices'
         | _ -> termSubst term
 
     and private substituteMany termSubst typeSubst timeSubst terms ctor =

--- a/VSharp.SILI.Core/Substitution.fs
+++ b/VSharp.SILI.Core/Substitution.fs
@@ -56,8 +56,12 @@ module Substitution =
             Struct contents' typ'
         | ConcreteHeapAddress addr -> ConcreteHeapAddress (timeSubst addr)
         | Ref address -> substituteAddress recur typeSubst address |> Ref
-        | Ptr(address, typ, shift) -> Ptr (substitutePointerBase recur typeSubst address) (typeSubst typ) (recur shift)
-        | Slice(term, s, e, pos) -> Slice (recur term) (recur s) (recur e) (recur pos)
+        | Ptr(address, typ, shift) ->
+            let address' = substitutePointerBase recur typeSubst address
+            Ptr address' (typeSubst typ) (recur shift)
+        | Slice(term, slices) ->
+            let slices' = List.map (fun (s, e, pos) -> recur s, recur e, recur pos) slices
+            createSlice (recur term) slices'
         | _ -> termSubst term
 
     and private substituteMany termSubst typeSubst timeSubst terms ctor =

--- a/VSharp.SILI/CILState.fs
+++ b/VSharp.SILI/CILState.fs
@@ -128,7 +128,7 @@ module internal CilStateOperations =
 
     let hasRuntimeException (s : cilState) =
         match s.state.exceptionsRegister with
-        | Unhandled(_, isRuntime) -> isRuntime
+        | Unhandled(_, isRuntime, _) -> isRuntime
         | _ -> false
 
     let isStopped s = isIIEState s || stoppedByException s || not(isExecutable(s))

--- a/VSharp.SILI/CILState.fs
+++ b/VSharp.SILI/CILState.fs
@@ -140,7 +140,7 @@ module internal CilStateOperations =
     let violatesLevel (s : cilState) maxBound =
         match tryCurrentLoc s with
         | Some currLoc when PersistentDict.contains currLoc s.level ->
-            s.level.[currLoc] >= maxBound
+            s.level[currLoc] >= maxBound
         | _ -> false
 
     // [NOTE] Obtaining exploring method
@@ -276,7 +276,7 @@ module internal CilStateOperations =
     let addTarget (state : cilState) target =
         let prev = state.targets
         state.targets <- Set.add target prev
-        prev.Count <> state.targets.Count 
+        prev.Count <> state.targets.Count
 
     let removeTarget (state : cilState) target =
         let prev = state.targets

--- a/VSharp.SILI/Interpreter.fs
+++ b/VSharp.SILI/Interpreter.fs
@@ -1694,8 +1694,9 @@ type internal ILInterpreter() as this =
 
     member private x.CommonThrow cilState error isRuntime =
         let codeLocations = List.map (Option.get << ip2codeLocation) cilState.ipStack
+        let stackTrace = List.map toString codeLocations |> join ","
         setCurrentIp (SearchingForHandler(codeLocations, List.empty)) cilState
-        setException (Unhandled(error, isRuntime)) cilState
+        setException (Unhandled(error, isRuntime, stackTrace)) cilState
 
     member private x.Throw (cilState : cilState) =
         let error = peek cilState

--- a/VSharp.SILI/Searcher.fs
+++ b/VSharp.SILI/Searcher.fs
@@ -64,10 +64,18 @@ type DFSSearcher() =
     let states = List<cilState>()
 
     let update parent newStates =
-        if Seq.isEmpty newStates |> not then
-            let last = states.Count - 1
-            assert(states[last] = parent)
-            states.RemoveAt(last)
+        let last = states.Count - 1
+        if states[last] = parent then
+            if Seq.isEmpty newStates |> not then
+                assert(states[last] = parent)
+                states.RemoveAt(last)
+                for newState in newStates do
+                    assert(states.Contains newState |> not)
+                    states.Add newState
+                states.Add(parent)
+        else
+            let success = states.Remove(parent)
+            assert(success)
             for newState in newStates do
                 assert(states.Contains newState |> not)
                 states.Add newState

--- a/VSharp.SILI/Statistics.fs
+++ b/VSharp.SILI/Statistics.fs
@@ -45,6 +45,7 @@ type public SILIStatistics() =
     let totalVisited = Dictionary<codeLocation, uint>()
     let visitedWithHistory = Dictionary<codeLocation, HashSet<codeLocation>>()
     let emittedErrors = HashSet<ipStack * string>()
+    let emittedExceptions = HashSet<string * string>()
 
     let mutable isVisitedBlocksNotCoveredByTestsRelevant = true
     let visitedBlocksNotCoveredByTests = Dictionary<cilState, Set<codeLocation>>()
@@ -255,7 +256,9 @@ type public SILIStatistics() =
         visitedBlocksNotCoveredByTests.Remove s |> ignore
 
     member x.IsNewError (s : cilState) (errorMessage : string) =
-        emittedErrors.Add(s.ipStack, errorMessage)
+        match s.state.exceptionsRegister with
+        | Unhandled(_, _, stackTrace) -> emittedExceptions.Add(stackTrace, errorMessage)
+        | _ -> emittedErrors.Add(s.ipStack, errorMessage)
 
     member x.TrackStepBackward (pob : pob) (cilState : cilState) =
         // TODO

--- a/VSharp.SILI/TestGenerator.fs
+++ b/VSharp.SILI/TestGenerator.fs
@@ -288,7 +288,7 @@ module TestGenerator =
 
                 let hasException, message =
                     match state.exceptionsRegister with
-                    | Unhandled(e, _) ->
+                    | Unhandled(e, _, _) ->
                         let t = MostConcreteTypeOfHeapRef state e
                         test.Exception <- t
                         let message =

--- a/VSharp.Solver/Z3.fs
+++ b/VSharp.Solver/Z3.fs
@@ -329,6 +329,14 @@ module internal Z3 =
         member private x.MkBVURem operands : BitVecExpr =
             x.ExtendIfNeed operands false |> ctx.MkBVURem
 
+        member private x.Max (left : BitVecExpr) (right : BitVecExpr) =
+            assert(left.SortSize = right.SortSize)
+            x.MkITE(x.MkBVSGT(left, right), left, right) :?> BitVecExpr
+
+        member private x.Min (left : BitVecExpr) (right : BitVecExpr) =
+            assert(left.SortSize = right.SortSize)
+            x.MkITE(x.MkBVSGT(left, right), right, left) :?> BitVecExpr
+
 // ------------------------------- Encoding: common -------------------------------
 
         member public x.EncodeTerm encCtx (t : term) : encodingResult =
@@ -425,7 +433,8 @@ module internal Z3 =
 
         member private x.ExtractOrExtend (expr : BitVecExpr) size =
             let exprSize = expr.SortSize
-            if exprSize > size then ctx.MkExtract(size - 1u, 0u, expr)
+            if exprSize = size then expr
+            elif exprSize > size then ctx.MkExtract(size - 1u, 0u, expr)
             else ctx.MkSignExt(size - exprSize, expr)
 
         member private x.ReverseBytes (expr : BitVecExpr) =
@@ -434,45 +443,65 @@ module internal Z3 =
             let bytes = List.init (size / 8) (fun byte -> ctx.MkExtract(uint ((byte + 1) * 8) - 1u, uint (byte * 8), expr))
             List.reduce (fun x y -> ctx.MkConcat(x, y)) bytes
 
+        member private x.ComputeSliceBounds assumptions cuts termSortSize =
+            assert(termSortSize % 8u = 0u && termSortSize > 0u)
+            let zero = ctx.MkBV(0, termSortSize)
+            let sizeExpr = ctx.MkBV(termSortSize / 8u, termSortSize)
+            let addBounds (startByte, endByte, pos) (assumptions, startExpr, sizeExpr, position) =
+                let assumptions = assumptions @ startByte.assumptions @ endByte.assumptions @ pos.assumptions
+                let startByte = x.ExtractOrExtend (startByte.expr :?> BitVecExpr) termSortSize
+                let endByte = x.ExtractOrExtend (endByte.expr :?> BitVecExpr) termSortSize
+                let pos = x.ExtractOrExtend (pos.expr :?> BitVecExpr) termSortSize
+                let startByte = x.MkBVSub(startByte, position)
+                let endByte = x.MkBVSub(endByte, position)
+                let left = x.Max startByte zero
+                let right = x.Min endByte sizeExpr
+                let sliceSize = x.MkBVSub(right, left)
+                let newLeft = x.MkBVAdd(startExpr, left)
+                let newRight = x.Min (x.MkBVAdd(newLeft, sliceSize)) sizeExpr
+                let newPos = x.Max pos zero
+                assumptions, newLeft, newRight, newPos
+            List.foldBack addBounds cuts (assumptions, zero, sizeExpr, zero)
+
         // TODO: make code better
         member private x.EncodeCombine encCtx slices typ =
             let res = ctx.MkNumeral(0, x.Type2Sort typ) :?> BitVecExpr
             let window = res.SortSize
             let windowExpr = ctx.MkNumeral(window, x.Type2Sort(Types.IndexType)) :?> BitVecExpr
-            let zero = ctx.MkNumeral(0, x.Type2Sort(Types.IndexType)) :?> BitVecExpr
             let addOneSlice (res, assumptions) slice =
-                let term, startByte, endByte, pos =
+                let term, cuts =
                     match slice.term with
-                    | Slice(term, startByte, endByte, pos) ->
-                        x.EncodeTerm encCtx term, x.EncodeTerm encCtx startByte, x.EncodeTerm encCtx endByte, x.EncodeTerm encCtx pos
-                    | _ -> internalfailf "encoding combine: expected slice as argument, but got %O" slice
-                let assumptions = assumptions @ term.assumptions @ startByte.assumptions @ endByte.assumptions @ pos.assumptions
-                let term = term.expr :?> BitVecExpr
-                let startByte = startByte.expr :?> BitVecExpr
-                let endByte = endByte.expr :?> BitVecExpr
-                let pos = pos.expr :?> BitVecExpr
-                let pos = x.MkBVMul(pos, ctx.MkBV(8, pos.SortSize))
-                let startBit = x.MkBVMul(startByte, ctx.MkBV(8, startByte.SortSize))
-                let endBit = x.MkBVMul(endByte, ctx.MkBV(8, endByte.SortSize))
-                let termSize = term.SortSize
-                let sizeExpr = ctx.MkBV(termSize, endBit.SortSize)
-                let left = x.MkITE(x.MkBVSGT(startBit, zero), startBit, zero) :?> BitVecExpr
-                let right = x.MkITE(x.MkBVSGT(sizeExpr, endBit), endBit, sizeExpr) :?> BitVecExpr
-                let size = x.MkBVSub(right, left)
-                let intersects = x.MkBVSGT(size, zero)
-                let term = x.ReverseBytes term
-                let left = x.ExtractOrExtend left term.SortSize
-                let term = x.MkBVLShr(x.MkBVShl(term, left), left)
-                let toShiftRight = x.ExtractOrExtend (x.MkBVSub(sizeExpr, right)) term.SortSize
-                let term = x.MkBVLShr(term, toShiftRight)
+                    | Slice(term, cuts) ->
+                        let slices = List.map (fun (s, e, pos) -> x.EncodeTerm encCtx s, x.EncodeTerm encCtx e, x.EncodeTerm encCtx pos) cuts
+                        x.EncodeTerm encCtx term, slices
+                    | _ -> x.EncodeTerm encCtx slice, List.empty
+                let t = term.expr :?> BitVecExpr
+                let assumptions = assumptions @ term.assumptions
+                let termSize = t.SortSize
+                let sizeExpr = ctx.MkBV(termSize, termSize)
+                let assumptions, lByte, rByte, posByte = x.ComputeSliceBounds assumptions cuts termSize
+                let lByte = x.ExtractOrExtend lByte termSize
+                let rByte = x.ExtractOrExtend rByte termSize
+                let posByte = x.ExtractOrExtend posByte termSize
+                let lBit = x.MkBVMul(lByte, ctx.MkBV(8, termSize))
+                let rBit = x.MkBVMul(rByte, ctx.MkBV(8, termSize))
+                let posBit = x.MkBVMul(posByte, ctx.MkBV(8, termSize))
+                let sliceSize = x.MkBVSub(rBit, lBit)
+                let zero = ctx.MkBV(0, termSize)
+                let intersects = x.MkBVSGT(sliceSize, zero)
+                let term = x.ReverseBytes t
+                let left = x.ExtractOrExtend lBit termSize
+                let term = x.MkBVShl(term, left)
+                let cutRight = x.ExtractOrExtend (x.MkBVSub(sizeExpr, rBit)) termSize
+                let term = x.MkBVLShr(term, x.MkBVAdd(left, cutRight))
                 let term =
                     if termSize > window then ctx.MkExtract(window - 1u, 0u, term)
                     else ctx.MkZeroExt(window - termSize, term)
-                let w = x.ExtractOrExtend windowExpr term.SortSize
-                let s = x.ExtractOrExtend sizeExpr term.SortSize
-                let pos = x.ExtractOrExtend pos term.SortSize
-                let toShiftRight = x.ExtractOrExtend toShiftRight term.SortSize
-                let shift = x.MkBVAdd(x.MkBVSub(w, x.MkBVSub(s, pos)), toShiftRight)
+                let changedTermSize = term.SortSize
+                let w = x.ExtractOrExtend windowExpr changedTermSize
+                let pos = x.ExtractOrExtend posBit changedTermSize
+                let sliceSize = x.ExtractOrExtend sliceSize changedTermSize
+                let shift = x.MkBVSub(w, x.MkBVAdd(pos, sliceSize))
                 let part = x.MkBVShl(term, shift)
                 let res = x.MkITE(intersects, x.MkBVOr(res, part), res) :?> BitVecExpr
                 res, assumptions
@@ -951,8 +980,6 @@ module internal Z3 =
             let subst = Dictionary<ISymbolicConstantSource, term>()
             let stackEntries = Dictionary<stackKey, term ref>()
             let state = {Memory.EmptyState() with complete = true}
-            // TODO: some of evaluated constants are written to model: most of them contain stack reading
-            // TODO: maybe encode stack reading as reading from array?
             encodingCache.t2e |> Seq.iter (fun kvp ->
                 match kvp.Key with
                 | {term = Constant(_, StructFieldChain(fields, StackReading(key)), t)} as constant ->
@@ -992,7 +1019,7 @@ module internal Z3 =
             Memory.NewStackFrame state None (List.ofSeq frame)
 
             let defaultValues = Dictionary<regionSort, term ref>()
-            encodingCache.regionConstants |> Seq.iter (fun kvp ->
+            for kvp in encodingCache.regionConstants do
                 let region, fields = kvp.Key
                 let constant = kvp.Value
                 let arr = m.Eval(constant, false)
@@ -1003,7 +1030,7 @@ module internal Z3 =
                     if arr.IsConstantArray then
                         assert(arr.Args.Length = 1)
                         let constantValue =
-                            if Types.IsValueType typeOfLocation then x.Decode typeOfLocation arr.Args.[0]
+                            if Types.IsValueType typeOfLocation then x.Decode typeOfLocation arr.Args[0]
                             else
                                 let addr = x.DecodeConcreteHeapAddress arr.Args[0] |> ConcreteHeapAddress
                                 HeapRef addr typeOfLocation
@@ -1038,11 +1065,11 @@ module internal Z3 =
                             assert(states.Length = 1 && states[0] = state)
                         else internalfailf "Unexpected quantifier expression in model: %O" arr
                     else internalfailf "Unexpected array expression in model: %O" arr
-                parseArray arr)
-            defaultValues |> Seq.iter (fun kvp ->
+                parseArray arr
+            for kvp in defaultValues do
                 let region = kvp.Key
                 let constantValue = kvp.Value.Value
-                Memory.FillRegion state constantValue region)
+                Memory.FillRegion state constantValue region
 
             state.startingTime <- [encodingCache.lastSymbolicAddress - 1]
 

--- a/VSharp.Test/Tests/Lists.cs
+++ b/VSharp.Test/Tests/Lists.cs
@@ -435,6 +435,24 @@ namespace IntegrationTests
             return 3;
         }
 
+        [Ignore("Need to add arrays into type candidates")]
+        public static int ArrayAliasWrite(object[] o, string[] s, string str1, string str2)
+        {
+            if (o[42] == str1)
+            {
+                if (str1 != String.Empty)
+                {
+                    s[42] = str2;
+                    if (o[42] == str2)
+                        return 1;
+                    if (o[42] != str1)
+                        throw new ArgumentException("unreachable");
+                }
+            }
+
+            return 0;
+        }
+
         [TestSvm(100)]
         public static int MakeDefaultAndWrite(int k)
         {

--- a/VSharp.Test/Tests/Typecast.cs
+++ b/VSharp.Test/Tests/Typecast.cs
@@ -218,7 +218,7 @@ namespace IntegrationTests.Typecast
             return 0;
         }
 
-        [TestSvm(100)]
+        [Ignore("takes too much time")]
         public static object DownCastObject8(object obj)
         {
             if (obj is decimal d)

--- a/VSharp.Test/Tests/Typecast.cs
+++ b/VSharp.Test/Tests/Typecast.cs
@@ -152,6 +152,12 @@ namespace IntegrationTests.Typecast
                     return obj;
             }
 
+            if (obj is decimal dec)
+            {
+                if (dec > 10)
+                    return dec + 10;
+            }
+
             if (obj is string s)
             {
                 return s.Length;
@@ -183,6 +189,43 @@ namespace IntegrationTests.Typecast
                         // Unreachable case
                         return -3;
                 }
+            }
+
+            return 0;
+        }
+
+        [TestSvm(100)]
+        public static object DownCastObject6(object obj)
+        {
+            if (obj is decimal d)
+            {
+                return d + 10;
+            }
+
+            return 0;
+        }
+
+        [TestSvm(100)]
+        public static object DownCastObject7(object obj)
+        {
+            if (obj is decimal d)
+            {
+                if (d > 10)
+                    return d * 10 + 10;
+                return d / 10 % 10;
+            }
+
+            return 0;
+        }
+
+        [TestSvm(100)]
+        public static object DownCastObject8(object obj)
+        {
+            if (obj is decimal d)
+            {
+                if (d.GetHashCode() == 3000)
+                    return d * 10 + 10;
+                return d / 10 % 10;
             }
 
             return 0;

--- a/VSharp.Test/Tests/Unsafe.cs
+++ b/VSharp.Test/Tests/Unsafe.cs
@@ -715,6 +715,84 @@ namespace IntegrationTests
             return structValue.X;
         }
 
+        [TestSvm(65)]
+        public static int ReinterpretationVsNarrowCast(long l, int i)
+        {
+            long* p = &l;
+            if (*(UInt64*)p != (UInt64)l)
+                throw new ArgumentException("unreachable");
+            if (*(Int32*)p != (Int32)l)
+                throw new ArgumentException("unreachable");
+            if (*(UInt32*)p != (UInt32)l)
+                throw new ArgumentException("unreachable");
+            if (*(Int16*)p != (Int16)l)
+                throw new ArgumentException("unreachable");
+            if (*(char*)p != (char)l)
+                throw new ArgumentException("unreachable");
+            if (*(UInt16*)p != (UInt16)l)
+                throw new ArgumentException("unreachable");
+            if (*(sbyte*)p != (sbyte)l)
+                throw new ArgumentException("unreachable");
+            if (*(byte*)p != (byte)l)
+                throw new ArgumentException("unreachable");
+
+            int* p1 = &i;
+            if (*(Int64*)p1 != (Int64)i)
+                throw new Exception("reachable");
+            if (*(UInt64*)p1 != (UInt64)i)
+                throw new Exception("reachable");
+            if (*(UInt32*)p1 != (UInt32)i)
+                throw new ArgumentException("unreachable");
+            if (*(Int16*)p1 != (Int16)i)
+                throw new ArgumentException("unreachable");
+            if (*(char*)p1 != (char)i)
+                throw new ArgumentException("unreachable");
+            if (*(UInt16*)p1 != (UInt16)i)
+                throw new ArgumentException("unreachable");
+            if (*(sbyte*)p1 != (sbyte)i)
+                throw new ArgumentException("unreachable");
+            if (*(byte*)p1 != (byte)i)
+                throw new ArgumentException("unreachable");
+
+            return 0;
+        }
+
+        [TestSvm(100)]
+        public static int DoubleReinterpretation(long a, int i, int j)
+        {
+            var p = &a;
+            var ptr = (int*)((byte*)p + i);
+            var v = *ptr;
+            ptr = (int*)((byte *)p + i);
+            *ptr = v;
+            return *(int*)((byte*)ptr + j);
+        }
+
+        [TestSvm(100)]
+        public static int DoubleReinterpretation1(int[] arr, int i, int j)
+        {
+            fixed (int* p = arr)
+            {
+                var ptr = (long*)((byte*)p + i);
+                var v = *ptr;
+                ptr = (long*)p + i;
+                *ptr = v;
+                return *(int*)((byte*)ptr + j);
+            }
+        }
+
+        [TestSvm(100)]
+        public static int DoubleWrite(long[] arr, int i, int v, byte v2)
+        {
+            fixed (long* p = arr)
+            {
+                var ptr = (int*)((byte*)p + i);
+                *ptr = v;
+                *(byte*)ptr = v2;
+                return *ptr;
+            }
+        }
+
         [Ignore("Insufficient information")]
         public static int ReturnIntFromIntPtr(int myFavouriteParameter)
         {

--- a/VSharp.TestRenderer/MethodRenderer.cs
+++ b/VSharp.TestRenderer/MethodRenderer.cs
@@ -478,6 +478,23 @@ internal class MethodRenderer : CodeRenderer
             return RenderArray(type, obj, preferredName);
         }
 
+        private ExpressionSyntax[] RenderArrayElements(
+            int[][] indices,
+            object[] values,
+            Type elemType,
+            string arrayPreferredName)
+        {
+            var renderedValues = new ExpressionSyntax[indices.Length];
+            for (int i = 0; i < indices.Length; i++)
+            {
+                var elementPreferredName = arrayPreferredName + "_Elem" + i;
+                var value = values[i];
+                var explicitType = NeedExplicitType(value, elemType) ? elemType : null;
+                renderedValues[i] = RenderObject(value, elementPreferredName, explicitType);
+            }
+
+            return renderedValues;
+        }
         private ExpressionSyntax RenderCompactZeroLb(
             ArrayTypeSyntax type,
             System.Array array,
@@ -490,20 +507,15 @@ internal class MethodRenderer : CodeRenderer
             var elemType = array.GetType().GetElementType();
             Debug.Assert(elemType != null);
             var arrayPreferredName = preferredName ?? "array";
-
-            var renderedValues = new ExpressionSyntax[indices.Length];
-            for (int i = 0; i < indices.Length; i++)
-            {
-                var elementPreferredName = arrayPreferredName + "_Elem" + i;
-                var value = values[i];
-                var explicitType = NeedExplicitType(value, elemType) ? elemType : null;
-                renderedValues[i] = RenderObject(value, elementPreferredName, explicitType);
-            }
+            ExpressionSyntax[] renderedValues;
 
             if (TypeUtils.isPublic(elemType))
             {
                 var createArray = RenderArrayCreation(type, lengths);
                 var arrayId = AddDecl(arrayPreferredName, type, createArray);
+                var physAddress = new physicalAddress(array);
+                _renderedObjects[physAddress] = arrayId;
+
                 if (defaultValue != null)
                 {
                     var explicitType = NeedExplicitType(defaultValue, typeof(object)) ? typeof(object) : null;
@@ -513,14 +525,20 @@ internal class MethodRenderer : CodeRenderer
                         RenderCall(AllocatorType(), AllocatorFill, arrayId, defaultId);
                     AddExpression(call);
                 }
+
+                renderedValues = RenderArrayElements(indices, values, elemType, arrayPreferredName);
                 for (int i = 0; i < indices.Length; i++)
                     AddAssignment(RenderArrayAssignment(arrayId, renderedValues[i], indices[i]));
                 return arrayId;
             }
 
             var elems = new (int[], ExpressionSyntax)[indices.Length];
+            renderedValues = RenderArrayElements(indices, values, elemType, arrayPreferredName);
             for (int i = 0; i < indices.Length; i++)
+            {
                 elems[i] = (indices[i], renderedValues[i]);
+            }
+
             return RenderPrivateElemArray(array, elems, lengths, preferredName, defaultValue);
         }
 

--- a/VSharp.Utils/Logger.fs
+++ b/VSharp.Utils/Logger.fs
@@ -42,6 +42,10 @@ module Logger =
         currentTextWriter.WriteLine(builder.ToString())
         currentTextWriter.Flush()
 
+    let public writeLine (message : string) =
+        currentTextWriter.WriteLine(message)
+        currentTextWriter.Flush()
+
     let public printLogString vLevel (message : string) =
         if currentLogLevel >= vLevel then
             writeLineString vLevel "" message

--- a/VSharp.Utils/PersistentDictionary.fs
+++ b/VSharp.Utils/PersistentDictionary.fs
@@ -11,7 +11,7 @@ type public pdict<'key, 'value> when 'key : equality and 'value : equality =
     private {impl : PersistentHashMap<'key, 'value>; mutable hash : int option}
     static member Empty() = {impl = PersistentHashMap<'key, 'value>.Empty(); hash = None}
     member x.Item
-        with get key = x.impl.[key]
+        with get key = x.impl[key]
 
     override x.GetHashCode() =
         let createHash() =
@@ -22,7 +22,8 @@ type public pdict<'key, 'value> when 'key : equality and 'value : equality =
 
     override x.Equals(o : obj) =
         match o with
-        | :? pdict<'key, 'value> as h -> x.GetHashCode() = h.GetHashCode()
+        | :? pdict<'key, 'value> as h ->
+            x.GetHashCode() = h.GetHashCode() && Seq.forall2 (=) x.impl h.impl
         | _ -> false
 
 module public PersistentDict =

--- a/VSharp.Utils/TypeUtils.fs
+++ b/VSharp.Utils/TypeUtils.fs
@@ -58,6 +58,7 @@ module TypeUtils =
 
     let isNumeric x = numericTypes.Contains x || x.IsEnum
     let isIntegral = integralTypes.Contains
+    let isIntegralOrEnum x = integralTypes.Contains x || x.IsEnum
     let isReal = realTypes.Contains
     let isUnsigned = unsignedTypes.Contains
     let isPrimitive = primitiveTypes.Contains

--- a/VSharp.Utils/VSharp.Utils.fsproj
+++ b/VSharp.Utils/VSharp.Utils.fsproj
@@ -17,9 +17,9 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Compile Include="Prelude.fs" />
         <Compile Include="Logger.fs" />
         <Compile Include="WeakDictionary.fs" />
-        <Compile Include="Prelude.fs" />
         <Compile Include="Collections.fs" />
         <Compile Include="MappedStack.fs" />
         <Compile Include="PersistentDictionary.fs" />


### PR DESCRIPTION
- fixed unsafe operations
- added simplification for slice of combined term
- fixed internal calls
- C# concrete calculator functions moved to ILCalculator
- fixed renderer
- fixed statistics
- fixed reflection utils
- fixed DFS searcher