### PR TITLE
Stabilization: part XXII

### DIFF
--- a/VSharp.API/VSharp.API.csproj
+++ b/VSharp.API/VSharp.API.csproj
@@ -60,6 +60,7 @@
       <ProjectReference Include="..\VSharp.SILI\VSharp.SILI.fsproj" PrivateAssets="all" />
       <ProjectReference Include="..\VSharp.SILI.Core\VSharp.SILI.Core.fsproj" PrivateAssets="all" />
       <ProjectReference Include="..\VSharp.Solver\VSharp.Solver.fsproj" PrivateAssets="all" />
+      <ProjectReference Include="..\VSharp.SVM\VSharp.SVM.fsproj" />
       <ProjectReference Include="..\VSharp.TestExtensions\VSharp.TestExtensions.csproj" PrivateAssets="all" />
       <ProjectReference Include="..\VSharp.TestRenderer\VSharp.TestRenderer.csproj" PrivateAssets="all" />
       <ProjectReference Include="..\VSharp.TestRunner\VSharp.TestRunner.csproj" PrivateAssets="all" />

--- a/VSharp.API/VSharp.cs
+++ b/VSharp.API/VSharp.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Text;
 using VSharp.CSharpUtils;
 using VSharp.Interpreter.IL;
+using VSharp.SVM;
 
 namespace VSharp
 {
@@ -117,7 +118,7 @@ namespace VSharp
             var baseSearchMode = options.SearchStrategy.ToSiliMode();
             // TODO: customize search strategies via console options
             var siliOptions =
-                new SiliOptions(
+                new SVMOptions(
                     explorationMode: explorationMode.NewTestCoverageMode(
                         coverageZone,
                         options.Timeout > 0 ? searchMode.NewFairMode(baseSearchMode) : baseSearchMode
@@ -135,7 +136,7 @@ namespace VSharp
                     stepsLimit: options.StepsLimit
                 );
 
-            using var explorer = new SILI(siliOptions);
+            using var explorer = new SVM.SVM(siliOptions);
             var statistics = explorer.Statistics;
 
             void HandleInternalFail(Method? method, Exception exception)
@@ -148,6 +149,7 @@ namespace VSharp
                 if (exception is UnknownMethodException unknownMethodException)
                 {
                     Logger.printLogString(Logger.Error, $"Unknown method: {unknownMethodException.Method.FullName}");
+                    Logger.printLogString(Logger.Error, $"StackTrace: {unknownMethodException.InterpreterStackTrace}");
                     return;
                 }
 

--- a/VSharp.CSharpUtils/ReflectionUtils.cs
+++ b/VSharp.CSharpUtils/ReflectionUtils.cs
@@ -48,7 +48,9 @@ namespace VSharp.CSharpUtils
         private static bool IsPublic(Type t)
         {
             Debug.Assert(t != null && t != t.DeclaringType);
-            return t.IsPublic || t.IsNestedPublic && IsPublic(t.DeclaringType);
+            return
+                t.IsPublic
+                || t is { IsNestedPublic: true, DeclaringType: not null } && IsPublic(t.DeclaringType);
         }
 
         public static IEnumerable<Type> GetExportedTypesChecked(this Assembly assembly)

--- a/VSharp.IL/VSharp.IL.fsproj
+++ b/VSharp.IL/VSharp.IL.fsproj
@@ -14,6 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <Compile Include="Loader.fs" />
       <Compile Include="OpCodes.fs" />
       <Compile Include="ILRewriter.fs" />
       <Compile Include="MethodBody.fs" />
@@ -22,7 +23,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\VSharp.InternalCalls\VSharp.InternalCalls.fsproj" />
       <ProjectReference Include="..\VSharp.SILI.Core\VSharp.SILI.Core.fsproj" />
       <ProjectReference Include="..\VSharp.Utils\VSharp.Utils.fsproj" />
     </ItemGroup>

--- a/VSharp.InternalCalls/Activator.fs
+++ b/VSharp.InternalCalls/Activator.fs
@@ -5,7 +5,7 @@ open VSharp.Core
 
 module internal Activator =
 
-    let internal CreateInstance (state : state) (args : term list) : term =
+    let internal CreateInstance (_ : state) (args : term list) : term =
         assert(List.length args = 1)
         let t = args[0] |> Helpers.unwrapType
         Memory.DefaultOf t

--- a/VSharp.InternalCalls/Activator.fsi
+++ b/VSharp.InternalCalls/Activator.fsi
@@ -5,5 +5,5 @@ open VSharp.Core
 
 module internal Activator =
 
-    [<Implements("System.Object System.Activator.CreateInstance()")>]
-    val internal CreateInstance : state -> term list -> term
+    [<Implements("T System.Activator.CreateInstance()")>]
+    val CreateInstance : state -> term list -> term

--- a/VSharp.InternalCalls/Buffer.fs
+++ b/VSharp.InternalCalls/Buffer.fs
@@ -6,48 +6,73 @@ open VSharp.Core
 
 // ------------------------------ System.Buffer --------------------------------
 
-module Buffer =
+module internal Buffer =
 
-    let private Memmove (state : state) dst src elemCount =
-        let elemCount = Types.Cast elemCount typeof<int>
-        let getArrayInfo ref =
-            match ref.term with
-            | Ref(ArrayIndex(address, indices, arrayType)) -> address, indices, arrayType
-            | Ref(ClassField(address, field)) when field = Reflection.stringFirstCharField ->
+    let private getArrayInfo state ref =
+        let zero = MakeNumber 0
+        match ref.term with
+        | HeapRef(address, _) ->
+            let t = MostConcreteTypeOfRef state ref
+            if TypeUtils.isArrayType t then
+                let elemType = t.GetElementType()
+                let indices, arrayType =
+                    if t.IsSZArray then [zero], (elemType, 1, true)
+                    else
+                        let rank = t.GetArrayRank()
+                        let indices = List.init rank (fun _ -> zero)
+                        let arrayType = (elemType, rank, false)
+                        indices, arrayType
+                address, indices, arrayType
+            elif t = typeof<string> then
                 let address, stringArrayType = Memory.StringArrayInfo state address None
-                address, [MakeNumber 0], stringArrayType
-            | Ptr(HeapLocation(address, t), sightType, offset) ->
-                match TryPtrToArrayInfo t sightType offset with
-                | Some(index, arrayType) ->
-                    let address =
-                        if t = typeof<string> then Memory.StringArrayInfo state address None |> fst
-                        else address
-                    address, index, arrayType
-                | None -> internalfail $"Memmove: unexpected pointer {ref}"
-            | _ -> internalfail $"Memmove: unexpected reference {ref}"
-        let dstAddr, dstIndices, dstArrayType = getArrayInfo dst
-        let srcAddr, srcIndices, srcArrayType = getArrayInfo src
+                address, [zero], stringArrayType
+            else internalfail $"Memmove: unexpected HeapRef type {t}"
+        | Ref(ArrayIndex(address, indices, arrayType)) -> address, indices, arrayType
+        | Ref(ClassField(address, field)) when field = Reflection.stringFirstCharField ->
+            let address, stringArrayType = Memory.StringArrayInfo state address None
+            address, [zero], stringArrayType
+        | Ptr(HeapLocation _ as pointerBase, sightType, offset) ->
+            match TryPtrToRef state pointerBase sightType offset with
+            | Some(ArrayIndex(address, index, arrayType)) -> address, index, arrayType
+            | _ -> internalfail $"Memmove: unexpected pointer {ref}"
+        | _ -> internalfail $"Memmove: unexpected reference {ref}"
+
+    let CommonMemmove (state : state) dst dstIndex src srcIndex elemCount =
+        let elemCount = Types.Cast elemCount typeof<int>
+        let dstAddr, dstIndices, dstArrayType = getArrayInfo state dst
+        let srcAddr, srcIndices, srcArrayType = getArrayInfo state src
         let dstType = Types.ArrayTypeToSymbolicType dstArrayType
         let srcType = Types.ArrayTypeToSymbolicType srcArrayType
         let dstHeapRef = HeapRef dstAddr dstType
         let srcHeapRef = HeapRef srcAddr srcType
         let dstLinearIndex = Memory.LinearizeArrayIndex state dstAddr dstIndices dstArrayType
+        let dstLinearIndex =
+            match dstIndex with
+            | Some dstIndex -> API.Arithmetics.Add dstLinearIndex dstIndex
+            | None -> dstLinearIndex
         let srcLinearIndex = Memory.LinearizeArrayIndex state srcAddr srcIndices srcArrayType
+        let srcLinearIndex =
+            match srcIndex with
+            | Some srcIndex -> API.Arithmetics.Add srcLinearIndex srcIndex
+            | None -> srcLinearIndex
         Memory.CopyArray state srcHeapRef srcLinearIndex srcType dstHeapRef dstLinearIndex dstType elemCount
 
-    let internal GenericMemmove (state : state) (args : term list) : term =
+    let Memmove (state : state) dst src elemCount =
+        CommonMemmove state dst None src None elemCount
+
+    let GenericMemmove (state : state) (args : term list) : term =
         assert(List.length args = 4)
         let dst, src, elemCount = args[1], args[2], args[3]
         Memmove state dst src elemCount
         Nop()
 
-    let internal ByteMemmove (state : state) (args : term list) : term =
+    let ByteMemmove (state : state) (args : term list) : term =
         assert(List.length args = 3)
         let dst, src, elemCount = args[0], args[1], args[2]
         Memmove state dst src elemCount
         Nop()
 
-    let internal MemoryCopy (state : state) (args : term list) : term =
+    let MemoryCopy (state : state) (args : term list) : term =
         assert(List.length args = 4)
         let dst, src, dstSize, count = args[0], args[1], args[2], args[3]
         // TODO: use 'dstSize' to check for exception

--- a/VSharp.InternalCalls/Buffer.fsi
+++ b/VSharp.InternalCalls/Buffer.fsi
@@ -6,11 +6,13 @@ open VSharp.Core
 
 module internal Buffer =
 
+    val CommonMemmove : state -> term -> term option -> term -> term option -> term -> unit
+
     [<Implements("System.Void System.Buffer.Memmove(T&, T&, System.UIntPtr)")>]
-    val internal GenericMemmove : state -> term list -> term
+    val GenericMemmove : state -> term list -> term
 
     [<Implements("System.Void System.Buffer.Memmove(System.Byte&, System.Byte&, System.UIntPtr)")>]
-    val internal ByteMemmove : state -> term list -> term
+    val ByteMemmove : state -> term list -> term
 
     [<Implements("System.Void System.Buffer.MemoryCopy(System.Void*, System.Void*, System.Int64, System.Int64)")>]
-    val internal MemoryCopy : state -> term list -> term
+    val MemoryCopy : state -> term list -> term

--- a/VSharp.InternalCalls/ByReference.fsi
+++ b/VSharp.InternalCalls/ByReference.fsi
@@ -6,10 +6,10 @@ open VSharp.Core
 
 module internal ByReference =
 
-    val internal isValueField : fieldId -> bool
+    val isValueField : fieldId -> bool
 
     [<Implements("System.Void System.ByReference`1[T]..ctor(this, T&)")>]
-    val internal ctor : state -> term list -> (term * state) list
+    val ctor : state -> term list -> (term * state) list
 
     [<Implements("T& System.ByReference`1[T].get_Value(this)")>]
-    val internal getValue : state -> term list -> term
+    val getValue : state -> term list -> term

--- a/VSharp.InternalCalls/ChessDotNet.fsi
+++ b/VSharp.InternalCalls/ChessDotNet.fsi
@@ -7,7 +7,7 @@ open VSharp.Core
 module internal ChessDotNet =
 
     [<Implements("System.Boolean ChessDotNet.Position.Equals(this, System.Object)")>]
-    val internal PositionEquals : state -> term list -> term
+    val PositionEquals : state -> term list -> term
 
     [<Implements("System.Boolean ChessDotNet.Piece.Equals(this, System.Object)")>]
-    val internal PieceEquals : state -> term list -> term
+    val PieceEquals : state -> term list -> term

--- a/VSharp.InternalCalls/Delegate.fs
+++ b/VSharp.InternalCalls/Delegate.fs
@@ -1,0 +1,83 @@
+namespace VSharp.System
+
+open global.System
+open VSharp
+open VSharp.Core
+open VSharp.Interpreter.IL
+open VSharp.Interpreter.IL.CilStateOperations
+
+module internal Delegate =
+
+    let DelegateCombine (i : IInterpreter) cilState (args : term list) =
+        assert(List.length args = 2)
+        let d1 = args[0]
+        let d2 = args[1]
+        assert(IsReference d1 && IsReference d2)
+        let combine t cilState k =
+            let d = Memory.CombineDelegates cilState.state args t
+            push d cilState
+            List.singleton cilState |> k
+        let typesCheck cilState k =
+            let state = cilState.state
+            let d1Type = MostConcreteTypeOfRef state d1
+            let d2Type = MostConcreteTypeOfRef state d2
+            let t = TypeUtils.mostConcreteType d1Type d2Type
+            let secondCheck cilState k =
+                StatedConditionalExecutionCIL cilState
+                    (fun state k -> k (Types.RefIsType state d2 t, state))
+                    (combine t)
+                    (i.Raise i.ArgumentException)
+                    k
+            StatedConditionalExecutionCIL cilState
+                (fun state k -> k (Types.RefIsType state d1 t, state))
+                secondCheck
+                (i.Raise i.ArgumentException)
+                k
+        let nullCheck cilState k =
+            StatedConditionalExecutionCIL cilState
+                (fun state k -> k (IsNullReference d2, state))
+                (fun cilState k -> push d1 cilState; List.singleton cilState |> k)
+                typesCheck
+                k
+        StatedConditionalExecutionCIL cilState
+            (fun state k -> k (IsNullReference d1, state))
+            (fun cilState k -> push d2 cilState; List.singleton cilState |> k)
+            nullCheck
+            id
+
+    let DelegateRemove (i : IInterpreter) cilState (args : term list) =
+        assert(List.length args = 2)
+        let source = args[0]
+        let toRemove = args[1]
+        assert(IsReference source && IsReference toRemove)
+        let remove t cilState k =
+            let d = Memory.RemoveDelegate cilState.state source toRemove t
+            push d cilState
+            List.singleton cilState |> k
+        let typesCheck cilState k =
+            let state = cilState.state
+            let sourceType = MostConcreteTypeOfRef cilState.state source
+            let toRemoveType = MostConcreteTypeOfRef state toRemove
+            let t = TypeUtils.mostConcreteType sourceType toRemoveType
+            let secondCheck cilState k =
+                StatedConditionalExecutionCIL cilState
+                    (fun state k -> k (Types.RefIsType state toRemove t, state))
+                    (remove t)
+                    (i.Raise i.ArgumentException)
+                    k
+            StatedConditionalExecutionCIL cilState
+                (fun state k -> k (Types.RefIsType state source t, state))
+                secondCheck
+                (i.Raise i.ArgumentException)
+                k
+        let nullCheck cilState k =
+            StatedConditionalExecutionCIL cilState
+                (fun state k -> k (IsNullReference source, state))
+                (fun cilState k -> push (TypeOf source |> NullRef) cilState; List.singleton cilState |> k)
+                typesCheck
+                k
+        StatedConditionalExecutionCIL cilState
+            (fun state k -> k (IsNullReference toRemove, state))
+            (fun cilState k -> push source cilState; List.singleton cilState |> k)
+            nullCheck
+            id

--- a/VSharp.InternalCalls/Delegate.fsi
+++ b/VSharp.InternalCalls/Delegate.fsi
@@ -1,0 +1,14 @@
+namespace VSharp.System
+
+open global.System
+open VSharp
+open VSharp.Core
+open VSharp.Interpreter.IL
+
+module internal Delegate =
+
+    [<Implements("System.Delegate System.Delegate.Combine(System.Delegate, System.Delegate)")>]
+    val DelegateCombine : IInterpreter -> cilState -> term list -> cilState list
+
+    [<Implements("System.Delegate System.Delegate.Remove(System.Delegate, System.Delegate)")>]
+    val DelegateRemove : IInterpreter -> cilState -> term list -> cilState list

--- a/VSharp.InternalCalls/Diagnostics.fs
+++ b/VSharp.InternalCalls/Diagnostics.fs
@@ -1,0 +1,20 @@
+namespace VSharp.System
+
+open global.System
+open VSharp
+open VSharp.Core
+open VSharp.Interpreter.IL
+open VSharp.Interpreter.IL.CilStateOperations
+
+module internal Diagnostics =
+
+    let DebugAssert (_ : IInterpreter) cilState (args : term list) =
+        assert(List.length args = 1)
+        let condition = List.head args
+        StatedConditionalExecutionCIL cilState
+            (fun state k -> k (condition, state))
+            (fun cilState k -> (); k [cilState])
+            (fun cilState k ->
+                ErrorReporter.ReportFatalError cilState "Debug.Assert failed"
+                k [])
+            id

--- a/VSharp.InternalCalls/Diagnostics.fsi
+++ b/VSharp.InternalCalls/Diagnostics.fsi
@@ -1,0 +1,11 @@
+namespace VSharp.System
+
+open global.System
+open VSharp
+open VSharp.Core
+open VSharp.Interpreter.IL
+
+module internal Diagnostics =
+
+    [<Implements("System.Void System.Diagnostics.Debug.Assert(System.Boolean)")>]
+    val DebugAssert : IInterpreter -> cilState -> term list -> cilState list

--- a/VSharp.InternalCalls/Enum.fsi
+++ b/VSharp.InternalCalls/Enum.fsi
@@ -6,7 +6,7 @@ open VSharp.Core
 module internal Enum =
 
     [<Implements("System.Reflection.CorElementType System.Enum.InternalGetCorElementType(this)")>]
-    val internal InternalGetCorElementType : state -> term list -> term
+    val InternalGetCorElementType : state -> term list -> term
 
     [<Implements("System.Void System.Enum.GetEnumValuesAndNames(System.Runtime.CompilerServices.QCallTypeHandle, System.Runtime.CompilerServices.ObjectHandleOnStack, System.Runtime.CompilerServices.ObjectHandleOnStack, Interop+BOOL)")>]
-    val internal GetEnumValuesAndNames : state -> term list -> (term * state) list
+    val GetEnumValuesAndNames : state -> term list -> (term * state) list

--- a/VSharp.InternalCalls/Environment.fsi
+++ b/VSharp.InternalCalls/Environment.fsi
@@ -6,22 +6,22 @@ open VSharp.Core
 
 // ------------------------------- mscorlib.System.Environment -------------------------------
 
-module Environment =
+module internal Environment =
 
     [<Implements("System.String System.Environment.GetResourceFromDefault(System.String)")>]
-    val internal GetResourceFromDefault : state -> term list -> term
+    val GetResourceFromDefault : state -> term list -> term
 
     [<Implements("System.Int32 System.Environment.get_CurrentManagedThreadId()")>]
-    val internal GetCurrentManagedThreadId : state -> term list -> term
+    val GetCurrentManagedThreadId : state -> term list -> term
 
     [<Implements("System.Int32 System.Threading.Thread.get_ManagedThreadId(this)")>]
-    val internal GetManagedThreadId : state -> term list -> term
+    val GetManagedThreadId : state -> term list -> term
 
     [<Implements("System.Void System.Console.WriteLine(System.String)")>]
-    val internal WriteLine : state -> term list -> term
+    val WriteLine : state -> term list -> term
 
     [<Implements("System.Boolean System.Console.get_IsOutputRedirected()")>]
-    val internal get_IsOutputRedirected : state -> term list -> term
+    val get_IsOutputRedirected : state -> term list -> term
 
     [<Implements("System.Void System.Console.Clear()")>]
-    val internal consoleClear : state -> term list -> term
+    val consoleClear : state -> term list -> term

--- a/VSharp.InternalCalls/EqualityComparer.fsi
+++ b/VSharp.InternalCalls/EqualityComparer.fsi
@@ -1,18 +1,17 @@
 namespace VSharp.System
 
 open global.System
-open VSharp
 open VSharp.Core
 
 module internal EqualityComparer =
 
 //    [<Implements("System.Object System.Collections.Generic.ComparerHelpers.CreateDefaultEqualityComparer(System.Type)")>]
-    val internal CreateDefaultEqualityComparer : state -> term list -> term
+    val CreateDefaultEqualityComparer : state -> term list -> term
 
 //    [<Implements("System.Object System.Collections.Generic.ComparerHelpers.CreateDefaultComparer(System.Type)")>]
-    val internal CreateDefaultComparer : state -> term list -> term
+    val CreateDefaultComparer : state -> term list -> term
 
 //    [<Implements("System.Collections.Generic.EqualityComparer`1[T] System.Collections.Generic.EqualityComparer`1[T].get_Default()")>]
-    val internal get_Default : state -> term list -> term
+    val get_Default : state -> term list -> term
 
-    val internal structuralEquality : state -> term -> term -> term
+    val structuralEquality : state -> term -> term -> term

--- a/VSharp.InternalCalls/Globalization.fsi
+++ b/VSharp.InternalCalls/Globalization.fsi
@@ -7,13 +7,13 @@ open VSharp.Core
 module internal Globalization =
 
     [<Implements("System.Globalization.CultureInfo System.Globalization.CultureInfo.get_CurrentCulture()")>]
-    val internal get_CurrentCulture : state -> term list -> term
+    val get_CurrentCulture : state -> term list -> term
 
     [<Implements("System.Globalization.CultureInfo System.Globalization.CultureInfo.get_InvariantCulture()")>]
-    val internal get_InvariantCulture : state -> term list -> term
+    val get_InvariantCulture : state -> term list -> term
 
     [<Implements("System.Globalization.CompareInfo System.Globalization.CultureInfo.get_CompareInfo(this)")>]
-    val internal get_CompareInfo : state -> term list -> term
+    val get_CompareInfo : state -> term list -> term
 
     [<Implements("System.Boolean System.Globalization.GlobalizationMode.get_Invariant()")>]
-    val internal get_Invariant : state -> term list -> term
+    val get_Invariant : state -> term list -> term

--- a/VSharp.InternalCalls/HashHelpers.fs
+++ b/VSharp.InternalCalls/HashHelpers.fs
@@ -1,0 +1,27 @@
+namespace VSharp.System
+
+open global.System
+open VSharp
+open VSharp.Core
+open VSharp.Interpreter.IL
+open VSharp.Interpreter.IL.CilStateOperations
+
+module internal HashHelpers =
+
+    let FastMod (i : IInterpreter) cilState (args : term list) =
+        assert(List.length args = 3)
+        let left, right = args[0], args[1]
+        let validCase cilState k =
+            let leftType = TypeOf left
+            let rightType = TypeOf right
+            let result =
+                if TypeUtils.isUnsigned leftType || TypeUtils.isUnsigned rightType then
+                    Arithmetics.RemUn left right
+                else Arithmetics.Rem left right
+            push result cilState
+            k [cilState]
+        StatedConditionalExecutionCIL cilState
+            (fun state k -> k (right === MakeNumber 0, state))
+            (i.Raise i.DivideByZeroException)
+            validCase
+            id

--- a/VSharp.InternalCalls/HashHelpers.fsi
+++ b/VSharp.InternalCalls/HashHelpers.fsi
@@ -1,0 +1,11 @@
+namespace VSharp.System
+
+open global.System
+open VSharp
+open VSharp.Core
+open VSharp.Interpreter.IL
+
+module internal HashHelpers =
+
+    [<Implements("System.UInt32 System.Collections.HashHelpers.FastMod(System.UInt32, System.UInt32, System.UInt64)")>]
+    val FastMod : IInterpreter -> cilState -> term list -> cilState list

--- a/VSharp.InternalCalls/Helpers.fs
+++ b/VSharp.InternalCalls/Helpers.fs
@@ -10,3 +10,8 @@ module internal Helpers =
         match term.term with
         | Concrete(:? Type as t, _) -> t
         | _ -> internalfail $"InternalCalls: unexpected wrapped type {term}"
+
+module SetUp =
+
+    let ConfigureInternalCalls() =
+        Loader.SetInternalCallsAssembly (System.Reflection.Assembly.GetExecutingAssembly())

--- a/VSharp.InternalCalls/IntPtr.fsi
+++ b/VSharp.InternalCalls/IntPtr.fsi
@@ -7,27 +7,27 @@ open VSharp.Core
 module internal IntPtr =
 
     [<Implements("System.Void System.IntPtr..ctor(this, System.Int32)")>]
-    val internal intPtrCtorFromInt : state -> term list -> (term * state) list
+    val intPtrCtorFromInt : state -> term list -> (term * state) list
 
     [<Implements("System.Void System.IntPtr..ctor(this, System.Void*)")>]
-    val internal intPtrCtorFromPtr : state -> term list -> (term * state) list
+    val intPtrCtorFromPtr : state -> term list -> (term * state) list
 
     [<Implements("System.Void System.IntPtr..ctor(this, System.Int64)")>]
-    val internal intPtrCtorFromLong : state -> term list -> (term * state) list
+    val intPtrCtorFromLong : state -> term list -> (term * state) list
 
     [<Implements("System.Void* System.IntPtr.ToPointer(this)")>]
-    val internal intPtrToPointer : state -> term list -> term
+    val intPtrToPointer : state -> term list -> term
 
 module internal UIntPtr =
 
     [<Implements("System.Void System.UIntPtr..ctor(this, System.UInt32)")>]
-    val internal uintPtrCtorFromUInt : state -> term list -> (term * state) list
+    val uintPtrCtorFromUInt : state -> term list -> (term * state) list
 
     [<Implements("System.Void System.UIntPtr..ctor(this, System.Void*)")>]
-    val internal uintPtrCtorFromPtr : state -> term list -> (term * state) list
+    val uintPtrCtorFromPtr : state -> term list -> (term * state) list
 
     [<Implements("System.Void System.UIntPtr..ctor(this, System.UInt64)")>]
-    val internal uintPtrCtorFromULong : state -> term list -> (term * state) list
+    val uintPtrCtorFromULong : state -> term list -> (term * state) list
 
     [<Implements("System.Void* System.UIntPtr.ToPointer(this)")>]
-    val internal uintPtrToPointer : state -> term list -> term
+    val uintPtrToPointer : state -> term list -> term

--- a/VSharp.InternalCalls/Interlocked.fsi
+++ b/VSharp.InternalCalls/Interlocked.fsi
@@ -3,30 +3,31 @@ namespace VSharp.System
 open global.System
 open VSharp
 open VSharp.Core
+open VSharp.Interpreter.IL
 
 module internal Interlocked =
 
     [<Implements("T System.Threading.Interlocked.CompareExchange(T&, T, T)")>]
-    val internal genericCompareExchange : state -> term list -> (term * state) list
+    val genericCompareExchange : IInterpreter -> cilState -> term list -> cilState list
 
     [<Implements("System.Int32 System.Threading.Interlocked.CompareExchange(System.Int32&, System.Int32, System.Int32)")>]
-    val internal intCompareExchange : state -> term list -> (term * state) list
+    val intCompareExchange : IInterpreter -> cilState -> term list -> cilState list
 
     [<Implements("System.IntPtr System.Threading.Interlocked.CompareExchange(System.IntPtr&, System.IntPtr, System.IntPtr)")>]
     [<Implements("System.Object System.Runtime.InteropServices.GCHandle.InternalCompareExchange(System.IntPtr, System.Object, System.Object)")>]
-    val internal intPtrCompareExchange : state -> term list -> (term * state) list
+    val intPtrCompareExchange : IInterpreter -> cilState -> term list -> cilState list
 
     [<Implements("T System.Threading.Interlocked.Exchange(T&, T)")>]
-    val internal genericExchange : state -> term list -> (term * state) list
+    val genericExchange : IInterpreter -> cilState -> term list -> cilState list
 
     [<Implements("System.Int32 System.Threading.Interlocked.Exchange(System.Int32&, System.Int32)")>]
-    val internal intExchange : state -> term list -> (term * state) list
+    val intExchange : IInterpreter -> cilState -> term list -> cilState list
 
     [<Implements("System.Int32 System.Threading.Interlocked.ExchangeAdd(System.Int32&, System.Int32)")>]
-    val internal intExchangeAdd : state -> term list -> (term * state) list
+    val intExchangeAdd : IInterpreter -> cilState -> term list -> cilState list
 
     [<Implements("System.Int64 System.Threading.Interlocked.ExchangeAdd(System.Int64&, System.Int64)")>]
-    val internal longExchangeAdd : state -> term list -> (term * state) list
+    val longExchangeAdd : IInterpreter -> cilState -> term list -> cilState list
 
     [<Implements("System.Void System.Threading.Interlocked.MemoryBarrier()")>]
-    val internal memoryBarrier : state -> term list -> term
+    val memoryBarrier : state -> term list -> term

--- a/VSharp.InternalCalls/InteropServices.fsi
+++ b/VSharp.InternalCalls/InteropServices.fsi
@@ -6,10 +6,10 @@ open VSharp.Core
 module internal InteropServices =
 
     [<Implements("T& System.Runtime.InteropServices.MemoryMarshal.GetArrayDataReference(T[])")>]
-    val internal GetArrayDataReference : state -> term list -> term
+    val GetArrayDataReference : state -> term list -> term
 
     [<Implements("System.Void System.Runtime.InteropServices.NativeMemory.Free(System.Void*)")>]
-    val internal Free : state -> term list -> term
+    val Free : state -> term list -> term
 
     [<Implements("System.Void* System.Runtime.InteropServices.NativeMemory.AlignedAlloc(System.UIntPtr, System.UIntPtr)")>]
-    val internal AlignedAlloc : state -> term list -> term
+    val AlignedAlloc : state -> term list -> term

--- a/VSharp.InternalCalls/PlatformHelper.fsi
+++ b/VSharp.InternalCalls/PlatformHelper.fsi
@@ -8,26 +8,26 @@ module internal PlatformHelper =
 
     [<Implements("System.Int32 System.Threading.PlatformHelper.get_ProcessorCount()")>]
     [<Implements("System.Int32 System.Environment.get_ProcessorCount()")>]
-    val internal get_ProcessorCount : state -> term list -> term
+    val get_ProcessorCount : state -> term list -> term
 
     [<Implements("System.Boolean System.Runtime.Intrinsics.X86.Lzcnt.get_IsSupported()")>]
     [<Implements("System.Boolean System.Runtime.Intrinsics.X86.Lzcnt+X64.get_IsSupported()")>]
-    val internal lzcntIsSupported : state -> term list -> term
+    val lzcntIsSupported : state -> term list -> term
 
     [<Implements("System.Boolean System.Runtime.Intrinsics.Arm.ArmBase.get_IsSupported()")>]
     [<Implements("System.Boolean System.Runtime.Intrinsics.Arm.AdvSimd+Arm64.get_IsSupported()")>]
     [<Implements("System.Boolean System.Runtime.Intrinsics.Arm.ArmBase+Arm64.get_IsSupported()")>]
-    val internal armBaseIsSupported : state -> term list -> term
+    val armBaseIsSupported : state -> term list -> term
 
     [<Implements("System.Boolean System.Runtime.Intrinsics.X86.Avx2.get_IsSupported()")>]
-    val internal avx2IsSupported : state -> term list -> term
+    val avx2IsSupported : state -> term list -> term
 
     [<Implements("System.Boolean System.Runtime.Intrinsics.X86.Sse2.get_IsSupported()")>]
-    val internal sse2IsSupported : state -> term list -> term
+    val sse2IsSupported : state -> term list -> term
 
     [<Implements("System.Boolean System.Runtime.Intrinsics.X86.X86Base.get_IsSupported()")>]
     [<Implements("System.Boolean System.Runtime.Intrinsics.X86.X86Base+X64.get_IsSupported()")>]
-    val internal x86BaseIsSupported : state -> term list -> term
+    val x86BaseIsSupported : state -> term list -> term
 
     [<Implements("System.Boolean System.Runtime.Intrinsics.Vector128.get_IsHardwareAccelerated()")>]
     val vector128IsHardwareAccelerated : state -> term list -> term

--- a/VSharp.InternalCalls/Runtime.CompilerServices.RuntimeHelpers.fs
+++ b/VSharp.InternalCalls/Runtime.CompilerServices.RuntimeHelpers.fs
@@ -3,8 +3,7 @@ namespace VSharp.System
 open global.System
 open VSharp
 open VSharp.Core
-open System.Runtime.InteropServices
-open System.Reflection
+open VSharp.Interpreter.IL
 
 module Runtime_CompilerServices_RuntimeHelpers =
 
@@ -20,7 +19,7 @@ module Runtime_CompilerServices_RuntimeHelpers =
         let typ = List.head args |> Helpers.unwrapType
         MakeBool (Reflection.isReferenceOrContainsReferences typ)
 
-    let CommonGetHashCode (state : state) (args : term list) : term =
+    let CommonGetHashCode (_ : state) (args : term list) : term =
         assert(List.length args = 1)
         let object = List.head args
         GetHashCode object
@@ -37,7 +36,12 @@ module Runtime_CompilerServices_RuntimeHelpers =
         let enumValue = Memory.Read state boxedThis
         GetHashCode enumValue
 
-    let Equals (state : state) (args : term list) : term =
+    let Equals (_ : state) (args : term list) : term =
         assert(List.length args = 2)
         let x, y = args.[0], args.[1]
         x === y
+
+    let RunStaticCtor (_ : IInterpreter) (cilState : cilState) (args : term list) =
+        assert(List.length args = 1)
+        // TODO: initialize statics of argument
+        List.singleton cilState

--- a/VSharp.InternalCalls/Runtime.CompilerServices.RuntimeHelpers.fsi
+++ b/VSharp.InternalCalls/Runtime.CompilerServices.RuntimeHelpers.fsi
@@ -3,8 +3,9 @@ namespace VSharp.System
 open global.System
 open VSharp
 open VSharp.Core
+open VSharp.Interpreter.IL
 
-module Runtime_CompilerServices_RuntimeHelpers =
+module internal Runtime_CompilerServices_RuntimeHelpers =
 
     [<Implements("System.Boolean System.Runtime.CompilerServices.RuntimeHelpers.IsBitwiseEquatable()")>]
     val IsBitwiseEquatable : state -> term list -> term
@@ -23,3 +24,7 @@ module Runtime_CompilerServices_RuntimeHelpers =
 
     [<Implements("System.Boolean System.Runtime.CompilerServices.RuntimeHelpers.Equals(System.Object, System.Object)")>]
     val Equals : state -> term list -> term
+
+    [<Implements("System.Void System.Runtime.CompilerServices.RuntimeHelpers._RunClassConstructor(System.RuntimeType)")>]
+    [<Implements("System.Void System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(System.Runtime.CompilerServices.QCallTypeHandle)")>]
+    val RunStaticCtor : IInterpreter -> cilState -> term list -> cilState list

--- a/VSharp.InternalCalls/SR.fsi
+++ b/VSharp.InternalCalls/SR.fsi
@@ -7,85 +7,85 @@ open VSharp.Core
 module internal SR =
 
     [<Implements("System.String System.SR.get_Arg_OverflowException()")>]
-    val internal get_Arg_OverflowException : state -> term list -> term
+    val get_Arg_OverflowException : state -> term list -> term
 
     [<Implements("System.String System.SR.get_Arg_SystemException()")>]
-    val internal get_Arg_SystemException : state -> term list -> term
+    val get_Arg_SystemException : state -> term list -> term
 
     [<Implements("System.String System.SR.get_Arg_IndexOutOfRangeException()")>]
-    val internal get_Arg_IndexOutOfRangeException : state -> term list -> term
+    val get_Arg_IndexOutOfRangeException : state -> term list -> term
 
     [<Implements("System.String System.SR.get_Arg_NullReferenceException()")>]
-    val internal get_Arg_NullReferenceException : state -> term list -> term
+    val get_Arg_NullReferenceException : state -> term list -> term
 
     [<Implements("System.String System.SR.get_Arg_ArrayTypeMismatchException()")>]
-    val internal get_Arg_ArrayTypeMismatchException : state -> term list -> term
+    val get_Arg_ArrayTypeMismatchException : state -> term list -> term
 
     [<Implements("System.String System.SR.get_Arg_InvalidHandle()")>]
-    val internal get_Arg_InvalidHandle : state -> term list -> term
+    val get_Arg_InvalidHandle : state -> term list -> term
 
     [<Implements("System.String System.SR.get_Arg_InvalidOperationException()")>]
-    val internal get_Arg_InvalidOperationException : state -> term list -> term
+    val get_Arg_InvalidOperationException : state -> term list -> term
 
     [<Implements("System.String System.SR.get_ArgumentOutOfRange_Index()")>]
-    val internal get_ArgumentOutOfRange_Index : state -> term list -> term
+    val get_ArgumentOutOfRange_Index : state -> term list -> term
 
     [<Implements("System.String System.SR.get_Arg_PlatformNotSupported()")>]
-    val internal get_Arg_PlatformNotSupported : state -> term list -> term
+    val get_Arg_PlatformNotSupported : state -> term list -> term
 
     [<Implements("System.String System.SR.get_Arg_NotGenericTypeDefinition()")>]
-    val internal get_Arg_NotGenericTypeDefinition : state -> term list -> term
+    val get_Arg_NotGenericTypeDefinition : state -> term list -> term
 
     [<Implements("System.String System.SR.get_Arg_ArgumentException()")>]
-    val internal get_Arg_ArgumentException : state -> term list -> term
+    val get_Arg_ArgumentException : state -> term list -> term
 
     [<Implements("System.String System.SR.get_Arg_ArgumentOutOfRangeException()")>]
-    val internal get_Arg_ArgumentOutOfRangeException : state -> term list -> term
+    val get_Arg_ArgumentOutOfRangeException : state -> term list -> term
 
     [<Implements("System.String System.SR.get_Arg_ArgumentNullException()")>]
-    val internal get_Arg_ArgumentNullException : state -> term list -> term
+    val get_Arg_ArgumentNullException : state -> term list -> term
 
     [<Implements("System.String System.SR.get_ArgumentNull_Generic()")>]
-    val internal get_ArgumentNull_Generic : state -> term list -> term
+    val get_ArgumentNull_Generic : state -> term list -> term
 
     [<Implements("System.String System.SR.get_Arg_DivideByZero()")>]
-    val internal get_Arg_DivideByZero : state -> term list -> term
+    val get_Arg_DivideByZero : state -> term list -> term
 
     [<Implements("System.String System.SR.get_Arg_ArithmeticException()")>]
-    val internal get_Arg_ArithmeticException : state -> term list -> term
+    val get_Arg_ArithmeticException : state -> term list -> term
 
     [<Implements("System.String System.SR.get_Arg_KeyNotFoundWithKey()")>]
-    val internal get_Arg_KeyNotFoundWithKey : state -> term list -> term
+    val get_Arg_KeyNotFoundWithKey : state -> term list -> term
 
     [<Implements("System.String System.SR.get_InvalidOperation_EmptyStack()")>]
-    val internal get_InvalidOperation_EmptyStack : state -> term list -> term
+    val get_InvalidOperation_EmptyStack : state -> term list -> term
 
     [<Implements("System.String System.Exception.GetMessageFromNativeResources(System.Exception+ExceptionMessageKind)")>]
-    val internal getMessageFromNativeResources : state -> term list -> term
+    val getMessageFromNativeResources : state -> term list -> term
 
     [<Implements("System.String System.SR.get_ConcurrentDictionary_ConcurrencyLevelMustBePositive()")>]
-    val internal concurrencyLevelMustBePositive : state -> term list -> term
+    val concurrencyLevelMustBePositive : state -> term list -> term
 
     [<Implements("System.String System.SR.get_ConcurrentDictionary_ConcurrencyLevelMustBeNegative()")>]
-    val internal concurrencyLevelMustBeNegative : state -> term list -> term
+    val concurrencyLevelMustBeNegative : state -> term list -> term
 
     [<Implements("System.String System.SR.get_ArgumentOutOfRange_BadYearMonthDay()")>]
-    val internal get_ArgumentOutOfRange_BadYearMonthDay : state -> term list -> term
+    val get_ArgumentOutOfRange_BadYearMonthDay : state -> term list -> term
 
     [<Implements("System.String System.SR.get_ArgumentOutOfRange_Count()")>]
-    val internal get_ArgumentOutOfRange_Count : state -> term list -> term
+    val get_ArgumentOutOfRange_Count : state -> term list -> term
 
     [<Implements("System.String System.SR.get_ArgumentOutOfRange_StartIndex()")>]
-    val internal get_ArgumentOutOfRange_StartIndex : state -> term list -> term
+    val get_ArgumentOutOfRange_StartIndex : state -> term list -> term
 
     [<Implements("System.String System.SR.get_ArgumentOutOfRange_SmallCapacity()")>]
-    val internal get_ArgumentOutOfRange_SmallCapacity : state -> term list -> term
+    val get_ArgumentOutOfRange_SmallCapacity : state -> term list -> term
 
     [<Implements("System.String System.SR.get_Argument_HasToBeArrayClass()")>]
-    val internal get_Argument_HasToBeArrayClass : state -> term list -> term
+    val get_Argument_HasToBeArrayClass : state -> term list -> term
 
     [<Implements("System.String System.SR.get_ThreadLocal_Disposed()")>]
-    val internal get_ThreadLocal_Disposed : state -> term list -> term
+    val get_ThreadLocal_Disposed : state -> term list -> term
 
     [<Implements("System.String System.SR.get_Arg_NotImplementedException()")>]
-    val internal get_Arg_NotImplementedException : state -> term list -> term
+    val get_Arg_NotImplementedException : state -> term list -> term

--- a/VSharp.InternalCalls/Span.fs
+++ b/VSharp.InternalCalls/Span.fs
@@ -2,12 +2,15 @@ namespace VSharp.System
 
 open System
 open global.System
+
 open VSharp
 open VSharp.Core
+open VSharp.Interpreter.IL
+open VSharp.Interpreter.IL.CilStateOperations
 
 // ------------------------------ System.ReadOnlySpan --------------------------------
 
-module ReadOnlySpan =
+module internal ReadOnlySpan =
 
     let private isContentReferenceField fieldId =
         let name = fieldId.name
@@ -29,20 +32,20 @@ module ReadOnlySpan =
             HeapRef address (eType.MakeArrayType dim)
         else ArrayIndex(address, indices, arrayType) |> Ref
 
-    let internal GetLength (state : state) (spanStruct : term) =
+    let GetLength (state : state) (spanStruct : term) =
         let spanFields = Terms.TypeOf spanStruct |> Reflection.fieldsOf false
         assert(Array.length spanFields = 2)
         let lenField = spanFields |> Array.find (fst >> isLengthField) |> fst
         Memory.ReadField state spanStruct lenField
 
-    let internal GetContentsRef (state : state) (spanStruct : term) =
+    let GetContents (cilState : cilState) (spanStruct : term) =
         let spanFields = Terms.TypeOf spanStruct |> Reflection.fieldsOf false
         assert(Array.length spanFields = 2)
+        let state = cilState.state
         let ptrField = spanFields |> Array.find (fst >> isContentReferenceField) |> fst
-        // TODO: throw ThrowIndexOutOfRangeException if len is less or equal to index
         let lenField = spanFields |> Array.find (fst >> isLengthField) |> fst
-        let len = Memory.ReadField state spanStruct lenField
-        let ptrFieldValue = Memory.ReadField state spanStruct ptrField
+        let len = readField cilState spanStruct lenField
+        let ptrFieldValue = readField cilState spanStruct ptrField
         let ptrFieldType = ptrField.typ
         let ptr =
             if ptrFieldIsByRef ptrFieldType then
@@ -50,52 +53,75 @@ module ReadOnlySpan =
                 let byRefFields = Terms.TypeOf ptrFieldValue |> Reflection.fieldsOf false
                 assert(Array.length byRefFields = 1)
                 let byRefField = byRefFields |> Array.find (fst >> ByReference.isValueField) |> fst
-                Memory.ReadField state ptrFieldValue byRefField
+                readField cilState ptrFieldValue byRefField
             else
                 // Case for .NET 7, where Span contains 'Byte&' field
                 ptrFieldValue
-        match ptr.term with
-        // Case for char span made from string
-        | Ref(ClassField(address, field)) when field = Reflection.stringFirstCharField ->
-            HeapRef address typeof<char[]>
-        | Ref(ArrayIndex(addr, indices, arrayType)) when indices = [MakeNumber 0] ->
-            CreateArrayRef addr indices arrayType
-        | Ptr(HeapLocation(_, t) as pointerBase, sightType, offset) ->
-            match TryPtrToRef state pointerBase sightType offset with
-            | Some(ArrayIndex(address, indices, arrayType)) -> CreateArrayRef address indices arrayType
-            | Some address -> Ref address
-            | None when t.IsSZArray || t = typeof<string> -> ptr
-            | None -> internalfail $"GetContentsRef: unexpected pointer to contents {ptr}"
-        | Ptr(pointerBase, sightType, offset) when len = MakeNumber 1 ->
-            match TryPtrToRef state pointerBase sightType offset with
-            | Some address -> Ref address
-            | _ -> ptr
-        | _ -> internalfail $"GetContentsRef: unexpected reference to contents {ptr}"
+        let ref =
+            match ptr.term with
+            // Case for char span made from string
+            | Ref(ClassField(address, field)) when field = Reflection.stringFirstCharField ->
+                let address, arrayType = Memory.StringArrayInfo state address None
+                CreateArrayRef address [MakeNumber 0] arrayType
+            | Ref(ArrayIndex(addr, indices, arrayType)) ->
+                CreateArrayRef addr indices arrayType
+            | HeapRef(address, _) ->
+                let t = MostConcreteTypeOfRef state ptr
+                if TypeUtils.isArrayType t then ptr
+                elif t = typeof<string> then
+                    let address, arrayType = Memory.StringArrayInfo state address None
+                    CreateArrayRef address [MakeNumber 0] arrayType
+                elif TypeUtils.isValueType t && len = MakeNumber 1 then
+                    HeapReferenceToBoxReference ptr
+                else internalfail $"GetContents: unexpected pointer {ptr}"
+            | DetachedPtr _ -> ptr
+            | Ptr(HeapLocation(_, t) as pointerBase, sightType, offset) ->
+                // TODO: add 'TryPtrToRef' to ctor
+                match TryPtrToRef state pointerBase sightType offset with
+                | Some(ArrayIndex(address, indices, arrayType)) -> CreateArrayRef address indices arrayType
+                | Some address -> Ref address
+                | None when t.IsSZArray || t = typeof<string> -> ptr
+                | None -> internalfail $"GetContentsRef: unexpected pointer to contents {ptr}"
+            | Ptr(pointerBase, sightType, offset) when len = MakeNumber 1 ->
+                match TryPtrToRef state pointerBase sightType offset with
+                | Some address -> Ref address
+                | _ -> ptr
+            | _ -> internalfail $"GetContentsRef: unexpected reference to contents {ptr}"
+        ref, len
 
-    let internal GetItemFromReadOnlySpan (state : state) (args : term list) : term =
+    let private IsArrayContents ref =
+        match ref.term with
+        | HeapRef(_, t)
+        | Ptr(HeapLocation(_, t), _, _) ->
+            TypeUtils.isArrayType t || t = typeof<string>
+        | Ref(ArrayIndex _) -> true
+        | _ -> false
+
+    let GetItem (i : IInterpreter) (cilState : cilState) (args : term list) =
         assert(List.length args = 3)
         let this, wrappedType, index = args[0], args[1], args[2]
         let t = Helpers.unwrapType wrappedType
-        let span = Memory.Read state this
-        let ref = GetContentsRef state span
-        let isArrayContents =
-            match ref.term with
-            | HeapRef(_, t)
-            | Ptr(HeapLocation(_, t), _, _) ->
-                TypeUtils.isArrayType t || t = typeof<string>
-            | Ref(ArrayIndex _) -> true
-            | _ -> false
-        if isArrayContents then
-            Memory.ReferenceArrayIndex state ref [index] (Some t)
-        elif index = MakeNumber 0 then
-            assert(TypeOfLocation ref = t)
-            ref
-        else internalfail $"GetItemFromReadOnlySpan: unexpected contents ref {ref}"
+        let span = read cilState this
+        let ref, len = GetContents cilState span
+        let checkIndex cilState k =
+            let readIndex cilState k =
+                let ref =
+                    if IsArrayContents ref then
+                        Memory.ReferenceArrayIndex cilState.state ref [index] (Some t)
+                    elif index = MakeNumber 0 then
+                        assert(TypeOfLocation ref = t)
+                        ref
+                    else internalfail $"GetItemFromReadOnlySpan: unexpected contents ref {ref}"
+                push ref cilState
+                List.singleton cilState |> k
+            StatedConditionalExecutionCIL cilState
+                (fun state k -> k (Arithmetics.Less index len, state))
+                readIndex
+                (i.Raise i.IndexOutOfRangeException)
+                k
+        i.NpeOrInvoke cilState ref checkIndex id
 
-    let internal GetItemFromSpan (state : state) (args : term list) : term =
-        GetItemFromReadOnlySpan state args
-
-    let private InitSpanStruct spanStruct refToFirst length =
+    let private InitSpanStruct cilState spanStruct refToFirst length =
         let spanFields = Terms.TypeOf spanStruct |> Reflection.fieldsOf false
         assert(Array.length spanFields = 2)
         let ptrField, ptrFieldInfo = spanFields |> Array.find (fst >> isContentReferenceField)
@@ -107,48 +133,54 @@ module ReadOnlySpan =
                 let byRefFields = Reflection.fieldsOf false ptrFieldType
                 assert(Array.length byRefFields = 1)
                 let valueField = byRefFields |> Array.find (fst >> ByReference.isValueField) |> fst
-                let initializedByRef = Memory.WriteStructField byRef valueField refToFirst
-                Memory.WriteStructField spanStruct ptrField initializedByRef
+                let initializedByRef = writeStructField cilState byRef valueField refToFirst
+                writeStructField cilState spanStruct ptrField initializedByRef
             else
                 // Case for .NET 7, where Span contains 'Byte&' field
-                Memory.WriteStructField spanStruct ptrField refToFirst
+                writeStructField cilState spanStruct ptrField refToFirst
         let lengthField = spanFields |> Array.find (fst >> isLengthField) |> fst
-        Memory.WriteStructField spanWithPtrField lengthField length
+        writeStructField cilState spanWithPtrField lengthField length
 
-    let private CommonCtor (state : state) this refToFirst length =
-        let span = Memory.Read state this
-        let initializedSpan = InitSpanStruct span refToFirst length
-        Memory.Write state this initializedSpan |> List.map (withFst (Nop()))
+    let private CommonCtor (cilState : cilState) this refToFirst length =
+        let span = read cilState this
+        let initializedSpan = InitSpanStruct cilState span refToFirst length
+        write cilState this initializedSpan
 
-    let internal CtorFromFromArray (state : state) this arrayRef =
-        let refToFirstElement = Memory.ReferenceArrayIndex state arrayRef [MakeNumber 0] None
-        let lengthOfArray = Memory.ArrayLengthByDimension state arrayRef (MakeNumber 0)
-        CommonCtor state this refToFirstElement lengthOfArray
-
-    let internal CtorFromPtrForSpan (state : state) (args : term list) : (term * state) list =
+    let CtorFromPtr (i : IInterpreter) (cilState : cilState) (args : term list) : cilState list =
         assert(List.length args = 4)
         let this, wrappedType, ptr, size = args[0], args[1], args[2], args[3]
-        if ptr = MakeNullPtr typeof<Void> then
-            // Ptr came from localloc instruction
-            let elementType = Helpers.unwrapType wrappedType
-            let arrayRef = Memory.AllocateVectorArray state size elementType
-            CtorFromFromArray state this arrayRef
-        else
-            CommonCtor state this ptr size
+        let t = Helpers.unwrapType wrappedType
+        let ctor cilState k =
+            let state = cilState.state
+            let ptr =
+                if isStackArray cilState ptr then
+                    // Ptr came from localloc instruction
+                    Memory.AllocateVectorArray state size t
+                elif MostConcreteTypeOfRef state ptr = t then ptr
+                else Types.Cast ptr (t.MakePointerType())
+            CommonCtor cilState this ptr size |> k
+        StatedConditionalExecutionCIL cilState
+            (fun state k -> k (Arithmetics.GreaterOrEqual size (MakeNumber 0), state))
+            ctor
+            (i.Raise i.ArgumentOutOfRangeException)
+            id
 
-    let internal CtorFromPtrForReadOnlySpan (state : state) (args : term list) : (term * state) list =
-        CtorFromPtrForSpan state args
-
-    let internal CtorFromArrayForReadOnlySpan (state : state) (args : term list) : (term * state) list =
+    let CtorFromArray (_ : IInterpreter) (cilState : cilState) (args : term list) : cilState list =
         assert(List.length args = 3)
         let this, arrayRef = args[0], args[2]
-        CtorFromFromArray state this arrayRef
+        let state = cilState.state
+        let refToFirstElement = Memory.ReferenceArrayIndex state arrayRef [MakeNumber 0] None
+        let lengthOfArray = Memory.ArrayLengthByDimension state arrayRef (MakeNumber 0)
+        CommonCtor cilState this refToFirstElement lengthOfArray
 
-    let ReadOnlySpanCreateFromString (state : state) (args : term list) : term =
+    let CreateFromString (_ : IInterpreter) (cilState : cilState) (args : term list) : cilState list =
         assert(List.length args = 1)
         let string = args[0]
         let spanType = readOnlySpanType().MakeGenericType(typeof<char>)
         let span = Memory.DefaultOf spanType
+        let state = cilState.state
         let refToFirst = Memory.ReferenceField state string Reflection.stringFirstCharField
         let length = Memory.StringLength state string
-        InitSpanStruct span refToFirst length
+        let spanStruct = InitSpanStruct cilState span refToFirst length
+        push spanStruct cilState
+        List.singleton cilState

--- a/VSharp.InternalCalls/Span.fsi
+++ b/VSharp.InternalCalls/Span.fsi
@@ -6,23 +6,23 @@ open VSharp.Core
 
 module internal ReadOnlySpan =
 
-    val internal GetContentsRef : state -> term -> term
-    val internal GetLength : state -> term -> term
+    val GetContentsRef : state -> term -> term
+    val GetLength : state -> term -> term
 
     [<Implements("T& System.ReadOnlySpan`1[T].get_Item(this, System.Int32)")>]
-    val internal GetItemFromReadOnlySpan : state -> term list -> term
+    val GetItemFromReadOnlySpan : state -> term list -> term
 
     [<Implements("T& System.Span`1[T].get_Item(this, System.Int32)")>]
-    val internal GetItemFromSpan : state -> term list -> term
+    val GetItemFromSpan : state -> term list -> term
 
     [<Implements("System.Void System.Span`1[T]..ctor(this, System.Void*, System.Int32)")>]
-    val internal CtorFromPtrForSpan : state -> term list -> (term * state) list
+    val CtorFromPtrForSpan : state -> term list -> (term * state) list
 
     [<Implements("System.Void System.ReadOnlySpan`1[T]..ctor(this, System.Void*, System.Int32)")>]
-    val internal CtorFromPtrForReadOnlySpan : state -> term list -> (term * state) list
+    val CtorFromPtrForReadOnlySpan : state -> term list -> (term * state) list
 
     [<Implements("System.Void System.ReadOnlySpan`1[T]..ctor(this, T[])")>]
-    val internal CtorFromArrayForReadOnlySpan : state -> term list -> (term * state) list
+    val CtorFromArrayForReadOnlySpan : state -> term list -> (term * state) list
 
     [<Implements("System.ReadOnlySpan`1[System.Char] System.String.op_Implicit(System.String)")>]
     val ReadOnlySpanCreateFromString : state -> term list -> term

--- a/VSharp.InternalCalls/Span.fsi
+++ b/VSharp.InternalCalls/Span.fsi
@@ -3,26 +3,24 @@ namespace VSharp.System
 open global.System
 open VSharp
 open VSharp.Core
+open VSharp.Interpreter.IL
 
 module internal ReadOnlySpan =
 
-    val GetContentsRef : state -> term -> term
+    val GetContents : cilState -> term -> term * term
     val GetLength : state -> term -> term
 
     [<Implements("T& System.ReadOnlySpan`1[T].get_Item(this, System.Int32)")>]
-    val GetItemFromReadOnlySpan : state -> term list -> term
-
     [<Implements("T& System.Span`1[T].get_Item(this, System.Int32)")>]
-    val GetItemFromSpan : state -> term list -> term
-
-    [<Implements("System.Void System.Span`1[T]..ctor(this, System.Void*, System.Int32)")>]
-    val CtorFromPtrForSpan : state -> term list -> (term * state) list
+    val GetItem : IInterpreter -> cilState -> term list -> cilState list
 
     [<Implements("System.Void System.ReadOnlySpan`1[T]..ctor(this, System.Void*, System.Int32)")>]
-    val CtorFromPtrForReadOnlySpan : state -> term list -> (term * state) list
+    [<Implements("System.Void System.Span`1[T]..ctor(this, System.Void*, System.Int32)")>]
+    val CtorFromPtr : IInterpreter -> cilState -> term list -> cilState list
 
     [<Implements("System.Void System.ReadOnlySpan`1[T]..ctor(this, T[])")>]
-    val CtorFromArrayForReadOnlySpan : state -> term list -> (term * state) list
+    [<Implements("System.Void System.Span`1[T]..ctor(this, T[])")>]
+    val CtorFromArray : IInterpreter -> cilState -> term list -> cilState list
 
     [<Implements("System.ReadOnlySpan`1[System.Char] System.String.op_Implicit(System.String)")>]
-    val ReadOnlySpanCreateFromString : state -> term list -> term
+    val CreateFromString : IInterpreter -> cilState -> term list -> cilState list

--- a/VSharp.InternalCalls/String.fs
+++ b/VSharp.InternalCalls/String.fs
@@ -25,15 +25,13 @@ module internal String =
         Memory.StringFromReplicatedChar state this char length
         Nop()
 
-    let CtorFromSpan (state : state) (args : term list) : term =
+    let CtorFromSpan (_ : IInterpreter) (cilState : cilState) (args : term list) : cilState list =
         assert(List.length args = 2)
         let this, span = args[0], args[1]
-        let ref = ReadOnlySpan.GetContentsRef state span
+        let ref, len = ReadOnlySpan.GetContents cilState span
         assert(TypeOf ref |> TypeUtils.isArrayType)
-        let len = ReadOnlySpan.GetLength state span
-        match Memory.StringCtorOfCharArrayAndLen state ref this len with
-        | [ _ ] -> Nop()
-        | _ -> internalfail "CtorFromSpan: need to branch execution"
+        let states = Memory.StringCtorOfCharArrayAndLen cilState.state ref this len
+        List.map (changeState cilState) states
 
     let CtorFromPtr (i : IInterpreter) (cilState : cilState) (args : term list) =
         assert(List.length args = 4)

--- a/VSharp.InternalCalls/String.fs
+++ b/VSharp.InternalCalls/String.fs
@@ -2,8 +2,12 @@ namespace VSharp.System
 
 open FSharpx.Collections
 open global.System
+
 open VSharp
 open VSharp.Core
+open VSharp.Interpreter.IL
+open VSharp.Interpreter.IL.CilStateOperations
+open VSharp.Core.API.Arithmetics
 
 // ------------------------------- mscorlib.System.Array -------------------------------
 
@@ -17,7 +21,7 @@ module internal String =
 
     let CtorFromReplicatedChar state args =
         assert(List.length args = 3)
-        let this, char, length = args.[0], args.[1], args.[2]
+        let this, char, length = args[0], args[1], args[2]
         Memory.StringFromReplicatedChar state this char length
         Nop()
 
@@ -30,6 +34,41 @@ module internal String =
         match Memory.StringCtorOfCharArrayAndLen state ref this len with
         | [ _ ] -> Nop()
         | _ -> internalfail "CtorFromSpan: need to branch execution"
+
+    let CtorFromPtr (i : IInterpreter) (cilState : cilState) (args : term list) =
+        assert(List.length args = 4)
+        let this = args[0]
+        let ptr = args[1]
+        let startIndex = args[2]
+        let length = args[3]
+        let zero = MakeNumber 0
+        let rangeCheck() =
+            (length >>= zero)
+            &&& (startIndex >>= zero)
+        let copy cilState k =
+            let cilStates = writeClassField cilState this Reflection.stringLengthField length
+            for cilState in cilStates do
+                Buffer.CommonMemmove cilState.state this None ptr (Some startIndex) length
+            k cilStates
+        let checkPtr cilState k =
+            StatedConditionalExecutionCIL cilState
+                (fun state k -> k (!!(IsBadRef ptr), state))
+                copy
+                (i.Raise i.ArgumentOutOfRangeException)
+                k
+        let emptyStringCase cilState k =
+            writeClassField cilState this Reflection.stringLengthField zero |> k
+        let checkLength cilState k =
+            StatedConditionalExecutionCIL cilState
+                (fun state k -> k (length === zero, state))
+                emptyStringCase
+                checkPtr
+                k
+        StatedConditionalExecutionCIL cilState
+            (fun state k -> k (rangeCheck(), state))
+            checkLength
+            (i.Raise i.ArgumentOutOfRangeException)
+            id
 
     let GetLength (state : state) (args : term list) =
         assert(List.length args = 1)
@@ -93,3 +132,32 @@ module internal String =
         assert(List.length args = 1)
         let length = List.head args
         Memory.AllocateEmptyString state length
+
+    let FillStringChecked (interpreter : IInterpreter) (cilState : cilState) (args : term list) =
+        assert(List.length args = 3)
+        let state = cilState.state
+        let dest, destPos, src = args[0], args[1], args[2]
+        let srcPos = MakeNumber 0
+        let srcLength = Memory.StringLength state src
+        let destLength = Memory.StringLength state dest
+        let (<<=) = Arithmetics.(<<=)
+        let check = srcLength <<= (Arithmetics.Sub destLength destPos)
+        let copy (cilState : cilState) k =
+            Memory.CopyStringArray cilState.state src srcPos dest destPos srcLength
+            k [cilState]
+        StatedConditionalExecutionCIL cilState
+            (fun state k -> k (check, state))
+            copy
+            (interpreter.Raise interpreter.IndexOutOfRangeException)
+            id
+
+    let GetChars (interpreter : IInterpreter) (cilState : cilState) (args : term list) =
+        assert(List.length args = 2)
+        let this = args[0]
+        let index = args[1]
+        let length = Memory.StringLength cilState.state this
+        let getChar cilState k =
+            let char = Memory.ReadStringChar cilState.state this index
+            push char cilState
+            List.singleton cilState |> k
+        interpreter.AccessArray getChar cilState length index id

--- a/VSharp.InternalCalls/String.fsi
+++ b/VSharp.InternalCalls/String.fsi
@@ -16,7 +16,7 @@ module internal String =
     val CtorFromReplicatedChar : state -> term list -> term
 
     [<Implements("System.Void System.String..ctor(this, System.ReadOnlySpan`1[System.Char])")>]
-    val CtorFromSpan : state -> term list -> term
+    val CtorFromSpan : IInterpreter -> cilState -> term list -> cilState list
 
     [<Implements("System.Void System.String..ctor(this, System.Char*, System.Int32, System.Int32)")>]
     val CtorFromPtr : IInterpreter -> cilState -> term list -> cilState list

--- a/VSharp.InternalCalls/String.fsi
+++ b/VSharp.InternalCalls/String.fsi
@@ -3,6 +3,7 @@ namespace VSharp.System
 open global.System
 open VSharp
 open VSharp.Core
+open VSharp.Interpreter.IL
 
 // ------------------------------- mscorlib.System.String -------------------------------
 
@@ -16,6 +17,9 @@ module internal String =
 
     [<Implements("System.Void System.String..ctor(this, System.ReadOnlySpan`1[System.Char])")>]
     val CtorFromSpan : state -> term list -> term
+
+    [<Implements("System.Void System.String..ctor(this, System.Char*, System.Int32, System.Int32)")>]
+    val CtorFromPtr : IInterpreter -> cilState -> term list -> cilState list
 
     [<Implements("System.Int32 System.String.get_Length(this)")>]
     val GetLength : state -> term list -> term
@@ -35,3 +39,9 @@ module internal String =
 
     [<Implements("System.String System.String.FastAllocateString(System.Int32)")>]
     val FastAllocateString : state -> term list -> term
+
+    [<Implements("System.Void System.String.FillStringChecked(System.String, System.Int32, System.String)")>]
+    val FillStringChecked : IInterpreter -> cilState -> term list -> cilState list
+
+    [<Implements("System.Char System.String.get_Chars(this, System.Int32)")>]
+    val GetChars : IInterpreter -> cilState -> term list -> cilState list

--- a/VSharp.InternalCalls/SystemArray.fsi
+++ b/VSharp.InternalCalls/SystemArray.fsi
@@ -3,6 +3,7 @@ namespace VSharp.System
 open global.System
 open VSharp
 open VSharp.Core
+open VSharp.Interpreter.IL
 
 // ------------------------------- mscorlib.System.Array -------------------------------
 
@@ -25,3 +26,27 @@ module internal SystemArray =
 
     [<Implements("T System.SZArrayHelper.get_Item(this, System.Int32)")>]
     val GetItem : state -> term list -> term
+
+    [<Implements("System.Int32 System.Array.GetLength(this, System.Int32)")>]
+    val GetArrayLength : IInterpreter -> cilState -> term list -> cilState list
+
+    [<Implements("System.Int32 System.Array.GetLowerBound(this, System.Int32)")>]
+    val GetArrayLowerBound : IInterpreter -> cilState -> term list -> cilState list
+
+    [<Implements("System.Void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)")>]
+    val CommonInitializeArray : IInterpreter -> cilState -> term list -> cilState list
+
+    [<Implements("System.Void System.Array.Clear(System.Array, System.Int32, System.Int32)")>]
+    val Clear : IInterpreter -> cilState -> term list -> cilState list
+
+    [<Implements("System.Void System.Array.Copy(System.Array, System.Int32, System.Array, System.Int32, System.Int32, System.Boolean)")>]
+    val CopyArrayExtendedForm1 : IInterpreter -> cilState -> term list -> cilState list
+
+    [<Implements("System.Void System.Array.Copy(System.Array, System.Int32, System.Array, System.Int32, System.Int32)")>]
+    val CopyArrayExtendedForm2 : IInterpreter -> cilState -> term list -> cilState list
+
+    [<Implements("System.Void System.Array.Copy(System.Array, System.Array, System.Int32)")>]
+    val CopyArrayShortForm : IInterpreter -> cilState -> term list -> cilState list
+
+    [<Implements("System.Void System.Array.Fill(T[], T)")>]
+    val FillArray : IInterpreter -> cilState -> term list -> cilState list

--- a/VSharp.InternalCalls/Thread.fsi
+++ b/VSharp.InternalCalls/Thread.fsi
@@ -3,25 +3,32 @@ namespace VSharp.System
 open global.System
 open VSharp
 open VSharp.Core
+open VSharp.Interpreter.IL
 
 // ------------------------------ mscorlib.System.Threading.Thread --------------------------------
 
-module Thread =
+module internal Thread =
 
     [<Implements("System.AppDomain System.Threading.Thread.GetFastDomainInternal()")>]
-    val internal GetFastDomainInternal : state -> term list -> term
+    val GetFastDomainInternal : state -> term list -> term
 
     [<Implements("System.AppDomain System.Threading.Thread.GetDomainInternal()")>]
-    val internal GetDomainInternal : state -> term list -> term
+    val GetDomainInternal : state -> term list -> term
 
     [<Implements("System.Void System.Threading.Thread.SpinWaitInternal(System.Int32)")>]
-    val internal SpinWaitInternal : state -> term list -> term
+    val SpinWaitInternal : state -> term list -> term
 
     [<Implements("System.Void System.Threading.SpinWait.SpinOnce(this)")>]
-    val internal SpinOnce : state -> term list -> term
+    val SpinOnce : state -> term list -> term
 
     [<Implements("System.Boolean System.Threading.Thread.Yield()")>]
-    val internal Yield : state -> term list -> term
+    val Yield : state -> term list -> term
 
     [<Implements("System.Void System.Threading.Thread.SleepInternal(System.Int32)")>]
-    val internal SleepInternal : state -> term list -> term
+    val SleepInternal : state -> term list -> term
+
+    [<Implements("System.Void System.Threading.Monitor.ReliableEnter(System.Object, System.Boolean&)")>]
+    val MonitorReliableEnter : IInterpreter -> cilState -> term list -> cilState list
+
+    [<Implements("System.Void System.Threading.Monitor.Enter(System.Object)")>]
+    val MonitorEnter : IInterpreter -> cilState -> term list -> cilState list

--- a/VSharp.InternalCalls/Unsafe.fs
+++ b/VSharp.InternalCalls/Unsafe.fs
@@ -3,33 +3,35 @@ namespace VSharp.System
 open global.System
 open VSharp
 open VSharp.Core
+open VSharp.Interpreter.IL
+open VSharp.Interpreter.IL.CilStateOperations
 
 // ------------------------------ System.Unsafe --------------------------------
 
-module Unsafe =
+module internal Unsafe =
 
-    let internal AsPointer (_ : state) (args : term list) : term =
+    let AsPointer (_ : state) (args : term list) : term =
         assert(List.length args = 2)
 //        Types.Cast (List.item 1 args) (Pointer Void)
         List.item 1 args
 
-    let internal ObjectAsT (_ : state) (args : term list) : term =
+    let ObjectAsT (_ : state) (args : term list) : term =
         assert(List.length args = 2)
         let typ, ref = args[0], args[1]
         let typ = Helpers.unwrapType typ
         Types.Cast ref typ
 
-    let internal AsRef (_ : state) (args : term list) : term =
+    let AsRef (_ : state) (args : term list) : term =
         assert(List.length args = 2)
         let t = Helpers.unwrapType args[0]
         let ptr = args[1]
         Types.Cast ptr (t.MakePointerType())
 
-    let internal PointerAsRef (_ : state) (args : term list) : term =
+    let PointerAsRef (_ : state) (args : term list) : term =
         assert(List.length args = 2)
-        args.[1]
+        args[1]
 
-    let internal TFromAsTTo (_ : state) (args : term list) : term =
+    let TFromAsTTo (_ : state) (args : term list) : term =
         assert(List.length args = 3)
         let toType = Helpers.unwrapType args[1]
         let pointerType = toType.MakePointerType()
@@ -37,22 +39,22 @@ module Unsafe =
         assert(IsReference ref || IsPtr ref)
         Types.Cast ref pointerType
 
-    let internal NullRef (_ : state) (args : term list) : term =
+    let NullRef (_ : state) (args : term list) : term =
         match args with
         | [{term = Concrete(:? Type as t, _)}] -> NullRef t
         | _ -> __unreachable__()
 
-    let internal IsNullRef (_ : state) (args : term list) : term =
+    let IsNullRef (_ : state) (args : term list) : term =
         assert(List.length args = 2)
         let ref = args[1]
         IsNullReference ref
 
-    let internal AddByteOffset (_ : state) (args : term list) : term =
+    let AddByteOffset (_ : state) (args : term list) : term =
         assert(List.length args = 3)
         let ref, offset = args[1], args[2]
         PerformBinaryOperation OperationType.Add ref offset id
 
-    let internal ByteOffset (_ : state) (args : term list) : term =
+    let ByteOffset (_ : state) (args : term list) : term =
         assert(List.length args = 2)
         let origin, target = args[0], args[1]
         let offset = PerformBinaryOperation OperationType.Subtract target origin id
@@ -63,42 +65,47 @@ module Unsafe =
         let byteOffset = Arithmetics.Mul offset size
         PerformBinaryOperation OperationType.Add ref byteOffset id
 
-    let internal AddIntPtr (_ : state) (args : term list) : term =
+    let AddIntPtr (_ : state) (args : term list) : term =
         assert(List.length args = 3)
         let typ, ref, offset = args[0], args[1], args[2]
         CommonAdd typ ref offset
 
-    let internal AddInt (_ : state) (args : term list) : term =
+    let AddInt (_ : state) (args : term list) : term =
         assert(List.length args = 3)
         let typ, ref, offset = args[0], args[1], args[2]
         CommonAdd typ ref offset
 
-    let internal ReadUnaligned (state : state) (args : term list) : term =
+    let ReadUnaligned (i : IInterpreter) (cilState : cilState) (args : term list) =
         assert(List.length args = 2)
         let typ, ref = args[0], args[1]
         let typ = Helpers.unwrapType typ
         let castedPtr = Types.Cast ref (typ.MakePointerType())
-        Memory.Read state castedPtr
+        let readByPtr cilState k =
+            let value = read cilState castedPtr
+            push value cilState
+            List.singleton cilState |> k
+        i.NpeOrInvoke cilState castedPtr readByPtr id
 
-    let WriteUnaligned (state : state) (args : term list) : (term * state) list =
+    let WriteUnaligned (i : IInterpreter) (cilState : cilState) (args : term list) =
         assert(List.length args = 3)
         let typ, ref, value = args[0], args[1], args[2]
         let typ = Helpers.unwrapType typ
         let castedPtr = Types.Cast ref (typ.MakePointerType())
-        let states = Memory.Write state castedPtr value
-        List.map (withFst <| Nop()) states
+        let writeByPtr cilState k =
+            write cilState castedPtr value |> k
+        i.NpeOrInvoke cilState castedPtr writeByPtr id
 
-    let internal SizeOf (_ : state) (args : term list) : term =
+    let SizeOf (_ : state) (args : term list) : term =
         assert(List.length args = 1)
         let typ = Helpers.unwrapType args[0]
         Types.SizeOf typ |> MakeNumber
 
-    let internal AreSame (_ : state) (args : term list) : term =
+    let AreSame (_ : state) (args : term list) : term =
         assert(List.length args = 3)
         let ptr1, ptr2 = args[1], args[2]
         ptr1 === ptr2
 
-    let internal GetRawData (state : state) (args : term list) : term =
+    let GetRawData (state : state) (args : term list) : term =
         assert(List.length args = 1)
         let ref = args[0]
         match ref.term with
@@ -109,5 +116,5 @@ module Unsafe =
             Ptr (HeapLocation(address, t)) typeof<byte> (MakeNumber 0)
         | _ -> internalfail $"GetRawData: unexpected ref {ref}"
 
-    let internal SkipInit (_ : state) (_ : term list) : term =
+    let SkipInit (_ : state) (_ : term list) : term =
         Nop()

--- a/VSharp.InternalCalls/Unsafe.fsi
+++ b/VSharp.InternalCalls/Unsafe.fsi
@@ -8,72 +8,72 @@ module internal Unsafe =
 
     [<Implements("System.Void* Internal.Runtime.CompilerServices.Unsafe.AsPointer(T&)")>]
     [<Implements("System.Void* System.Runtime.CompilerServices.Unsafe.AsPointer(T&)")>]
-    val internal AsPointer : state -> term list -> term
+    val AsPointer : state -> term list -> term
 
     [<Implements("T Internal.Runtime.CompilerServices.Unsafe.As(System.Object)")>]
     [<Implements("T System.Runtime.CompilerServices.Unsafe.As(System.Object)")>]
-    val internal ObjectAsT : state -> term list -> term
+    val ObjectAsT : state -> term list -> term
 
     [<Implements("T& Internal.Runtime.CompilerServices.Unsafe.AsRef(T&)")>]
     [<Implements("T& System.Runtime.CompilerServices.Unsafe.AsRef(T&)")>]
-    val internal AsRef : state -> term list -> term
+    val AsRef : state -> term list -> term
 
     [<Implements("T& Internal.Runtime.CompilerServices.Unsafe.AsRef(System.Void*)")>]
     [<Implements("T& System.Runtime.CompilerServices.Unsafe.AsRef(System.Void*)")>]
-    val internal PointerAsRef : state -> term list -> term
+    val PointerAsRef : state -> term list -> term
 
     [<Implements("TTo& Internal.Runtime.CompilerServices.Unsafe.As(TFrom&)")>]
     [<Implements("TTo& System.Runtime.CompilerServices.Unsafe.As(TFrom&)")>]
-    val internal TFromAsTTo : state -> term list -> term
+    val TFromAsTTo : state -> term list -> term
 
     [<Implements("T& Internal.Runtime.CompilerServices.Unsafe.NullRef()")>]
     [<Implements("T& System.Runtime.CompilerServices.Unsafe.NullRef()")>]
-    val internal NullRef : state -> term list -> term
+    val NullRef : state -> term list -> term
 
     [<Implements("System.Boolean Internal.Runtime.CompilerServices.Unsafe.IsNullRef(T&)")>]
     [<Implements("System.Boolean System.Runtime.CompilerServices.Unsafe.IsNullRef(T&)")>]
-    val internal IsNullRef : state -> term list -> term
+    val IsNullRef : state -> term list -> term
 
     [<Implements("T& Internal.Runtime.CompilerServices.Unsafe.AddByteOffset(T&, System.UIntPtr)")>]
     [<Implements("T& System.Runtime.CompilerServices.Unsafe.AddByteOffset(T&, System.UIntPtr)")>]
     [<Implements("T& Internal.Runtime.CompilerServices.Unsafe.AddByteOffset(T&, System.IntPtr)")>]
     [<Implements("T& System.Runtime.CompilerServices.Unsafe.AddByteOffset(T&, System.IntPtr)")>]
-    val internal AddByteOffset : state -> term list -> term
+    val AddByteOffset : state -> term list -> term
 
     [<Implements("System.IntPtr Internal.Runtime.CompilerServices.Unsafe.ByteOffset(System.Byte&, System.Byte&)")>]
     [<Implements("System.IntPtr System.Runtime.CompilerServices.Unsafe.ByteOffset(System.Byte&, System.Byte&)")>]
-    val internal ByteOffset : state -> term list -> term
+    val ByteOffset : state -> term list -> term
 
     [<Implements("T& Internal.Runtime.CompilerServices.Unsafe.Add(T&, System.IntPtr)")>]
     [<Implements("T& System.Runtime.CompilerServices.Unsafe.Add(T&, System.IntPtr)")>]
     [<Implements("T& Internal.Runtime.CompilerServices.Unsafe.Add(T&, System.UIntPtr)")>]
     [<Implements("T& System.Runtime.CompilerServices.Unsafe.Add(T&, System.UIntPtr)")>]
-    val internal AddIntPtr : state -> term list -> term
+    val AddIntPtr : state -> term list -> term
 
     [<Implements("T& Internal.Runtime.CompilerServices.Unsafe.Add(T&, System.Int32)")>]
     [<Implements("T& System.Runtime.CompilerServices.Unsafe.Add(T&, System.Int32)")>]
-    val internal AddInt : state -> term list -> term
+    val AddInt : state -> term list -> term
 
     [<Implements("T Internal.Runtime.CompilerServices.Unsafe.ReadUnaligned(System.Byte&)")>]
     [<Implements("T System.Runtime.CompilerServices.Unsafe.ReadUnaligned(System.Byte&)")>]
-    val internal ReadUnaligned : state -> term list -> term
+    val ReadUnaligned : state -> term list -> term
 
     [<Implements("System.Void Internal.Runtime.CompilerServices.Unsafe.WriteUnaligned(System.Byte&, T)")>]
     [<Implements("System.Void System.Runtime.CompilerServices.Unsafe.WriteUnaligned(System.Byte&, T)")>]
-    val internal WriteUnaligned : state -> term list -> (term * state) list
+    val WriteUnaligned : state -> term list -> (term * state) list
 
     [<Implements("System.Int32 Internal.Runtime.CompilerServices.Unsafe.SizeOf()")>]
     [<Implements("System.Int32 System.Runtime.CompilerServices.Unsafe.SizeOf()")>]
-    val internal SizeOf : state -> term list -> term
+    val SizeOf : state -> term list -> term
 
     [<Implements("System.Boolean Internal.Runtime.CompilerServices.Unsafe.AreSame(T&, T&)")>]
     [<Implements("System.Boolean System.Runtime.CompilerServices.Unsafe.AreSame(T&, T&)")>]
-    val internal AreSame : state -> term list -> term
+    val AreSame : state -> term list -> term
 
     [<Implements("System.Byte& System.Runtime.CompilerServices.RuntimeHelpers.GetRawData(System.Object)")>]
     [<Implements("System.Byte& Internal.Runtime.CompilerServices.RuntimeHelpers.GetRawData(System.Object)")>]
-    val internal GetRawData : state -> term list -> term
+    val GetRawData : state -> term list -> term
 
     [<Implements("System.Void Internal.Runtime.CompilerServices.Unsafe.SkipInit(T&)")>]
     [<Implements("System.Void System.Runtime.CompilerServices.Unsafe.SkipInit(T&)")>]
-    val internal SkipInit : state -> term list -> term
+    val SkipInit : state -> term list -> term

--- a/VSharp.InternalCalls/Unsafe.fsi
+++ b/VSharp.InternalCalls/Unsafe.fsi
@@ -3,6 +3,7 @@ namespace VSharp.System
 open global.System
 open VSharp
 open VSharp.Core
+open VSharp.Interpreter.IL
 
 module internal Unsafe =
 
@@ -56,11 +57,11 @@ module internal Unsafe =
 
     [<Implements("T Internal.Runtime.CompilerServices.Unsafe.ReadUnaligned(System.Byte&)")>]
     [<Implements("T System.Runtime.CompilerServices.Unsafe.ReadUnaligned(System.Byte&)")>]
-    val ReadUnaligned : state -> term list -> term
+    val ReadUnaligned : IInterpreter -> cilState -> term list -> cilState list
 
     [<Implements("System.Void Internal.Runtime.CompilerServices.Unsafe.WriteUnaligned(System.Byte&, T)")>]
     [<Implements("System.Void System.Runtime.CompilerServices.Unsafe.WriteUnaligned(System.Byte&, T)")>]
-    val WriteUnaligned : state -> term list -> (term * state) list
+    val WriteUnaligned : IInterpreter -> cilState -> term list -> cilState list
 
     [<Implements("System.Int32 Internal.Runtime.CompilerServices.Unsafe.SizeOf()")>]
     [<Implements("System.Int32 System.Runtime.CompilerServices.Unsafe.SizeOf()")>]

--- a/VSharp.InternalCalls/VSharp.InternalCalls.fsproj
+++ b/VSharp.InternalCalls/VSharp.InternalCalls.fsproj
@@ -42,10 +42,10 @@
         <Compile Include="ByReference.fs" />
         <Compile Include="Span.fsi" />
         <Compile Include="Span.fs" />
-        <Compile Include="String.fsi" />
-        <Compile Include="String.fs" />
         <Compile Include="Buffer.fsi" />
         <Compile Include="Buffer.fs" />
+        <Compile Include="String.fsi" />
+        <Compile Include="String.fs" />
         <Compile Include="EqualityComparer.fsi" />
         <Compile Include="EqualityComparer.fs" />
         <Compile Include="ChessDotNet.fsi" />
@@ -56,17 +56,23 @@
         <Compile Include="Interlocked.fs" />
         <Compile Include="Globalization.fsi" />
         <Compile Include="Globalization.fs" />
+        <Compile Include="Diagnostics.fsi" />
+        <Compile Include="Diagnostics.fs" />
+        <Compile Include="HashHelpers.fsi" />
+        <Compile Include="HashHelpers.fs" />
+        <Compile Include="Delegate.fsi" />
+        <Compile Include="Delegate.fs" />
         <Compile Include="PlatformHelper.fsi" />
         <Compile Include="PlatformHelper.fs" />
         <Compile Include="InteropServices.fsi" />
         <Compile Include="InteropServices.fs" />
         <Compile Include="Activator.fsi" />
         <Compile Include="Activator.fs" />
-        <Compile Include="Loader.fs" />
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\VSharp.SILI.Core\VSharp.SILI.Core.fsproj" />
+      <ProjectReference Include="..\VSharp.SILI\VSharp.SILI.fsproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/VSharp.InternalCalls/Volatile.fsi
+++ b/VSharp.InternalCalls/Volatile.fsi
@@ -6,7 +6,7 @@ open VSharp.Core
 
 // ------------------------------ mscorlib.System.Threading.Volatile --------------------------------
 
-module Volatile =
+module internal Volatile =
 
     [<Implements("T System.Threading.Volatile.Read(T&)")>]
-    val internal Read : state -> term list -> term
+    val Read : state -> term list -> term

--- a/VSharp.SILI.Core/API.fs
+++ b/VSharp.SILI.Core/API.fs
@@ -327,8 +327,11 @@ module API =
             let indices = List.map (fun i -> primitiveCast i typeof<int>) indices
             match arrayRef.term with
             | HeapRef(addr, typ) ->
-                let elemType, dim, _ as arrayType =
-                    Memory.mostConcreteTypeOfHeapRef state addr typ |> symbolicTypeToArrayType
+                let t = Memory.mostConcreteTypeOfHeapRef state addr typ
+                let addr, (elemType, dim, _ as arrayType) =
+                    if TypeUtils.isArrayType t then
+                        addr, symbolicTypeToArrayType t
+                    else StringArrayInfo state addr None
                 assert(dim = List.length indices)
                 match valueType with
                 | Some valueType when not (IsSafeContext elemType valueType) ->

--- a/VSharp.SILI.Core/API.fs
+++ b/VSharp.SILI.Core/API.fs
@@ -142,7 +142,8 @@ module API =
             | {term = Ptr(HeapLocation(addr, _), _, offset)} when addr = zeroAddress() && offset = makeNumber 0 -> Some()
             | _ -> None
 
-        let (|DetachedPtr|_|) term = (|DetachedPtr|_|) term.term
+        let (|DetachedPtr|_|) term = (|DetachedPtr|_|) term
+        let (|DetachedPtrTerm|_|) term = (|DetachedPtr|_|) term.term
 
         let (|StackReading|_|) src = Memory.(|StackReading|_|) src
         let (|HeapReading|_|) src = Memory.(|HeapReading|_|) src
@@ -242,13 +243,19 @@ module API =
 
     module public Arithmetics =
         let (===) x y = simplifyEqual x y id
+        let Equality x y = simplifyEqual x y id
         let (!==) x y = simplifyNotEqual x y id
+        let Inequality x y = simplifyNotEqual x y id
         let (<<) x y = simplifyLess x y id
+        let Less x y = simplifyLess x y id
         let (<<=) x y = simplifyLessOrEqual x y id
+        let LessOrEqual x y = simplifyLessOrEqual x y id
         let (>>) x y = simplifyGreater x y id
+        let Greater x y = simplifyGreater x y id
         let (>>=) x y = simplifyGreaterOrEqual x y id
-        let (%%%) x y = simplifyRemainder true (TypeOf x) x y id
+        let GreaterOrEqual x y = simplifyGreaterOrEqual x y id
         let GreaterOrEqualUn x y = simplifyGreaterOrEqualUn x y id
+        let (%%%) x y = simplifyRemainder true (TypeOf x) x y id
 
         let Mul x y = mul x y
         let Sub x y = sub x y

--- a/VSharp.SILI.Core/API.fs
+++ b/VSharp.SILI.Core/API.fs
@@ -114,8 +114,8 @@ module API =
 
         let ReinterpretConcretes terms t = reinterpretConcretes terms t
 
-        let TryPtrToArrayInfo pointerBase sightType offset =
-            Memory.tryPtrToArrayInfo pointerBase sightType offset
+        let TryPtrToRef state pointerBase sightType offset =
+            Memory.tryPtrToRef state pointerBase sightType offset
 
         let TryTermToObj state term = Memory.tryTermToObj state term
 
@@ -190,11 +190,7 @@ module API =
 
         let SpecializeWithKey constant key writeKey = Memory.specializeWithKey constant key writeKey
 
-        let rec HeapReferenceToBoxReference reference =
-            match reference.term with
-            | HeapRef(address, typ) -> Ref (BoxedLocation(address, typ))
-            | Union gvs -> gvs |> List.map (fun (g, v) -> (g, HeapReferenceToBoxReference v)) |> Merging.merge
-            | _ -> internalfailf "Unboxing: expected heap reference, but got %O" reference
+        let HeapReferenceToBoxReference reference = Memory.heapReferenceToBoxReference reference
 
         let AddConstraint conditionState condition =
             Memory.addConstraint conditionState condition
@@ -364,42 +360,8 @@ module API =
             | Union gvs -> gvs |> List.map (fun (g, v) -> (g, ReferenceArrayIndex state v indices valueType)) |> Merging.merge
             | _ -> internalfailf "Referencing array index: expected reference, but got %O" arrayRef
 
-        let rec ReferenceField state reference fieldId =
-            let declaringType = fieldId.declaringType
-            let isSuitableField address typ =
-                let typ = Memory.mostConcreteTypeOfHeapRef state address typ
-                declaringType.IsAssignableFrom typ
-            match reference.term with
-            | HeapRef(address, typ) when isSuitableField address typ |> not ->
-                // TODO: check this case with casting via "is"
-                Logger.trace "[WARNING] unsafe cast of term %O in safe context" reference
-                let offset = Reflection.getFieldIdOffset fieldId |> MakeNumber
-                Ptr (HeapLocation(address, typ)) fieldId.typ offset
-            | HeapRef(address, typ) when typ = typeof<string> && fieldId = Reflection.stringFirstCharField ->
-                let address, arrayType = Memory.stringArrayInfo state address None
-                ArrayIndex(address, [makeNumber 0], arrayType) |> Ref
-            | HeapRef(address, typ) when declaringType.IsValueType ->
-                // TODO: Need to check mostConcreteTypeOfHeapRef using pathCondition?
-                assert(isSuitableField address typ)
-                let ref = HeapReferenceToBoxReference reference
-                ReferenceField state ref fieldId
-            | HeapRef(address, typ) ->
-                // TODO: Need to check mostConcreteTypeOfHeapRef using pathCondition?
-                assert(isSuitableField address typ)
-                ClassField(address, fieldId) |> Ref
-            | Ref address when declaringType.IsAssignableFrom(address.TypeOfLocation) ->
-                assert declaringType.IsValueType
-                StructField(address, fieldId) |> Ref
-            | Ref address ->
-                assert declaringType.IsValueType
-                let pointerBase, offset = AddressToBaseAndOffset address
-                let fieldOffset = Reflection.getFieldIdOffset fieldId |> makeNumber
-                Ptr pointerBase fieldId.typ (add offset fieldOffset)
-            | Ptr(baseAddress, _, offset) ->
-                let fieldOffset = Reflection.getFieldIdOffset fieldId |> makeNumber
-                Ptr baseAddress fieldId.typ (add offset fieldOffset)
-            | Union gvs -> gvs |> List.map (fun (g, v) -> (g, ReferenceField state v fieldId)) |> Merging.merge
-            | _ -> internalfailf "Referencing field: expected reference, but got %O" reference
+        let ReferenceField state reference fieldId =
+            Memory.referenceField state reference fieldId
 
         let private transformBoxedRef ref =
             match ref.term with
@@ -424,8 +386,8 @@ module API =
                 | HeapRef _
                 | Ptr _
                 | Ref _ -> ReferenceField state target field |> Memory.read reporter state
-                | Struct _ -> Memory.readStruct reporter target field
-                | Combined _ -> Memory.readFieldUnsafe reporter target field
+                | Struct _ -> Memory.readStruct reporter state target field
+                | Combined _ -> Memory.readFieldUnsafe reporter state target field
                 | _ -> internalfailf "Reading field of %O" term
             Merging.guardedApply doRead term
 

--- a/VSharp.SILI.Core/API.fsi
+++ b/VSharp.SILI.Core/API.fsi
@@ -99,7 +99,8 @@ module API =
         val (|NullRef|_|) : term -> Type option
         val (|NonNullRef|_|) : term -> unit option
         val (|NullPtr|_|) : term -> unit option
-        val (|DetachedPtr|_|) : term -> term option
+        val (|DetachedPtr|_|) : termNode -> term option
+        val (|DetachedPtrTerm|_|) : term -> term option
 
         val (|StackReading|_|) : ISymbolicConstantSource -> option<stackKey>
         val (|HeapReading|_|) : ISymbolicConstantSource -> option<heapAddressKey * memoryRegion<heapAddressKey, vectorTime intervals>>
@@ -194,6 +195,12 @@ module API =
         // Lightweight version: divide by zero exceptions are ignored!
         val (%%%) : term -> term -> term
         val GreaterOrEqualUn : term -> term -> term
+        val Equality : term -> term -> term
+        val Inequality : term -> term -> term
+        val Less : term -> term -> term
+        val LessOrEqual : term -> term -> term
+        val Greater : term -> term -> term
+        val GreaterOrEqual : term -> term -> term
         val Mul : term -> term -> term
         val Sub : term -> term -> term
         val Add : term -> term -> term

--- a/VSharp.SILI.Core/API.fsi
+++ b/VSharp.SILI.Core/API.fsi
@@ -71,7 +71,7 @@ module API =
 
         val ReinterpretConcretes : term list -> Type -> obj
 
-        val TryPtrToArrayInfo : Type -> Type -> term -> option<term list * arrayType>
+        val TryPtrToRef : state -> pointerBase -> Type -> term -> option<address>
 
         val TryTermToObj : state -> term -> obj option
 

--- a/VSharp.SILI.Core/Branching.fs
+++ b/VSharp.SILI.Core/Branching.fs
@@ -2,7 +2,7 @@ namespace VSharp.Core
 
 open VSharp
 
-module Branching =
+module internal Branching =
 
     let checkSat state = SolverInteraction.checkSatWithSubtyping state
 

--- a/VSharp.SILI.Core/ConcreteMemory.fs
+++ b/VSharp.SILI.Core/ConcreteMemory.fs
@@ -73,7 +73,9 @@ type public ConcreteMemory private (physToVirt, virtToPhys) =
                 if exists && oldPhys = phys then
                     virtToPhys'.Add(virt, phys')
                 let key' = key.FromPhysicalAddress phys'
-                physToVirt'.Add(key', virt)
+                // Empty string is interned
+                if key' = RefKey {object = String.Empty} then physToVirt'[key'] <- virt
+                else physToVirt'.Add(key', virt)
             ConcreteMemory(physToVirt', virtToPhys')
 
 // ----------------------------- Primitives -----------------------------

--- a/VSharp.SILI.Core/Memory.fs
+++ b/VSharp.SILI.Core/Memory.fs
@@ -84,21 +84,6 @@ module internal Memory =
             add acc absOffset
         List.fold attachOne (makeNumber 0) [0 .. length]
 
-    let tryPtrToArrayInfo (typeOfBase : Type) sightType offset =
-        assert(typeOf offset = typeof<int>)
-        let checkType() =
-            typeOfBase.IsSZArray && typeOfBase.GetElementType() = sightType
-            || typeOfBase = typeof<string> && sightType = typeof<char>
-        let mutable elemSize = Nop()
-        let checkOffset() =
-            elemSize <- makeNumber (internalSizeOf sightType)
-            rem offset elemSize = makeNumber 0
-        if not typeOfBase.ContainsGenericParameters && checkType() && checkOffset() then
-            let arrayType = (sightType, 1, true)
-            let index = div offset elemSize
-            Some ([index], arrayType)
-        else None
-
 // -------------------------- Error reporter --------------------------
 
     type internal EmptyErrorReporter() =
@@ -965,11 +950,11 @@ module internal Memory =
             objToTerm state source typ value
         | _ -> readBoxedSymbolic state address typ
 
-    let rec readStruct reporter (structTerm : term) (field : fieldId) =
+    let rec readStruct reporter state (structTerm : term) (field : fieldId) =
         match structTerm.term with
         | Struct(fields, _) -> fields[field]
-        | Combined _ -> readFieldUnsafe reporter structTerm field
-        | _ -> internalfailf "Reading field of structure: expected struct, but got %O" structTerm
+        | Combined _ -> readFieldUnsafe reporter state structTerm field
+        | _ -> internalfail $"Reading field of structure: expected struct, but got {structTerm}"
 
     and private readSafe reporter state = function
         | PrimitiveStackLocation key -> readStackLocation state key
@@ -979,7 +964,7 @@ module internal Memory =
         | StaticField(typ, field) -> readStaticField state typ field
         | StructField(address, field) ->
             let structTerm = readSafe reporter state address
-            readStruct reporter structTerm field
+            readStruct reporter state structTerm field
         | ArrayLength(address, dimension, typ) -> readLength state address dimension typ
         | BoxedLocation(address, typ) -> readBoxedLocation state address typ
         | StackBufferIndex(key, index) -> readStackBuffer state key index
@@ -1021,35 +1006,39 @@ module internal Memory =
 
     // NOTE: returns list of slices
     // TODO: return empty if every slice is invalid
-    and private commonReadTermUnsafe (reporter : IErrorReporter) term startByte endByte pos stablePos =
-        match term.term with
-        | Struct(fields, t) -> commonReadStructUnsafe reporter fields t startByte endByte pos stablePos
-        | HeapRef _
-        | Ref _
-        | Ptr _ -> readAddressUnsafe reporter term startByte endByte
-        | Combined([t], _) -> commonReadTermUnsafe reporter t startByte endByte pos stablePos
-        | Combined(slices, _) ->
-            let readSlice part = commonReadTermUnsafe reporter part startByte endByte pos stablePos
+    and private commonReadTermUnsafe (reporter : IErrorReporter) term startByte endByte pos stablePos sightType =
+        let typ = typeOf term
+        let size = internalSizeOf typ
+        match term.term, sightType with
+        | _, Some sightType when startByte = makeNumber 0 && endByte = makeNumber size && typ = sightType ->
+            List.singleton term
+        | Struct(fields, t), _ -> commonReadStructUnsafe reporter fields t startByte endByte pos stablePos sightType
+        | HeapRef _, _
+        | Ref _, _
+        | Ptr _, _ -> readAddressUnsafe reporter term startByte endByte
+        | Combined([t], _), _ -> commonReadTermUnsafe reporter t startByte endByte pos stablePos sightType
+        | Combined(slices, _), _ ->
+            let readSlice part = commonReadTermUnsafe reporter part startByte endByte pos stablePos sightType
             List.collect readSlice slices
-        | Slice _
-        | Concrete _
-        | Constant _
-        | Expression _ ->
+        | Slice _, _
+        | Concrete _, _
+        | Constant _, _
+        | Expression _, _ ->
             sliceTerm term startByte endByte pos stablePos |> List.singleton
         | _ -> internalfailf "readTermUnsafe: unexpected term %O" term
 
-    and private readTermUnsafe reporter term startByte endByte =
-        commonReadTermUnsafe reporter term startByte endByte (neg startByte) false
+    and private readTermUnsafe reporter term startByte endByte sightType =
+        commonReadTermUnsafe reporter term startByte endByte (neg startByte) false sightType
 
-    and private readTermPartUnsafe reporter term startByte endByte =
-        commonReadTermUnsafe reporter term startByte endByte startByte true
+    and private readTermPartUnsafe reporter term startByte endByte sightType =
+        commonReadTermUnsafe reporter term startByte endByte startByte true sightType
 
-    and private commonReadStructUnsafe reporter fields structType startByte endByte pos stablePos =
+    and private commonReadStructUnsafe reporter fields structType startByte endByte pos stablePos sightType =
         let readField fieldId = fields[fieldId]
-        commonReadFieldsUnsafe reporter readField false structType startByte endByte pos stablePos
+        commonReadFieldsUnsafe reporter readField false structType startByte endByte pos stablePos sightType
 
-    and private readStructUnsafe reporter fields structType startByte endByte =
-        commonReadStructUnsafe reporter fields structType startByte endByte (neg startByte) false
+    and private readStructUnsafe reporter fields structType startByte endByte sightType =
+        commonReadStructUnsafe reporter fields structType startByte endByte (neg startByte) false sightType
 
     and private getAffectedFields reporter readField isStatic (blockType : Type) startByte endByte =
         let blockSize = Reflection.blockSize blockType
@@ -1088,23 +1077,23 @@ module internal Memory =
             List.foldBack concreteGetField allFields List.empty
         | _ -> List.map getField allFields
 
-    and private commonReadFieldsUnsafe reporter readField isStatic (blockType : Type) startByte endByte pos stablePos =
+    and private commonReadFieldsUnsafe reporter readField isStatic (blockType : Type) startByte endByte pos stablePos sightType =
         let affectedFields = getAffectedFields reporter readField isStatic blockType startByte endByte
         let readField (_, o, v, s, e) =
-            commonReadTermUnsafe reporter v s e (add pos o) stablePos
+            commonReadTermUnsafe reporter v s e (add pos o) stablePos sightType
         List.collect readField affectedFields
 
-    and private readFieldsUnsafe reporter readField isStatic (blockType : Type) startByte endByte =
-        commonReadFieldsUnsafe reporter readField isStatic blockType startByte endByte (neg startByte) false
+    and private readFieldsUnsafe reporter readField isStatic (blockType : Type) startByte endByte sightType =
+        commonReadFieldsUnsafe reporter readField isStatic blockType startByte endByte (neg startByte) false sightType
 
     // TODO: Add undefined behaviour:
     // TODO: 1. when reading info between fields
     // TODO: 3. when reading info outside block
     // TODO: 3. reinterpreting ref or ptr should return symbolic ref or ptr
-    and private readClassUnsafe reporter state address classType offset (viewSize : int) =
+    and private readClassUnsafe reporter state address classType offset (viewSize : int) sightType =
         let endByte = makeNumber viewSize |> add offset
         let readField fieldId = readClassField state address fieldId
-        readFieldsUnsafe reporter readField false classType offset endByte
+        readFieldsUnsafe reporter readField false classType offset endByte sightType
 
     and arrayIndicesToOffset state address (elementType, dim, _ as arrayType) indices =
         let lens = List.init dim (fun dim -> readLength state address (makeNumber dim) arrayType)
@@ -1135,81 +1124,165 @@ module internal Memory =
             (indices, element, startByte, endByte), add currentOffset elementSize
         List.mapFold getElement (mul firstElement elementSize) [0 .. countToRead - 1] |> fst
 
-    and private readArrayUnsafe reporter state address arrayType offset viewSize =
+    and private readArrayUnsafe reporter state address arrayType offset viewSize sightType =
         let indices = getAffectedIndices reporter state address (symbolicTypeToArrayType arrayType) offset viewSize
         let readIndex (_, elem, s, e) =
-            readTermUnsafe reporter elem s e
+            readTermUnsafe reporter elem s e sightType
         List.collect readIndex indices
 
-    and private readStringUnsafe reporter state address offset viewSize =
+    and private readStringUnsafe reporter state address offset viewSize sightType =
          // TODO: handle case, when reading string length
         let address, arrayType = stringArrayInfo state address None
         let indices = getAffectedIndices reporter state address arrayType offset viewSize
         let readChar (_, elem, s, e) =
-            readTermUnsafe reporter elem s e
+            readTermUnsafe reporter elem s e sightType
         List.collect readChar indices
 
-    and private readStaticUnsafe reporter state t offset (viewSize : int) =
+    and private readStaticUnsafe reporter state t offset (viewSize : int) sightType =
         let endByte = makeNumber viewSize |> add offset
         let readField fieldId = readStaticField state t fieldId
-        readFieldsUnsafe reporter readField true t offset endByte
+        readFieldsUnsafe reporter readField true t offset endByte sightType
 
-    and private readStackUnsafe reporter state loc offset (viewSize : int) =
+    and private readStackUnsafe reporter state loc offset (viewSize : int) sightType =
         let term = readStackLocation state loc
         let locSize = sizeOf term |> makeNumber
         let endByte = makeNumber viewSize |> add offset
         checkBlockBounds reporter locSize offset endByte
-        readTermUnsafe reporter term offset endByte
+        readTermUnsafe reporter term offset endByte sightType
 
-    and private readBoxedUnsafe reporter state loc typ offset viewSize =
+    and private readBoxedUnsafe reporter state loc typ offset viewSize sightType =
         let address = BoxedLocation(loc, typ)
         let endByte = makeNumber viewSize |> add offset
         match readSafe reporter state address with
-        | {term = Struct(fields, _)} -> readStructUnsafe reporter fields typ offset endByte
-        | term when isPrimitive typ || typ.IsEnum -> readTermUnsafe reporter term offset endByte
+        | {term = Struct(fields, _)} -> readStructUnsafe reporter fields typ offset endByte sightType
+        | term when isPrimitive typ || typ.IsEnum -> readTermUnsafe reporter term offset endByte sightType
         | term -> internalfail $"readUnsafe: reading struct resulted in term {term}"
 
     and private readUnsafe reporter state baseAddress offset sightType =
         let viewSize = internalSizeOf sightType
         let slices =
+            let sightType = Some sightType
             match baseAddress with
-            | HeapLocation(loc, sightType) ->
-                let typ = mostConcreteTypeOfHeapRef state loc sightType
+            | HeapLocation(loc, t) ->
+                let typ = mostConcreteTypeOfHeapRef state loc t
                 match typ with
-                | StringType -> readStringUnsafe reporter state loc offset viewSize
-                | ClassType _ -> readClassUnsafe reporter state loc typ offset viewSize
-                | ArrayType _ -> readArrayUnsafe reporter state loc typ offset viewSize
+                | StringType -> readStringUnsafe reporter state loc offset viewSize sightType
+                | ClassType _ -> readClassUnsafe reporter state loc typ offset viewSize sightType
+                | ArrayType _ -> readArrayUnsafe reporter state loc typ offset viewSize sightType
                 | _ when typ = typeof<Void> -> internalfail $"readUnsafe: reading from 'Void' by reference {baseAddress}"
-                | StructType _ -> readBoxedUnsafe reporter state loc typ offset viewSize
+                | StructType _ -> readBoxedUnsafe reporter state loc typ offset viewSize sightType
                 | _ when isPrimitive typ || typ.IsEnum ->
-                    readBoxedUnsafe reporter state loc typ offset viewSize
+                    readBoxedUnsafe reporter state loc typ offset viewSize sightType
                 | _ -> internalfailf $"Expected complex type, but got {typ}"
-            | StackLocation loc -> readStackUnsafe reporter state loc offset viewSize
-            | StaticLocation loc -> readStaticUnsafe reporter state loc offset viewSize
+            | StackLocation loc -> readStackUnsafe reporter state loc offset viewSize sightType
+            | StaticLocation loc -> readStaticUnsafe reporter state loc offset viewSize sightType
         combine slices sightType
 
-    and readFieldUnsafe (reporter : IErrorReporter) block (field : fieldId) =
-        assert(sizeOf block = internalSizeOf field.declaringType)
-        let fieldType = field.typ
-        let startByte = Reflection.getFieldIdOffset field
-        let endByte = startByte + internalSizeOf fieldType
-        let slices = readTermUnsafe reporter block (makeNumber startByte) (makeNumber endByte)
-        combine slices fieldType
+    and readFieldUnsafe (reporter : IErrorReporter) (state : state) (block : term) (field : fieldId) =
+        let declaringType = field.declaringType
+        match block.term with
+        | Combined(_, t) when declaringType.IsAssignableFrom t || sizeOf block = internalSizeOf field.declaringType ->
+            assert(sizeOf block = internalSizeOf field.declaringType)
+            let fieldType = field.typ
+            let startByte = Reflection.getFieldIdOffset field
+            let endByte = startByte + internalSizeOf fieldType
+            let sightType = Some fieldType
+            let slices = readTermUnsafe reporter block (makeNumber startByte) (makeNumber endByte) sightType
+            combine slices fieldType
+        | Combined(slices, _) ->
+            let isSuitableRef slice =
+                match slice.term with
+                | _ when isReference slice -> mostConcreteTypeOfRef state slice |> declaringType.IsAssignableFrom
+                | Ptr(pointerBase, sightType, offset) ->
+                    match tryPtrToRef state pointerBase sightType offset with
+                    | Some address -> declaringType.IsAssignableFrom(address.TypeOfLocation)
+                    | None -> false
+                | _ -> false
+            let refs = List.filter isSuitableRef slices |> List.distinct
+            if List.length refs = 1 then
+                let ref = List.head refs
+                referenceField state ref field |> read reporter state
+            else internalfail $"readFieldUnsafe: unexpected block {block}"
+        | _ -> internalfail $"readFieldUnsafe: unexpected block {block}"
+
+// -------------------------------- Pointer helpers --------------------------------
+
+    and tryPtrToRef state pointerBase sightType offset : address option =
+        assert(typeOf offset = typeof<int>)
+        let zero = makeNumber 0
+        match pointerBase with
+        | HeapLocation(address, t) ->
+            let typ = typeOfHeapLocation state address |> mostConcreteType t
+            let isArray() =
+                typ.IsSZArray && typ.GetElementType() = sightType
+                || typ = typeof<string> && sightType = typeof<char>
+            if typ.ContainsGenericParameters then None
+            elif isArray() then
+                let mutable elemSize = Nop()
+                let checkOffset() =
+                    elemSize <- makeNumber (internalSizeOf sightType)
+                    rem offset elemSize = zero
+                if checkOffset() then
+                    let index = div offset elemSize
+                    let address, arrayType =
+                        if t = typeof<string> then stringArrayInfo state address None
+                        else address, (sightType, 1, true)
+                    ArrayIndex(address, [index], arrayType) |> Some
+                else None
+            elif typ.IsValueType && sightType = typ && offset = zero then
+                BoxedLocation(address, t) |> Some
+            else None
+        | StackLocation stackKey when stackKey.TypeOfLocation = sightType && offset = zero ->
+            PrimitiveStackLocation stackKey |> Some
+        | _ -> None
+
+    and heapReferenceToBoxReference reference =
+        match reference.term with
+        | HeapRef(address, typ) -> Ref (BoxedLocation(address, typ))
+        | Union gvs -> gvs |> List.map (fun (g, v) -> (g, heapReferenceToBoxReference v)) |> Merging.merge
+        | _ -> internalfailf "Unboxing: expected heap reference, but got %O" reference
+
+    and referenceField state reference fieldId =
+        let declaringType = fieldId.declaringType
+        let isSuitableField address typ =
+            let typ = mostConcreteTypeOfHeapRef state address typ
+            declaringType.IsAssignableFrom typ
+        match reference.term with
+        | HeapRef(address, typ) when isSuitableField address typ |> not ->
+            // TODO: check this case with casting via "is"
+            Logger.trace "[WARNING] unsafe cast of term %O in safe context" reference
+            let offset = Reflection.getFieldIdOffset fieldId |> makeNumber
+            Ptr (HeapLocation(address, typ)) fieldId.typ offset
+        | HeapRef(address, typ) when typ = typeof<string> && fieldId = Reflection.stringFirstCharField ->
+            let address, arrayType = stringArrayInfo state address None
+            ArrayIndex(address, [makeNumber 0], arrayType) |> Ref
+        | HeapRef(address, typ) when declaringType.IsValueType ->
+            // TODO: Need to check mostConcreteTypeOfHeapRef using pathCondition?
+            assert(isSuitableField address typ)
+            let ref = heapReferenceToBoxReference reference
+            referenceField state ref fieldId
+        | HeapRef(address, typ) ->
+            // TODO: Need to check mostConcreteTypeOfHeapRef using pathCondition?
+            assert(isSuitableField address typ)
+            ClassField(address, fieldId) |> Ref
+        | Ref address when declaringType.IsAssignableFrom(address.TypeOfLocation) ->
+            assert declaringType.IsValueType
+            StructField(address, fieldId) |> Ref
+        | Ref address ->
+            assert declaringType.IsValueType
+            let pointerBase, offset = Pointers.addressToBaseAndOffset address
+            let fieldOffset = Reflection.getFieldIdOffset fieldId |> makeNumber
+            Ptr pointerBase fieldId.typ (add offset fieldOffset)
+        | Ptr(baseAddress, _, offset) ->
+            let fieldOffset = Reflection.getFieldIdOffset fieldId |> makeNumber
+            Ptr baseAddress fieldId.typ (add offset fieldOffset)
+        | Union gvs -> gvs |> List.map (fun (g, v) -> (g, referenceField state v fieldId)) |> Merging.merge
+        | _ -> internalfailf "Referencing field: expected reference, but got %O" reference
 
 // --------------------------- General reading ---------------------------
 
-    let isTypeInitialized state (typ : Type) =
-        let key : symbolicTypeKey = {typ=typ}
-        let matchingTypes = SymbolicSet.matchingElements key state.initializedTypes
-        match matchingTypes with
-        | [x] when x = key -> True()
-        | _ ->
-            let name = sprintf "%O_initialized" typ
-            let source : typeInitialized = {typ = typ; matchingTypes = SymbolicSet.ofSeq matchingTypes}
-            Constant name source typeof<bool>
-
     // TODO: take type of heap address
-    let rec read (reporter : IErrorReporter) state reference =
+    and read (reporter : IErrorReporter) state reference =
         match reference.term with
         | Ref address -> readSafe reporter state address
         | DetachedPtr _ ->
@@ -1224,6 +1297,16 @@ module internal Memory =
             reporter.ReportFatalError "reading by detached pointer" (True())
             Nop()
         | _ -> internalfailf $"Reading: expected reference, but got {reference}"
+
+    let isTypeInitialized state (typ : Type) =
+        let key : symbolicTypeKey = {typ=typ}
+        let matchingTypes = SymbolicSet.matchingElements key state.initializedTypes
+        match matchingTypes with
+        | [x] when x = key -> True()
+        | _ ->
+            let name = sprintf "%O_initialized" typ
+            let source : typeInitialized = {typ = typ; matchingTypes = SymbolicSet.ofSeq matchingTypes}
+            Constant name source typeof<bool>
 
 // ------------------------------- Writing -------------------------------
 
@@ -1417,7 +1500,10 @@ module internal Memory =
             value
 
     let rec writeTermUnsafe reporter term startByte value =
+        let termType = typeOf term
+        let valueType = typeOf value
         match term.term with
+        | _ when startByte = makeNumber 0 && termType = valueType -> value
         | Struct(fields, t) -> writeStructUnsafe reporter term fields t startByte value
         | HeapRef _
         | Ref _
@@ -1425,9 +1511,8 @@ module internal Memory =
         | Concrete _
         | Constant _
         | Expression _ ->
-            let termType = typeOf term
             let termSize = internalSizeOf termType
-            let valueSize = sizeOf value
+            let valueSize = internalSizeOf valueType
             match startByte.term with
             | Concrete(:? int as startByte, _) when startByte = 0 && valueSize = termSize ->
                 combine (List.singleton value) termType
@@ -1435,9 +1520,9 @@ module internal Memory =
                 let zero = makeNumber 0
                 let termSize = makeNumber termSize
                 let valueSize = makeNumber valueSize
-                let left = readTermPartUnsafe reporter term zero startByte
-                let valueSlices = readTermUnsafe reporter value (neg startByte) (sub termSize startByte)
-                let right = readTermPartUnsafe reporter term (add startByte valueSize) termSize
+                let left = readTermPartUnsafe reporter term zero startByte None
+                let valueSlices = readTermUnsafe reporter value (neg startByte) (sub termSize startByte) None
+                let right = readTermPartUnsafe reporter term (add startByte valueSize) termSize None
                 combine (left @ valueSlices @ right) termType
         | _ -> internalfailf "writeTermUnsafe: unexpected term %O" term
 
@@ -1901,7 +1986,7 @@ module internal Memory =
                 match x.baseSource with
                 | :? IStatedSymbolicConstantSource as baseSource ->
                     let structTerm = baseSource.Compose state
-                    readStruct emptyReporter structTerm x.field
+                    readStruct emptyReporter state structTerm x.field
                 | _ ->
                     let x = x :> ISymbolicConstantSource
                     match state.model with

--- a/VSharp.SILI.Core/Memory.fs
+++ b/VSharp.SILI.Core/Memory.fs
@@ -1214,7 +1214,7 @@ module internal Memory =
         assert(typeOf offset = typeof<int>)
         let zero = makeNumber 0
         match pointerBase with
-        | HeapLocation(address, t) ->
+        | HeapLocation(address, t) when address <> zeroAddress() ->
             let typ = typeOfHeapLocation state address |> mostConcreteType t
             let isArray() =
                 typ.IsSZArray && typ.GetElementType() = sightType
@@ -1232,7 +1232,7 @@ module internal Memory =
                         else address, (sightType, 1, true)
                     ArrayIndex(address, [index], arrayType) |> Some
                 else None
-            elif typ.IsValueType && sightType = typ && offset = zero then
+            elif isValueType typ && sightType = typ && offset = zero then
                 BoxedLocation(address, t) |> Some
             else None
         | StackLocation stackKey when stackKey.TypeOfLocation = sightType && offset = zero ->

--- a/VSharp.SILI.Core/Pointers.fs
+++ b/VSharp.SILI.Core/Pointers.fs
@@ -129,7 +129,7 @@ module internal Pointers =
             shift ptr bytesToShift |> k
         | HeapRef(address, t) ->
             assert t.IsArray
-            let ptrType = t.GetElementType().MakePointerType()
+            let ptrType = t.GetElementType()
             Ptr (HeapLocation(address, t)) ptrType bytesToShift |> k
         | _ -> internalfailf "address arithmetic: expected pointer, but got %O" ptr
 

--- a/VSharp.SILI.Core/Terms.fs
+++ b/VSharp.SILI.Core/Terms.fs
@@ -892,7 +892,7 @@ module internal Terms =
         let defaultCase() =
             Expression Combine terms t
         let isSolid term typeOfTerm =
-            typeOfTerm = t || isRefOrPtr term
+            typeOfTerm = t || isRefOrPtr term && (not t.IsValueType || t.IsByRef || isNative t || t.IsPrimitive)
         let simplify p s e pos =
             let typ = typeOf p
             let termSize = lazy (internalSizeOf typ)

--- a/VSharp.SILI/CILState.fs
+++ b/VSharp.SILI/CILState.fs
@@ -31,7 +31,6 @@ type cilState =
         mutable stepsNumber : uint
         mutable suspended : bool
         mutable targets : Set<codeLocation>
-        mutable lastPushInfo : term option
         /// <summary>
         /// All basic blocks visited by the state.
         /// </summary>
@@ -80,7 +79,6 @@ module CilStateOperations =
             stepsNumber = 0u
             suspended = false
             targets = Set.empty
-            lastPushInfo = None
             history = Set.empty
             entryMethod = Some entryMethod
             id = getNextStateId()
@@ -272,7 +270,6 @@ module CilStateOperations =
         | Nop -> internalfail "pushing 'NOP' value onto evaluation stack"
         | _ ->
             cilState.state.evaluationStack <- EvaluationStack.Push v cilState.state.evaluationStack
-            cilState.lastPushInfo <- Some v
 
     let pushMany vs (cilState : cilState) =
         if List.contains (Nop()) vs then

--- a/VSharp.SILI/CILState.fs
+++ b/VSharp.SILI/CILState.fs
@@ -255,9 +255,16 @@ module CilStateOperations =
     let setException exc (cilState : cilState) = cilState.state.exceptionsRegister <- exc
 
     let push v (cilState : cilState) =
-        cilState.state.evaluationStack <- EvaluationStack.Push v cilState.state.evaluationStack
-        cilState.lastPushInfo <- Some v
-    let pushMany vs (cilState : cilState) = cilState.state.evaluationStack <- EvaluationStack.PushMany vs cilState.state.evaluationStack
+        match v.term with
+        | Nop -> internalfail "pushing 'NOP' value onto evaluation stack"
+        | _ ->
+            cilState.state.evaluationStack <- EvaluationStack.Push v cilState.state.evaluationStack
+            cilState.lastPushInfo <- Some v
+
+    let pushMany vs (cilState : cilState) =
+        if List.contains (Nop()) vs then
+            internalfail "pushing 'NOP' value onto evaluation stack"
+        cilState.state.evaluationStack <- EvaluationStack.PushMany vs cilState.state.evaluationStack
 
     let peek (cilState : cilState) =
         EvaluationStack.Pop cilState.state.evaluationStack |> fst

--- a/VSharp.SILI/Interpreter.fs
+++ b/VSharp.SILI/Interpreter.fs
@@ -16,7 +16,7 @@ open MethodBody
 
 type cfg = CfgInfo
 
-module internal TypeUtils =
+module TypeUtils =
     open Types
 
     let float64Type = typedefof<double>
@@ -65,71 +65,9 @@ module internal TypeUtils =
         let Zero() = MakeNumber 0UL
         let MaxValue() = MakeNumber UInt64.MaxValue
 
-type internal ErrorReporter(reportError, reportFatalError, cilState) =
-    let mutable cilState = cilState
-    let mutable stateConfigured : bool = false
-
-    interface IErrorReporter with
-        override x.ReportError msg failCondition =
-            assert stateConfigured
-            Branching.commonStatedConditionalExecutionk cilState.state
-                (fun state k -> k (!!failCondition, state))
-                (fun _ k -> k ())
-                (fun state k -> k (reportError (changeState cilState state) msg))
-                (fun _ _ -> [])
-                ignore
-
-        override x.ReportFatalError msg failCondition =
-            assert stateConfigured
-            Branching.commonStatedConditionalExecutionk cilState.state
-                (fun state k -> k (!!failCondition, state))
-                (fun _ k -> k ())
-                (fun state k -> k (reportFatalError (changeState cilState state) msg))
-                (fun _ _ -> [])
-                ignore
-
-        override x.ConfigureState state =
-            cilState <- changeState cilState state
-            stateConfigured <- true
-
 module internal InstructionsSet =
 
-    let mutable reportError : cilState -> string -> unit =
-        fun _ _ -> internalfail "'reportError' is not ready"
-
-    let mutable reportFatalError : cilState -> string -> unit =
-        fun _ _ -> internalfail "'reportError' is not ready"
-
-    let createErrorReporter cilState =
-        ErrorReporter(reportError, reportFatalError, cilState)
-
     let idTransformation term k = k term
-
-    // ------------------------------------ Memory Interaction ------------------------------------
-
-    let read cilState ref =
-        let reporter = createErrorReporter cilState
-        Memory.ReadUnsafe reporter cilState.state ref
-
-    let readField cilState term field =
-        let reporter = createErrorReporter cilState
-        Memory.ReadFieldUnsafe reporter cilState.state term field
-
-    let readIndex cilState term index valueType =
-        let reporter = createErrorReporter cilState
-        Memory.ReadArrayIndexUnsafe reporter cilState.state term index valueType
-
-    let write cilState ref value =
-        let reporter = createErrorReporter cilState
-        Memory.WriteUnsafe reporter cilState.state ref value
-
-    let writeStructField cilState term field value =
-        let reporter = createErrorReporter cilState
-        Memory.WriteStructFieldUnsafe reporter cilState.state term field value
-
-    let writeIndex cilState term index value valueType =
-        let reporter = createErrorReporter cilState
-        Memory.WriteArrayIndexUnsafe reporter cilState.state term index value valueType
 
     // ------------------------------------ Metadata Interaction ------------------------------------
 
@@ -147,39 +85,6 @@ module internal InstructionsSet =
         | InFilterHandler(offset, m, _, _) -> Some (offset, m)
         | Leave(ip, _, _, _) -> (|InstructionEndingIp|_|) ip
         | _ -> None
-
-    // ------------------------------- Environment interaction -------------------------------
-
-    let rec internalCall (methodInfo : MethodInfo) (argsAndThis : term list) cilState k =
-        let s = cilState.state
-        let parameters : obj [] =
-            match methodInfo.GetParameters().Length with
-            | 2 -> [| s; argsAndThis |]
-            | _ -> internalfail "Only internal calls with signature 'state * term list -> term | (term * state) list' are supported"
-        let result =
-            try
-                methodInfo.Invoke(null, parameters)
-            with
-            | :? TargetInvocationException as targetException ->
-                Logger.trace $"InternalCall got TargetInvocationException {targetException.Message}"
-                let actualException = targetException.GetBaseException()
-                Logger.trace $"TargetInvocationException.GetBaseException {actualException.Message}"
-                raise actualException
-            | e ->
-                Logger.trace $"InternalCall got exception {e.Message}"
-                reraise()
-
-        let pushOnEvaluationStack (term : term, cilState : cilState) =
-            match term.term with
-            | Nop -> ()
-            | _ -> push term cilState
-        match result with
-        | :? term as r ->
-            let cilState = changeState cilState s
-            pushOnEvaluationStack(r, cilState); k [cilState]
-        | :? ((term * state) list) as r ->
-            r |> List.map (fun (t, s) -> let s' = changeState cilState s in pushOnEvaluationStack(t, s'); s') |> k
-        | _ -> internalfail "Internal call should return 'term' or tuple 'term * state'!"
 
     // ------------------------------- CIL instructions -------------------------------
 
@@ -233,8 +138,7 @@ module internal InstructionsSet =
         let location = referenceLocalVariable variableIndex m
         let typ = TypeOfLocation location
         let value = Types.Cast right typ
-        let states = write cilState location value
-        states |> List.map (changeState cilState)
+        write cilState location value
     let private simplifyConditionResult state res k =
         if Contradicts state !!res then k (True())
         elif Contradicts state res then k (False())
@@ -549,11 +453,11 @@ module internal InstructionsSet =
 
     let private fallThroughImpl stackSizeBefore newIp cilState =
         // if not constructing runtime exception
-        if not <| isUnhandledError cilState && Memory.CallStackSize cilState.state = stackSizeBefore then
+        if not <| isUnhandledExceptionOrError cilState && Memory.CallStackSize cilState.state = stackSizeBefore then
             setCurrentIp newIp cilState
 
     let fallThrough (m : Method) offset cilState op =
-        assert(not <| isUnhandledError cilState)
+        assert(not <| isUnhandledExceptionOrError cilState)
         let stackSizeBefore = Memory.CallStackSize cilState.state
         let newIp = instruction m (fallThroughTarget m offset)
         op m offset cilState
@@ -561,7 +465,7 @@ module internal InstructionsSet =
         [cilState]
 
     let forkThrough (m : Method) offset cilState op =
-        assert(not <| isUnhandledError cilState)
+        assert(not <| isUnhandledExceptionOrError cilState)
         let stackSizeBefore = Memory.CallStackSize cilState.state
         let newIp = instruction m (fallThroughTarget m offset)
         let cilStates = op m offset cilState
@@ -583,38 +487,74 @@ type UnknownMethodException(message : string, methodInfo : Method, interpreterSt
     member x.Method with get() = methodInfo
     member x.InterpreterStackTrace with get() = interpreterStackTrace
 
-type internal ILInterpreter() as this =
+// Interface for internal calls interaction
+type IInterpreter =
+    abstract Raise : (cilState -> unit) -> cilState -> (cilState list -> 'a) -> 'a
+    abstract NpeOrInvoke : cilState -> term -> (cilState -> (cilState list -> 'a) -> 'a) -> (cilState list -> 'a) -> 'a
+    abstract InvalidProgramException : cilState -> unit
+    abstract NullReferenceException : cilState -> unit
+    abstract ArgumentException : cilState -> unit
+    abstract ArgumentNullException : cilState -> unit
+    abstract ArgumentOutOfRangeException : cilState -> unit
+    abstract IndexOutOfRangeException : cilState -> unit
+    abstract ArrayTypeMismatchException : cilState -> unit
+    abstract RankException : cilState -> unit
+    abstract DivideByZeroException : cilState -> unit
+    abstract OverflowException : cilState -> unit
+    abstract ArithmeticException : cilState -> unit
+    abstract TypeInitializerException : string -> term -> cilState -> unit
+    abstract InvalidCastException : cilState -> unit
+    abstract OutOfMemoryException : cilState -> unit
+    abstract AccessArrayDimension : (term -> term -> cilState -> (cilState list -> cilState list) -> cilState list) -> cilState -> term -> term -> cilState list
+    abstract AccessArray : (cilState -> (cilState list -> 'a) -> 'a) -> cilState -> term -> term -> (cilState list -> 'a) -> 'a
 
-    let cilStateImplementations : Map<string, cilState -> term option -> term list -> cilState list> =
-        Map.ofList [
-            "System.Int32 System.Array.GetLength(this, System.Int32)", this.CommonGetArrayLength
-            "System.Int32 System.Array.GetLowerBound(this, System.Int32)", this.GetArrayLowerBound
-            "System.Void System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)", this.CommonInitializeArray
-            "System.Void System.String.FillStringChecked(System.String, System.Int32, System.String)", this.FillStringChecked
-            "System.Void System.Array.Clear(System.Array, System.Int32, System.Int32)", this.ClearArray
-            "System.Void System.Array.Copy(System.Array, System.Int32, System.Array, System.Int32, System.Int32, System.Boolean)", this.CopyArrayExtendedForm1
-            "System.Void System.Array.Copy(System.Array, System.Int32, System.Array, System.Int32, System.Int32)", this.CopyArrayExtendedForm2
-            "System.Void System.Array.Copy(System.Array, System.Array, System.Int32)", this.CopyArrayShortForm
-            "System.Void System.Array.Fill(T[], T)", this.FillArray
-            "System.Char System.String.get_Chars(this, System.Int32)", this.GetChars
-            "System.Void System.Threading.Monitor.ReliableEnter(System.Object, System.Boolean&)", this.MonitorReliableEnter
-            "System.Void System.Threading.Monitor.Enter(System.Object)", this.MonitorEnter
-            "System.Void System.Diagnostics.Debug.Assert(System.Boolean)", this.DebugAssert
-            "System.UInt32 System.Collections.HashHelpers.FastMod(System.UInt32, System.UInt32, System.UInt64)", this.FastMod
-            "System.Void System.Runtime.CompilerServices.RuntimeHelpers._RunClassConstructor(System.RuntimeType)", this.RunStaticCtor
-            "System.Void System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(System.Runtime.CompilerServices.QCallTypeHandle)", this.RunStaticCtor
-            "System.Delegate System.Delegate.Combine(System.Delegate, System.Delegate)", this.DelegateCombine
-            "System.Delegate System.Delegate.Remove(System.Delegate, System.Delegate)", this.DelegateRemove
-        ]
+type ILInterpreter() as this =
 
-    // NOTE: adding implementation names into Loader
-    do Loader.CilStateImplementations <- cilStateImplementations.Keys
+    // ------------------------------- Environment interaction -------------------------------
+
+    member x.InternalCall (originMethod : Method) (methodInfo : MethodInfo) (argsAndThis : term list) cilState k =
+        let neededParams = methodInfo.GetParameters() |> Array.map (fun p -> p.ParameterType)
+        let parameters : obj[] =
+            match neededParams with
+            | [| t1; t2; t3 |] when t1 = typeof<IInterpreter> && t2 = typeof<cilState> && t3 = typeof<term list> ->
+                [| x :> IInterpreter; cilState; argsAndThis |]
+            | [| t1; t2 |] when t1 = typeof<state> && t2 = typeof<term list> ->
+                [| cilState.state; argsAndThis |]
+            | _ -> internalfail $"InternalCall: unsupported signature of internal call {neededParams}"
+
+        let result =
+            try
+                methodInfo.Invoke(null, parameters)
+            with
+            | :? TargetInvocationException as targetException ->
+                Logger.error $"InternalCall got TargetInvocationException {targetException.Message}"
+                let actualException = targetException.GetBaseException()
+                Logger.error $"TargetInvocationException.GetBaseException {actualException.Message}"
+                raise actualException
+            | e ->
+                Logger.error $"InternalCall got exception {e.Message}"
+                reraise()
+
+        match result with
+        | :? term as result when not originMethod.HasNonVoidResult ->
+            assert(result = Nop())
+            k [cilState]
+        | :? term as result when originMethod.HasNonVoidResult ->
+            assert(result <> Nop())
+            push result cilState
+            k [cilState]
+        | :? ((term * state) list) as results when originMethod.HasNonVoidResult ->
+            results |> List.map (fun (t, s) -> let s' = changeState cilState s in push t s'; s') |> k
+        | :? ((term * state) list) as results ->
+            results |> List.map (fun (_, s) -> changeState cilState s) |> k
+        | :? (cilState list) as results ->
+            k results
+        | _ -> internalfail "Internal call should return 'term' or tuple 'term * state' or 'cilState list'!"
 
     member x.ConfigureErrorReporter errorReporter fatalErrorReporter =
-        reportError <- errorReporter
-        reportFatalError <- fatalErrorReporter
+        configureErrorReporter errorReporter fatalErrorReporter
 
-    member private x.Raise createException (cilState : cilState) k =
+    member x.Raise createException (cilState : cilState) k =
         createException cilState
         k [cilState]
 
@@ -641,324 +581,15 @@ type internal ILInterpreter() as this =
         let upperBound = Memory.ArrayRank cilState.state this
         x.AccessArray (accessor this dimension) cilState upperBound dimension id
 
-    member private x.CommonGetArrayLength (cilState : cilState) thisOption args =
-        match args with
-        | [dimensionsKey] ->
-            let arrayLengthByDimension arrayRef index cilState (k : cilState list -> 'a) =
-                push (Memory.ArrayLengthByDimension cilState.state arrayRef index) cilState
-                k [cilState]
-            x.AccessArrayDimension arrayLengthByDimension cilState (Option.get thisOption) dimensionsKey
-        | _ -> internalfail "unexpected number of arguments"
-
-    member private x.GetArrayLowerBound (cilState : cilState) (this : term option) args =
-        match args with
-        | [dimension] ->
-            let arrayLowerBoundByDimension arrayRef index (cilState : cilState) k =
-                push (Memory.ArrayLowerBoundByDimension cilState.state arrayRef index) cilState
-                k [cilState]
-            x.AccessArrayDimension arrayLowerBoundByDimension cilState (Option.get this) dimension
-        | _ -> internalfail "unexpected number of arguments"
-
-    member private x.NpeOrInvokeStatementCIL (cilState : cilState) (this : term) statement (k : cilState list -> 'a) =
+    member x.NpeOrInvokeStatementCIL (cilState : cilState) (this : term) statement (k : cilState list -> 'a) =
         StatedConditionalExecutionCIL cilState
             (fun state k -> k (IsBadRef this, state))
             (x.Raise x.NullReferenceException)
             statement
             k
 
-    member private x.CommonInitializeArray (cilState : cilState) _ (args : term list) =
-        match args with
-        | [arrayRef; handleTerm] ->
-            let initArray (cilState : cilState) k =
-                Memory.InitializeArray cilState.state arrayRef handleTerm
-                k [cilState]
-            x.NpeOrInvokeStatementCIL cilState arrayRef initArray id
-        | _ -> internalfail "unexpected number of arguments"
-
-    member private x.FillStringChecked (cilState : cilState) _ (args : term list) =
-        assert(List.length args = 3)
-        let state = cilState.state
-        let dest, destPos, src = args[0], args[1], args[2]
-        let srcPos = MakeNumber 0
-        let srcLength = Memory.StringLength state src
-        let destLength = Memory.StringLength state dest
-        let (<<=) = Arithmetics.(<<=)
-        let check = srcLength <<= (Arithmetics.Sub destLength destPos)
-        let copy (cilState : cilState) k =
-            Memory.CopyStringArray cilState.state src srcPos dest destPos srcLength
-            k [cilState]
-        StatedConditionalExecutionCIL cilState
-            (fun state k -> k (check, state))
-            copy
-            (x.Raise x.IndexOutOfRangeException)
-            id
-
-    member private x.ClearArray (cilState : cilState) _ (args : term list) =
-        assert(List.length args = 3)
-        let array, index, length = args[0], args[1], args[2]
-        let (>>) = API.Arithmetics.(>>)
-        let (<<) = API.Arithmetics.(<<)
-        let clearCase (cilState : cilState) k =
-            Memory.ClearArray cilState.state array index length
-            k [cilState]
-        let nonNullCase (cilState : cilState) k =
-            let zero = MakeNumber 0
-            let lb = Memory.ArrayLowerBoundByDimension cilState.state array zero
-            let numOfAllElements = Memory.CountOfArrayElements cilState.state array
-            let check = (index << lb) ||| ((Arithmetics.Add index length) >> numOfAllElements) ||| (length << zero)
-            StatedConditionalExecutionCIL cilState
-                (fun state k -> k (check, state))
-                (x.Raise x.IndexOutOfRangeException)
-                clearCase
-                k
-        StatedConditionalExecutionCIL cilState
-            (fun state k -> k (IsNullReference array, state))
-            (x.Raise x.ArgumentNullException)
-            nonNullCase
-            id
-
-    member private x.CommonCopyArray (cilState : cilState) src srcIndex dst dstIndex length =
-        let state = cilState.state
-        let srcType = MostConcreteTypeOfRef state src
-        let dstType = MostConcreteTypeOfRef state dst
-        let (>>) = API.Arithmetics.(>>)
-        let (>>=) = API.Arithmetics.(>>=)
-        let (<<) = API.Arithmetics.(<<)
-        let add = Arithmetics.Add
-        let zero = TypeUtils.Int32.Zero()
-        let srcLB = Memory.ArrayLowerBoundByDimension state src zero
-        let dstLB = Memory.ArrayLowerBoundByDimension state dst zero
-        let srcNumOfAllElements = Memory.CountOfArrayElements state src
-        let dstNumOfAllElements = Memory.CountOfArrayElements state dst
-        let defaultCase (cilState : cilState) k =
-            Memory.CopyArray cilState.state src srcIndex srcType dst dstIndex dstType length
-            k [cilState]
-        let lengthCheck (cilState : cilState) =
-            let endSrcIndex = add srcIndex length
-            let srcNumOfAllElements = srcNumOfAllElements
-            let endDstIndex = add dstIndex length
-            let dstNumOfAllElements = dstNumOfAllElements
-            let check =
-                (endSrcIndex >> srcNumOfAllElements) ||| (endSrcIndex << srcLB)
-                ||| (endDstIndex >> dstNumOfAllElements) ||| (endDstIndex << dstLB)
-            StatedConditionalExecutionCIL cilState
-                (fun state k -> k (check, state))
-                (x.Raise x.ArgumentException)
-                defaultCase
-        let indicesCheck (cilState : cilState) =
-            // TODO: extended form needs
-            let primitiveLengthCheck = (length << zero) ||| (if TypeUtils.isLong length then length >> TypeUtils.Int32.MaxValue() else False())
-            let srcIndexCheck = (srcIndex << srcLB) ||| (if TypeUtils.isLong srcIndex then srcIndex >>= srcNumOfAllElements else False())
-            let dstIndexCheck = (dstIndex << dstLB) ||| (if TypeUtils.isLong dstIndex then dstIndex >>= dstNumOfAllElements else False())
-
-            StatedConditionalExecutionCIL cilState
-                (fun state k -> k (primitiveLengthCheck ||| srcIndexCheck ||| dstIndexCheck, state))
-                (x.Raise x.ArgumentOutOfRangeException)
-                lengthCheck
-        let assignableCheck (cilState : cilState) =
-            let srcElemType = Types.ElementType srcType
-            let dstElemType = Types.ElementType dstType
-            let condition =
-                if Types.IsValueType srcElemType then True()
-                else Types.TypeIsType srcElemType dstElemType
-            StatedConditionalExecutionCIL cilState
-                (fun state k -> k (condition, state))
-                indicesCheck
-                (x.Raise x.InvalidCastException)
-        let rankCheck (cilState : cilState) =
-            if Types.RankOf srcType = Types.RankOf dstType then assignableCheck cilState
-            else x.Raise x.RankException cilState
-        StatedConditionalExecutionCIL cilState
-            (fun state k -> k (IsNullReference src ||| IsNullReference dst, state))
-            (x.Raise x.ArgumentNullException)
-            rankCheck
-            id
-
-    member private x.CopyArrayExtendedForm1 (cilState : cilState) _ (args : term list) =
-        assert(List.length args = 6)
-        let src, srcIndex, dst, dstIndex, length = args[0], args[1], args[2], args[3], args[4]
-        x.CommonCopyArray cilState src srcIndex dst dstIndex length
-
-    member private x.CopyArrayExtendedForm2 (cilState : cilState) _ (args : term list) =
-        assert(List.length args = 5)
-        let src, srcIndex, dst, dstIndex, length = args[0], args[1], args[2], args[3], args[4]
-        x.CommonCopyArray cilState src srcIndex dst dstIndex length
-
-    member private x.CopyArrayShortForm (cilState : cilState) _ (args : term list) =
-        assert(List.length args = 3)
-        let src, dst, length = args[0], args[1], args[2]
-        let state = cilState.state
-        let zero = TypeUtils.Int32.Zero()
-        let srcLB = Memory.ArrayLowerBoundByDimension state src zero
-        let dstLB = Memory.ArrayLowerBoundByDimension state src zero
-        x.CommonCopyArray cilState src srcLB dst dstLB length
-
-    member private x.FillArray (cilState : cilState) _ (args : term list) =
-        assert(List.length args = 3)
-        let array, value = args[1], args[2]
-        let fill cilState k =
-            Memory.FillArray cilState.state array value
-            k [cilState]
-        StatedConditionalExecutionCIL cilState
-            (fun state k -> k (IsNullReference array, state))
-            (x.Raise x.ArgumentNullException)
-            fill
-            id
-
-    member private x.GetChars (cilState : cilState) this (args : term list) =
-        assert(List.length args = 1)
-        match this with
-        | Some this ->
-            let index = List.item 0 args
-            let length = Memory.StringLength cilState.state this
-            let getChar cilState k =
-                let char = Memory.ReadStringChar cilState.state this index
-                push char cilState
-                List.singleton cilState |> k
-            x.AccessArray getChar cilState length index id
-        | None -> internalfailf $"String.GetChars: unexpected this {this}"
-
-    member private x.MonitorReliableEnter (cilState : cilState) this (args : term list) =
-        assert(List.length args = 2 && Option.isNone this)
-        let obj, resultRef = args[0], args[1]
-        let success cilState k =
-            Memory.Write cilState.state resultRef (True()) |> List.map (changeState cilState) |> k
-        BranchOnNullCIL cilState obj
-            (x.Raise x.ArgumentNullException)
-            success
-            id
-
-    member private x.MonitorEnter (cilState : cilState) this (args : term list) =
-        assert(List.length args = 1 && Option.isNone this)
-        let obj = List.head args
-        BranchOnNullCIL cilState obj
-            (x.Raise x.ArgumentNullException)
-            (fun cilState k -> List.singleton cilState |> k)
-            id
-
-    member private x.DebugAssert (cilState : cilState) this (args : term list) =
-        assert(List.length args = 1 && Option.isNone this)
-        let condition = List.head args
-        StatedConditionalExecutionCIL cilState
-            (fun state k -> k (condition, state))
-            (fun cilState k -> (); k [cilState])
-            (fun cilState k ->
-                reportFatalError cilState "Debug.Assert failed"
-                k [])
-            id
-
-    member private x.FastMod (cilState : cilState) this (args : term list) =
-        assert(List.length args = 3 && Option.isNone this)
-        let left, right = args[0], args[1]
-        let validCase cilState k =
-            let leftType = TypeOf left
-            let rightType = TypeOf right
-            let result =
-                if TypeUtils.isUnsigned leftType || TypeUtils.isUnsigned rightType then
-                    Arithmetics.RemUn left right
-                else Arithmetics.Rem left right
-            push result cilState
-            k [cilState]
-        StatedConditionalExecutionCIL cilState
-            (fun state k -> k (right === MakeNumber 0, state))
-            (x.Raise x.DivideByZeroException)
-            validCase
-            id
-
-    member private x.RunStaticCtor (cilState : cilState) this (args : term list) =
-        assert(List.length args = 1 && Option.isNone this)
-        // TODO: initialize statics of argument
-        List.singleton cilState
-
-    member private x.DelegateCombine cilState _ args =
-        assert(List.length args = 2)
-        let d1 = args[0]
-        let d2 = args[1]
-        assert(IsReference d1 && IsReference d2)
-        let combine t cilState k =
-            let d = Memory.CombineDelegates cilState.state args t
-            push d cilState
-            List.singleton cilState |> k
-        let typesCheck cilState k =
-            let state = cilState.state
-            let d1Type = MostConcreteTypeOfRef state d1
-            let d2Type = MostConcreteTypeOfRef state d2
-            let t = TypeUtils.mostConcreteType d1Type d2Type
-            let secondCheck cilState k =
-                StatedConditionalExecutionCIL cilState
-                    (fun state k -> k (Types.RefIsType state d2 t, state))
-                    (combine t)
-                    (x.Raise x.ArgumentException)
-                    k
-            StatedConditionalExecutionCIL cilState
-                (fun state k -> k (Types.RefIsType state d1 t, state))
-                secondCheck
-                (x.Raise x.ArgumentException)
-                k
-        let nullCheck cilState k =
-            StatedConditionalExecutionCIL cilState
-                (fun state k -> k (IsNullReference d2, state))
-                (fun cilState k -> push d1 cilState; List.singleton cilState |> k)
-                typesCheck
-                k
-        StatedConditionalExecutionCIL cilState
-            (fun state k -> k (IsNullReference d1, state))
-            (fun cilState k -> push d2 cilState; List.singleton cilState |> k)
-            nullCheck
-            id
-
-    member private x.DelegateRemove cilState _ args =
-        assert(List.length args = 2)
-        let source = args[0]
-        let toRemove = args[1]
-        assert(IsReference source && IsReference toRemove)
-        let remove t cilState k =
-            let d = Memory.RemoveDelegate cilState.state source toRemove t
-            push d cilState
-            List.singleton cilState |> k
-        let typesCheck cilState k =
-            let state = cilState.state
-            let sourceType = MostConcreteTypeOfRef cilState.state source
-            let toRemoveType = MostConcreteTypeOfRef state toRemove
-            let t = TypeUtils.mostConcreteType sourceType toRemoveType
-            let secondCheck cilState k =
-                StatedConditionalExecutionCIL cilState
-                    (fun state k -> k (Types.RefIsType state toRemove t, state))
-                    (remove t)
-                    (x.Raise x.ArgumentException)
-                    k
-            StatedConditionalExecutionCIL cilState
-                (fun state k -> k (Types.RefIsType state source t, state))
-                secondCheck
-                (x.Raise x.ArgumentException)
-                k
-        let nullCheck cilState k =
-            StatedConditionalExecutionCIL cilState
-                (fun state k -> k (IsNullReference source, state))
-                (fun cilState k -> push (TypeOf source |> NullRef) cilState; List.singleton cilState |> k)
-                typesCheck
-                k
-        StatedConditionalExecutionCIL cilState
-            (fun state k -> k (IsNullReference toRemove, state))
-            (fun cilState k -> push source cilState; List.singleton cilState |> k)
-            nullCheck
-            id
-
-    member private x.TrustedIntrinsics =
-        let intPtr = Reflection.getAllMethods typeof<IntPtr> |> Array.map Reflection.getFullMethodName
-        let volatile = Reflection.getAllMethods typeof<System.Threading.Volatile> |> Array.map Reflection.getFullMethodName
-        let defaultComparer = [|"System.Collections.Generic.Comparer`1[T] System.Collections.Generic.Comparer`1[T].get_Default()"|]
-        Array.concat [intPtr; volatile; defaultComparer]
-
-    member private x.IsNotImplementedIntrinsic (method : Method) fullMethodName =
-        let isIntrinsic =
-            let intrinsicAttr = "System.Runtime.CompilerServices.IntrinsicAttribute"
-            method.CustomAttributes |> Seq.exists (fun m -> m.AttributeType.ToString() = intrinsicAttr)
-        isIntrinsic && (Array.contains fullMethodName x.TrustedIntrinsics |> not)
-
-    member private x.ShouldMock (method : Method) fullMethodName =
-        Loader.isShimmed fullMethodName && ExternMocker.ShimSupported
-        || method.IsExternalMethod && not method.IsQCall
+    member private x.ShouldMock (method : Method) =
+        method.IsShimmed && ExternMocker.ShimSupported || method.IsExternalMethod && not method.IsQCall
 
     member private x.InstantiateThisIfNeed state thisOption (method : Method) =
         match thisOption with
@@ -1007,7 +638,7 @@ type internal ILInterpreter() as this =
                     (fun state k -> k (assumptions, state))
                     (fun cilState k -> k [cilState])
                     (fun cilState k ->
-                        if shouldReportError then reportError cilState message
+                        if shouldReportError then ErrorReporter.ReportError cilState message
                         k [])
                     k
 
@@ -1038,7 +669,7 @@ type internal ILInterpreter() as this =
                     (fun state k -> k (assumptions, state))
                     (fun cilState k -> k [cilState])
                     (fun cilState k ->
-                        if shouldReportError then reportError cilState message
+                        if shouldReportError then ErrorReporter.ReportError cilState message
                         k [])
                     k
 
@@ -1105,9 +736,9 @@ type internal ILInterpreter() as this =
         let error = Memory.AllocateConcreteObject state e (e.GetType())
         x.CommonThrow cilState error isRuntime
 
-    member private x.TryConcreteInvoke (method : Method) fullMethodName (args : term list) thisOption (cilState : cilState) =
+    member private x.TryConcreteInvoke (method : Method) (args : term list) thisOption (cilState : cilState) =
         let state = cilState.state
-        if method.IsConcretelyInvokable && Loader.isInvokeInternalCall fullMethodName then
+        if method.CanCallConcrete then
             // Before term args, type args are located
             let termArgs = List.skip (List.length args - method.Parameters.Length) args
             let objArgs = List.choose (TryTermToObj state) termArgs
@@ -1134,7 +765,7 @@ type internal ILInterpreter() as this =
                         push resultTerm cilState
                     | _ -> ()
                 with :? TargetInvocationException as e ->
-                    let isRuntime = Loader.isRuntimeExceptionsImplementation fullMethodName
+                    let isRuntime = method.IsRuntimeException
                     x.ConcreteInvokeCatch e.InnerException cilState isRuntime
                 true
         else false
@@ -1149,18 +780,17 @@ type internal ILInterpreter() as this =
         x.InstantiateThisIfNeed cilState.state thisOption method
 
         let fallThroughCall (cilState : cilState) =
-            if isUnhandledError cilState |> not then
+            if isUnhandledExceptionOrError cilState |> not then
                 ILInterpreter.FallThroughCall cilState
             cilState
 
-        if x.TryConcreteInvoke method fullMethodName typeAndMethodArgs thisOption cilState then
+        if x.TryConcreteInvoke method typeAndMethodArgs thisOption cilState then
             fallThroughCall cilState |> List.singleton |> k
-        elif Map.containsKey fullMethodName cilStateImplementations then
-            cilStateImplementations[fullMethodName] cilState thisOption typeAndMethodArgs |> List.map fallThroughCall |> k
-        elif Map.containsKey fullMethodName Loader.FSharpImplementations then
+        elif method.IsFSharpInternalCall then
             let thisAndArguments = optCons typeAndMethodArgs thisOption
-            internalCall Loader.FSharpImplementations[fullMethodName] thisAndArguments cilState (List.map fallThroughCall >> k)
-        elif Map.containsKey fullMethodName Loader.CSharpImplementations then
+            let internalCall = method.GetInternalCall
+            x.InternalCall method internalCall thisAndArguments cilState (List.map fallThroughCall >> k)
+        elif method.IsCSharpInternalCall then
             assert method.HasBody
             ILInterpreter.InitFunctionFrameCIL cilState method thisOption (Some args)
             [cilState] |> k
@@ -1183,7 +813,7 @@ type internal ILInterpreter() as this =
             let stackTrace = Memory.StackTraceString cilState.state.stack
             let message = $"Not supported internal call: {fullMethodName}"
             UnknownMethodException(message, method, stackTrace) |> raise
-        elif x.IsNotImplementedIntrinsic method fullMethodName then
+        elif method.IsNotImplementedIntrinsic then
             let stackTrace = Memory.StackTraceString cilState.state.stack
             let message = $"Not supported intrinsic method: {fullMethodName}"
             UnknownMethodException(message, method, stackTrace) |> raise
@@ -1538,8 +1168,7 @@ type internal ILInterpreter() as this =
         let typ = resolveTypeFromMetadata m (offset + Offset.from OpCodes.Stobj.Size)
         let store cilState k =
             let value = Types.Cast value typ
-            let states = write cilState ref value
-            states |> List.map (changeState cilState) |> k
+            write cilState ref value |> k
         x.NpeOrInvokeStatementCIL cilState ref store id
 
     member x.LdFldWithFieldInfo (fieldInfo : FieldInfo) addressNeeded (cilState : cilState) =
@@ -1572,8 +1201,7 @@ type internal ILInterpreter() as this =
             let reference =
                 if TypeUtils.isPointer fieldInfo.DeclaringType then targetRef
                 else Reflection.wrapField fieldInfo |> Memory.ReferenceField cilState.state targetRef
-            let states = write cilState reference value
-            List.map (changeState cilState) states |> k
+            write cilState reference value |> k
         x.NpeOrInvokeStatementCIL cilState targetRef storeWhenTargetIsNotNull id
 
     member private x.LdElemCommon (typ : Type option) (cilState : cilState) arrayRef indices =
@@ -1620,8 +1248,7 @@ type internal ILInterpreter() as this =
         let checkedStElem (cilState : cilState) (k : cilState list -> 'a) =
             let typeOfValue = TypeOf value
             let uncheckedStElem (cilState : cilState) (k : cilState list -> 'a) =
-                let states = writeIndex cilState arrayRef indices value typ
-                List.map (changeState cilState) states |> k
+                writeIndex cilState arrayRef indices value typ |> k
             let checkTypeMismatch (cilState : cilState) (k : cilState list -> 'a) =
                 let condition =
                     if Types.IsValueType typeOfValue then True()
@@ -1680,8 +1307,7 @@ type internal ILInterpreter() as this =
         let value, address = pop2 cilState
         let store cilState k =
             let value = valueCast value
-            let states = write cilState address value
-            states |> List.map (changeState cilState) |> k
+            write cilState address value |> k
         x.NpeOrInvokeStatementCIL cilState address store id
 
     member x.BoxNullable (t : Type) (v : term) (cilState : cilState) : cilState list =
@@ -1781,7 +1407,7 @@ type internal ILInterpreter() as this =
 
     member private x.Throw (cilState : cilState) =
         let error = peek cilState
-        let isRuntime = Loader.isRuntimeExceptionsImplementation (currentMethod cilState).FullName
+        let isRuntime = (currentMethod cilState).IsRuntimeException
         BranchOnNullCIL cilState error
             (x.Raise x.NullReferenceException)
             (fun cilState k ->
@@ -2119,12 +1745,11 @@ type internal ILInterpreter() as this =
             && parameters |> Seq.forall2 (fun p1 p2 -> p2.ParameterType.IsAssignableFrom p1) argumentsTypes
         let ctors = constructors |> Array.filter suitable
         assert(Array.length ctors = 1)
-        let ctor = ctors[0]
-        let fullConstructorName = Reflection.getFullMethodName ctor
-        assert (Loader.hasRuntimeExceptionsImplementation fullConstructorName)
-        let proxyCtor = Loader.getRuntimeExceptionsImplementation fullConstructorName |> Application.getMethod
+        let ctor = Application.getMethod ctors[0]
+        assert ctor.HasRuntimeExceptionImpl
+        let proxyCtor = ctor.RuntimeExceptionImpl |> Application.getMethod
         ILInterpreter.InitFunctionFrameCIL cilState proxyCtor None (Some arguments)
-        let success = x.TryConcreteInvoke proxyCtor proxyCtor.FullName arguments None cilState
+        let success = x.TryConcreteInvoke proxyCtor arguments None cilState
         assert success
 
     member x.InvalidProgramException cilState =
@@ -2193,7 +1818,7 @@ type internal ILInterpreter() as this =
             let ip = currentIp cilState
             try
                 let allStates = x.MakeStep cilState
-                let newErrors, restStates = List.partition isUnhandledError allStates
+                let newErrors, restStates = List.partition isUnhandledExceptionOrError allStates
                 let errors = errors @ newErrors
                 let newIieStates, goodStates = List.partition isIIEState restStates
                 let incompleteStates = newIieStates @ incompleteStates
@@ -2594,7 +2219,32 @@ type internal ILInterpreter() as this =
             | _ -> __unreachable__()
 
         let renewInstructionsInfo cilState =
-            if not <| isUnhandledError cilState then
+            if not <| isUnhandledExceptionOrError cilState then
                 x.IncrementLevelIfNeeded m offset cilState
         newSts |> List.iter renewInstructionsInfo
         newSts
+
+// ------------------------------------ IExceptionManager implementation ------------------------------------
+
+    interface IInterpreter with
+        override x.Raise createException cilState k =
+            x.Raise createException cilState k
+        override x.NpeOrInvoke cilState ref statement k =
+            x.NpeOrInvokeStatementCIL cilState ref statement k
+        override x.InvalidProgramException cilState = x.InvalidProgramException cilState
+        override x.NullReferenceException cilState = x.NullReferenceException cilState
+        override x.ArgumentException cilState = x.ArgumentException cilState
+        override x.ArgumentNullException cilState = x.ArgumentNullException cilState
+        override x.ArgumentOutOfRangeException cilState = x.ArgumentOutOfRangeException cilState
+        override x.IndexOutOfRangeException cilState = x.IndexOutOfRangeException cilState
+        override x.ArrayTypeMismatchException cilState = x.ArrayTypeMismatchException cilState
+        override x.RankException cilState = x.RankException cilState
+        override x.DivideByZeroException cilState = x.DivideByZeroException cilState
+        override x.OverflowException cilState = x.OverflowException cilState
+        override x.ArithmeticException cilState = x.ArithmeticException cilState
+        override x.TypeInitializerException qualifiedTypeName innerException cilState =
+            x.TypeInitializerException qualifiedTypeName innerException cilState
+        override x.InvalidCastException cilState = x.InvalidCastException cilState
+        override x.OutOfMemoryException cilState = x.OutOfMemoryException cilState
+        override x.AccessArrayDimension accessor cilState this dim = x.AccessArrayDimension accessor cilState this dim
+        override x.AccessArray accessor cilState length index k = x.AccessArray accessor cilState length index k

--- a/VSharp.SILI/Interpreter.fs
+++ b/VSharp.SILI/Interpreter.fs
@@ -1504,7 +1504,7 @@ type ILInterpreter() as this =
         match y, x with
         | _ when TypeUtils.isIntegralTerm x && TypeUtils.isIntegralTerm y ->
             divRem x y
-        | DetachedPtr offset2, DetachedPtr offset1 ->
+        | DetachedPtrTerm offset2, DetachedPtrTerm offset1 ->
             divRem offset1 offset2
         | FloatT, _
         | _, FloatT when isRem -> internalfailf "Rem.Un is unspecified for Floats"

--- a/VSharp.SILI/VSharp.SILI.fsproj
+++ b/VSharp.SILI/VSharp.SILI.fsproj
@@ -17,31 +17,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Compile Include="Options.fs" />
         <Compile Include="InstructionPointer.fs" />
         <Compile Include="CILState.fs" />
-        <Compile Include="Statistics.fs" />
-        <Compile Include="Searcher.fs" />
         <Compile Include="Interpreter.fs" />
-        <Compile Include="CombinedWeighter.fs" />
-        <Compile Include="DistanceWeighter.fs" />
-        <Compile Include="ContributedCoverageSearcher.fs" />
-        <Compile Include="DFSSortedByContributedCoverageSearcher.fs" />
-        <Compile Include="ExecutionTree.fs" />
-        <Compile Include="ExecutionTreeSearcher.fs" />
-        <Compile Include="InterleavedSearcher.fs" />
-        <Compile Include="GuidedSearcher.fs" />
-        <Compile Include="FairSearcher.fs" />
-        <Compile Include="BidirectionalSearcher.fs" />
-        <Compile Include="SILI.fs" />
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\VSharp.IL\VSharp.IL.fsproj" />
-        <ProjectReference Include="..\VSharp.InternalCalls\VSharp.InternalCalls.fsproj" />
         <ProjectReference Include="..\VSharp.SILI.Core\VSharp.SILI.Core.fsproj" />
-        <ProjectReference Include="..\VSharp.Solver\VSharp.Solver.fsproj" />
-        <ProjectReference Include="..\VSharp.TestGenerator\VSharp.TestGenerator.fsproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/VSharp.SVM/CombinedWeighter.fs
+++ b/VSharp.SVM/CombinedWeighter.fs
@@ -1,7 +1,6 @@
-namespace VSharp.Interpreter.IL
+namespace VSharp.SVM
 
 open System
-open VSharp.Interpreter.IL
 
 /// <summary>
 /// Combines two weighters using the given combinator function.

--- a/VSharp.SVM/ContributedCoverageSearcher.fs
+++ b/VSharp.SVM/ContributedCoverageSearcher.fs
@@ -1,4 +1,4 @@
-namespace VSharp.Interpreter.IL
+namespace VSharp.SVM
 
 open System
 open VSharp.Utils
@@ -6,7 +6,7 @@ open VSharp.Utils
 /// <summary>
 /// Considers the number of visited basic blocks not covered yet by tests as a state's weight.
 /// </summary>
-type internal ContributedCoverageWeighter(statistics : SILIStatistics) =
+type internal ContributedCoverageWeighter(statistics : SVMStatistics) =
 
     let weight state = Some(statistics.GetVisitedBlocksNotCoveredByTests(state).Count |> uint)
 

--- a/VSharp.SVM/DFSSortedByContributedCoverageSearcher.fs
+++ b/VSharp.SVM/DFSSortedByContributedCoverageSearcher.fs
@@ -1,4 +1,4 @@
-namespace VSharp.Interpreter.IL
+namespace VSharp.SVM
 
 open System.Collections.Generic
 open Microsoft.FSharp.Core
@@ -24,12 +24,12 @@ type DFSSortedByContributedCoverageSearcher(statistics) =
 
     let comparer = Comparer.Create(compareWeightOpts)
     let getWeight = contributedCoverageWeighter.Weight
-    
+
     let update newStates =
         states.AddRange newStates
         // Stable sorting
         states <- states.OrderBy(getWeight, comparer).ToList()
-        
+
     interface IForwardSearcher with
         override x.Init initialStates = initialStates.OrderBy(getWeight, comparer) |> states.AddRange
         override x.Pick selector = Seq.tryFindBack selector states

--- a/VSharp.SVM/DistanceWeighter.fs
+++ b/VSharp.SVM/DistanceWeighter.fs
@@ -1,8 +1,9 @@
-namespace VSharp.Interpreter.IL
+namespace VSharp.SVM
 
 open System
 
 open VSharp
+open VSharp.Interpreter.IL
 open VSharp.Interpreter.IL.CilStateOperations
 open VSharp.Interpreter.IL.ipOperations
 
@@ -101,7 +102,7 @@ type ShortestDistanceWeighter(target : codeLocation) =
                 | None -> return 1u
             }
 
-type IntraproceduralShortestDistanceToUncoveredWeighter(statistics : SILIStatistics) =
+type IntraproceduralShortestDistanceToUncoveredWeighter(statistics : SVMStatistics) =
 
     let minDistance (method : Method) fromLoc =
         let infinity = UInt32.MaxValue

--- a/VSharp.SVM/ExecutionTree.fs
+++ b/VSharp.SVM/ExecutionTree.fs
@@ -1,4 +1,4 @@
-namespace VSharp.Interpreter.IL
+namespace VSharp.SVM
 
 open System.Collections.Generic
 

--- a/VSharp.SVM/ExecutionTreeSearcher.fs
+++ b/VSharp.SVM/ExecutionTreeSearcher.fs
@@ -1,8 +1,10 @@
-namespace VSharp.Interpreter.IL
+namespace VSharp.SVM
 
 open System
 open System.Collections.Generic
+
 open VSharp
+open VSharp.Interpreter.IL
 
 type internal ExecutionTreeSearcher(randomSeed : int option) =
 

--- a/VSharp.SVM/GuidedSearcher.fs
+++ b/VSharp.SVM/GuidedSearcher.fs
@@ -1,4 +1,4 @@
-namespace VSharp.Interpreter.IL
+namespace VSharp.SVM
 
 open System.Collections.Generic
 
@@ -50,7 +50,7 @@ type ITargetManager =
     abstract member CalculateTarget : cilState -> codeLocation option
     abstract member IsStuck : cilState -> bool
 
-type RecursionBasedTargetManager(statistics : SILIStatistics, threshold : uint) =
+type RecursionBasedTargetManager(statistics : SVMStatistics, threshold : uint) =
     interface ITargetManager with
         override x.IsStuck state =
             match tryCurrentLoc state with
@@ -197,8 +197,8 @@ type GuidedSearcher(baseSearcher : IForwardSearcher, targetManager : ITargetMana
         override x.StatesCount with get() =
             baseSearcher.StatesCount + (targetedSearchers.Values |> Seq.sumBy (fun s -> int s.Count))
 
-type ShortestDistanceBasedSearcher(statistics : SILIStatistics) =
+type ShortestDistanceBasedSearcher(statistics : SVMStatistics) =
     inherit WeightedSearcher(IntraproceduralShortestDistanceToUncoveredWeighter(statistics), BidictionaryPriorityQueue())
 
-type RandomShortestDistanceBasedSearcher(statistics : SILIStatistics, randomSeed : int option) =
+type RandomShortestDistanceBasedSearcher(statistics : SVMStatistics, randomSeed : int option) =
     inherit WeightedSearcher(AugmentedWeighter(IntraproceduralShortestDistanceToUncoveredWeighter(statistics), (WeightOperations.inverseLogarithmic 7u)), DiscretePDF(mkCilStateHashComparer, randomSeed))

--- a/VSharp.SVM/InterleavedSearcher.fs
+++ b/VSharp.SVM/InterleavedSearcher.fs
@@ -1,4 +1,4 @@
-﻿namespace VSharp.Interpreter.IL
+﻿namespace VSharp.SVM
 
 open System.Linq
 

--- a/VSharp.SVM/Options.fs
+++ b/VSharp.SVM/Options.fs
@@ -1,4 +1,4 @@
-namespace VSharp.Interpreter.IL
+namespace VSharp.SVM
 
 open System.Diagnostics
 open System.IO
@@ -22,7 +22,7 @@ type explorationMode =
     | TestCoverageMode of coverageZone * searchMode
     | StackTraceReproductionMode of StackTrace
 
-type SiliOptions = {
+type SVMOptions = {
     explorationMode : explorationMode
     outputDirectory : DirectoryInfo
     recThreshold : uint

--- a/VSharp.SVM/Searcher.fs
+++ b/VSharp.SVM/Searcher.fs
@@ -1,4 +1,4 @@
-namespace VSharp.Interpreter.IL
+namespace VSharp.SVM
 
 open System.Collections.Generic
 open FSharpx.Collections

--- a/VSharp.SVM/Statistics.fs
+++ b/VSharp.SVM/Statistics.fs
@@ -1,4 +1,4 @@
-namespace VSharp.Interpreter.IL
+namespace VSharp.SVM
 
 open System
 open System.Diagnostics
@@ -51,7 +51,7 @@ type generatedTestInfo =
     }
 
 // TODO: move statistics into (unique) instances of code location!
-type public SILIStatistics(entryMethods : Method seq) =
+type public SVMStatistics(entryMethods : Method seq) =
 
     let entryMethods = List<Method>(entryMethods)
 

--- a/VSharp.SVM/VSharp.SVM.fsproj
+++ b/VSharp.SVM/VSharp.SVM.fsproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="Options.fs" />
+        <Compile Include="Statistics.fs" />
+        <Compile Include="Searcher.fs" />
+        <Compile Include="CombinedWeighter.fs" />
+        <Compile Include="DistanceWeighter.fs" />
+        <Compile Include="ContributedCoverageSearcher.fs" />
+        <Compile Include="DFSSortedByContributedCoverageSearcher.fs" />
+        <Compile Include="ExecutionTree.fs" />
+        <Compile Include="ExecutionTreeSearcher.fs" />
+        <Compile Include="InterleavedSearcher.fs" />
+        <Compile Include="GuidedSearcher.fs" />
+        <Compile Include="FairSearcher.fs" />
+        <Compile Include="BidirectionalSearcher.fs" />
+        <Compile Include="SVM.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\VSharp.IL\VSharp.IL.fsproj" />
+      <ProjectReference Include="..\VSharp.InternalCalls\VSharp.InternalCalls.fsproj" />
+      <ProjectReference Include="..\VSharp.SILI\VSharp.SILI.fsproj" />
+      <ProjectReference Include="..\VSharp.Solver\VSharp.Solver.fsproj" />
+      <ProjectReference Include="..\VSharp.TestGenerator\VSharp.TestGenerator.fsproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="7.0.300" />
+    </ItemGroup>
+</Project>

--- a/VSharp.Test/Benchmarks/BenchmarkResult.cs
+++ b/VSharp.Test/Benchmarks/BenchmarkResult.cs
@@ -1,11 +1,11 @@
 ﻿#nullable enable
-using VSharp.Interpreter.IL;
+using VSharp.SVM;
 
 namespace VSharp.Test.Benchmarks;
 
 public readonly record struct BenchmarkResult(
     bool IsSuccessful,
-    SILIStatistics Statistics,
+    SVMStatistics Statistics,
     UnitTests Tests,
     BenchmarkTarget Target,
     int? Coverage = null

--- a/VSharp.Test/Benchmarks/Benchmarks.cs
+++ b/VSharp.Test/Benchmarks/Benchmarks.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Reflection;
 using ConsoleTables;
 using NUnit.Framework;
-using VSharp.Interpreter.IL;
+using VSharp.SVM;
 using VSharp.TestRenderer;
 
 namespace VSharp.Test.Benchmarks;
@@ -61,7 +61,7 @@ internal static class Benchmarks
         Logger.currentLogLevel = Logger.Warning;
 
         var unitTests = new UnitTests(Directory.GetCurrentDirectory());
-        var options = new SiliOptions(
+        var options = new SVMOptions(
             explorationMode: explorationMode.NewTestCoverageMode(coverageZone.MethodZone, searchStrategy),
             outputDirectory: unitTests.TestDirectory,
             recThreshold: 1,
@@ -75,7 +75,7 @@ internal static class Benchmarks
             randomSeed: randomSeed,
             stepsLimit: stepsLimit
         );
-        using var explorer = new SILI(options);
+        using var explorer = new SVM.SVM(options);
 
         explorer.Interpret(
             new[] { exploredMethodInfo },

--- a/VSharp.Test/Benchmarks/SearcherBenchmarks.cs
+++ b/VSharp.Test/Benchmarks/SearcherBenchmarks.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using VSharp.Interpreter.IL;
+using VSharp.SVM;
 
 namespace VSharp.Test.Benchmarks;
 

--- a/VSharp.Test/CsvStatisticsReporter.cs
+++ b/VSharp.Test/CsvStatisticsReporter.cs
@@ -61,13 +61,13 @@ internal class CsvStatisticsReporter : IStatisticsReporter
             ReleaseBranchesEnabled: testStatistics.ReleaseBranchesEnabled.ToString(),
             Timeout: testStatistics.Timeout.ToString(),
             Exception: (testStatistics.Exception?.InnerException ?? testStatistics.Exception)?.GetType().Name ?? "",
-            Duration: testStatistics.SiliStatisticsDump?.time.ToString() ?? "",
+            Duration: testStatistics.SvmStatisticsDump?.time.ToString() ?? "",
             TestsGenerated: testStatistics.TestsGenerated.ToString() ?? "",
             Coverage: testStatistics.Coverage?.ToString() ?? "",
-            CoveringStepsInsideZone: testStatistics.SiliStatisticsDump?.coveringStepsInsideZone.ToString() ?? "",
-            NonCoveringStepsInsideZone: testStatistics.SiliStatisticsDump?.nonCoveringStepsInsideZone.ToString() ?? "",
-            CoveringStepsOutsideZone: testStatistics.SiliStatisticsDump?.coveringStepsOutsideZone.ToString() ?? "",
-            NonCoveringStepsOutsideZone: testStatistics.SiliStatisticsDump?.nonCoveringStepsOutsideZone.ToString() ?? "",
+            CoveringStepsInsideZone: testStatistics.SvmStatisticsDump?.coveringStepsInsideZone.ToString() ?? "",
+            NonCoveringStepsInsideZone: testStatistics.SvmStatisticsDump?.nonCoveringStepsInsideZone.ToString() ?? "",
+            CoveringStepsOutsideZone: testStatistics.SvmStatisticsDump?.coveringStepsOutsideZone.ToString() ?? "",
+            NonCoveringStepsOutsideZone: testStatistics.SvmStatisticsDump?.nonCoveringStepsOutsideZone.ToString() ?? "",
             TestsOutputDirectory: testStatistics.TestsOutputDirectory ?? ""
         );
     }

--- a/VSharp.Test/ExecutionTreeTests.cs
+++ b/VSharp.Test/ExecutionTreeTests.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.FSharp.Core;
 using NUnit.Framework;
-using VSharp.Interpreter.IL;
+using VSharp.SVM;
 
 namespace VSharp.Test;
 

--- a/VSharp.Test/IntegrationTests.cs
+++ b/VSharp.Test/IntegrationTests.cs
@@ -15,6 +15,7 @@ using NUnit.Framework.Internal.Commands;
 using VSharp.CSharpUtils;
 using VSharp.Interpreter.IL;
 using VSharp.Solver;
+using VSharp.SVM;
 using VSharp.TestRenderer;
 
 namespace VSharp.Test
@@ -70,7 +71,7 @@ namespace VSharp.Test
         private const string SolverTimeoutParameterName = "solverTimeout";
         private const string ReleaseBranchesParameterName = "releaseBranches";
 
-        private static SiliOptions _options = null;
+        private static SVMOptions _options;
 
         static TestSvmAttribute()
         {
@@ -228,9 +229,9 @@ namespace VSharp.Test
 
                 _coverageZone = coverageZone switch
                 {
-                    CoverageZone.Method => Interpreter.IL.coverageZone.MethodZone,
-                    CoverageZone.Class => Interpreter.IL.coverageZone.ClassZone,
-                    CoverageZone.Module => Interpreter.IL.coverageZone.ModuleZone,
+                    CoverageZone.Method => SVM.coverageZone.MethodZone,
+                    CoverageZone.Class => SVM.coverageZone.ClassZone,
+                    CoverageZone.Module => SVM.coverageZone.ModuleZone,
                     _ => throw new ArgumentOutOfRangeException(nameof(coverageZone), coverageZone, null)
                 };
 
@@ -293,7 +294,7 @@ namespace VSharp.Test
                 try
                 {
                     var unitTests = new UnitTests(Directory.GetCurrentDirectory());
-                    _options = new SiliOptions(
+                    _options = new SVMOptions(
                         explorationMode: explorationMode.NewTestCoverageMode(_coverageZone, _searchStrat),
                         outputDirectory: unitTests.TestDirectory,
                         recThreshold: _recThresholdForTest,
@@ -307,7 +308,7 @@ namespace VSharp.Test
                         randomSeed: _randomSeed,
                         stepsLimit: _stepsLimit
                     );
-                    using var explorer = new SILI(_options);
+                    using var explorer = new SVM.SVM(_options);
 
                     explorer.Interpret(
                         new [] { exploredMethodInfo },
@@ -330,7 +331,7 @@ namespace VSharp.Test
 
                     stats = stats with
                     {
-                        SiliStatisticsDump = explorer.Statistics.DumpStatistics(),
+                        SvmStatisticsDump = explorer.Statistics.DumpStatistics(),
                         TestsGenerated = unitTests.UnitTestsCount,
                         TestsOutputDirectory = unitTests.TestDirectory.FullName
                     };

--- a/VSharp.Test/TestStatistics.cs
+++ b/VSharp.Test/TestStatistics.cs
@@ -1,6 +1,7 @@
+#nullable enable
 using System;
 using System.Reflection;
-using VSharp.Interpreter.IL;
+using VSharp.SVM;
 
 namespace VSharp.Test;
 
@@ -10,9 +11,9 @@ public record TestStatistics(
     int Timeout,
     SearchStrategy SearchStrategy,
     CoverageZone CoverageZone,
-    statisticsDump SiliStatisticsDump = null,
+    statisticsDump? SvmStatisticsDump = null,
     uint? Coverage = null,
     uint? TestsGenerated = null,
     string TestsOutputDirectory = "",
-    Exception Exception = null
+    Exception? Exception = null
 );

--- a/VSharp.Test/Tests/Lists.cs
+++ b/VSharp.Test/Tests/Lists.cs
@@ -869,7 +869,7 @@ namespace IntegrationTests
     [TestSvmFixture]
     public static class SpanTests
     {
-        [Ignore("check exceptions in 'Span.get_Item' internal call")]
+        [TestSvm(100)]
         public static unsafe byte SpanTest(int[] a, byte b, int i)
         {
             fixed (void* ptr = a)

--- a/VSharp.Test/Tests/Lists.cs
+++ b/VSharp.Test/Tests/Lists.cs
@@ -869,7 +869,7 @@ namespace IntegrationTests
     [TestSvmFixture]
     public static class SpanTests
     {
-        [TestSvm(100)]
+        [TestSvm(96)]
         public static unsafe byte SpanTest(int[] a, byte b, int i)
         {
             fixed (void* ptr = a)

--- a/VSharp.Test/Tests/Strings.cs
+++ b/VSharp.Test/Tests/Strings.cs
@@ -110,7 +110,7 @@ namespace IntegrationTests
             return upper == str;
         }
 
-        [Ignore("use error reporter in 'Unsafe.ReadUnaligned' internal call")]
+        [TestSvm(100)]
         public static int Contains(string str)
         {
             if (str.Contains("d8"))

--- a/VSharp.TestGenerator/TestGenerator.fs
+++ b/VSharp.TestGenerator/TestGenerator.fs
@@ -207,7 +207,7 @@ module TestGenerator =
             test.MemoryGraph.RepresentStruct t fieldReprs
         | NullRef _
         | NullPtr -> null
-        | DetachedPtr offset ->
+        | DetachedPtrTerm offset ->
             let offset = TypeUtils.convert (term2obj offset) typeof<int64> :?> int64
             test.MemoryGraph.RepresentDetachedPtr typeof<Void> offset
         | {term = Ptr(HeapLocation({term = ConcreteHeapAddress(addr)}, _), sightType, offset)} ->

--- a/VSharp.TestGenerator/TestGenerator.fs
+++ b/VSharp.TestGenerator/TestGenerator.fs
@@ -351,13 +351,11 @@ module TestGenerator =
 
     let private model2test (test : UnitTest) suite indices mockCache (m : Method) model (state : state) =
         let suitableState state =
-            let methodHasByRefParameter = m.Parameters |> Seq.exists (fun pi -> pi.ParameterType.IsByRef)
-            if m.DeclaringType.IsValueType && not m.IsStatic || methodHasByRefParameter then
-                Memory.CallStackSize state = 2
+            if m.HasParameterOnStack then Memory.CallStackSize state = 2
             else Memory.CallStackSize state = 1
 
-        if not <| suitableState state
-            then internalfail "Finished state has many frames on stack! (possibly unhandled exception)"
+        if not <| suitableState state then
+            internalfail "Finished state has many frames on stack! (possibly unhandled exception)"
 
         match model with
         | StateModel modelState -> modelState2test test suite indices mockCache m model modelState state

--- a/VSharp.Utils/MemoryGraph.fs
+++ b/VSharp.Utils/MemoryGraph.fs
@@ -316,18 +316,18 @@ type MemoryGraph(repr : memoryRepr, mockStorage : MockStorage, createCompactRepr
             let shift = decodeValue repr.shift :?> int64 |> uint64
             UIntPtr(shift) :> obj
         | :? pointerRepr as repr ->
-            let shift = decodeValue repr.shift :?> int64 |> nativeint
+            let shift = decodeValue repr.shift :?> int64
             let sightType = sourceTypes[repr.sightType]
             let index = repr.index
             let pointer =
                 if index <> nullSourceIndex then
                     // Case for pointer, attached to address 'index'
                     let obj = sourceObjects[repr.index]
-                    let refWithOffset = System.Runtime.CompilerServices.Unsafe.AddByteOffset(ref obj, shift)
-                    System.Runtime.CompilerServices.Unsafe.AsPointer(ref refWithOffset)
+                    let ptr = System.Runtime.CompilerServices.Unsafe.AsPointer(ref obj)
+                    System.Runtime.CompilerServices.Unsafe.Add<byte>(ptr, int shift)
                 else
                     // Case for detached pointer
-                    shift.ToPointer()
+                    (nativeint shift).ToPointer()
             Pointer.Box(pointer, sightType.MakePointerType())
         | :? structureRepr as repr when repr.typ >= 0 ->
             // Case for structs or classes of .NET type

--- a/VSharp.Utils/Reflection.fs
+++ b/VSharp.Utils/Reflection.fs
@@ -120,7 +120,8 @@ module public Reflection =
         | :? MethodInfo as m -> m.ReturnType
         | _ -> internalfail "unknown MethodBase"
 
-    let hasNonVoidResult m = (getMethodReturnType m).FullName <> typeof<Void>.FullName
+    let hasNonVoidResult m =
+        getMethodReturnType m <> typeof<Void> && not m.IsConstructor
 
     let hasThis (m : MethodBase) = m.CallingConvention.HasFlag(CallingConventions.HasThis)
 

--- a/VSharp.Utils/TypeUtils.fs
+++ b/VSharp.Utils/TypeUtils.fs
@@ -205,7 +205,7 @@ module TypeUtils =
             if isValueTypeParameter t then true
             elif isReferenceTypeParameter t then false
             else __insufficientInformation__ "Can't determine if %O is a value type or not!" t
-        | t -> t.IsValueType && t <> addressType
+        | t -> t.IsValueType && t <> addressType && t <> typeof<Void>
 
     let isNullable = function
         | (t : Type) when t.IsGenericParameter ->
@@ -495,9 +495,13 @@ module TypeUtils =
     /// 'mostConcreteType' will return 'leftType'
     /// Example: mostConcreteType typeof<uint array> typeof<int array> == typeof<uint array>
     let inline mostConcreteType (leftType : Type) (rightType : Type) =
+        let isStringCase() =
+            rightType = typeof<string> && leftType = typeof<char[]>
+            || leftType = typeof<string> && rightType = typeof<char[]>
         if leftType = null then rightType
         elif rightType = null then leftType
         elif rightType.IsAssignableFrom(leftType) then leftType
+        elif isStringCase() then typeof<string>
         else
             assert leftType.IsAssignableFrom(rightType)
             rightType

--- a/VSharp.sln
+++ b/VSharp.sln
@@ -30,6 +30,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "VSharp.TestGenerator", "VSh
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VSharp.CoverageRunner", "VSharp.CoverageRunner\VSharp.CoverageRunner.csproj", "{AEB2ABD0-5045-4A28-BBEB-2F353BD543FE}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "VSharp.SVM", "VSharp.SVM\VSharp.SVM.fsproj", "{9455C456-51A6-4CA3-B33A-4F168CBADADA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -127,5 +129,11 @@ Global
 		{AEB2ABD0-5045-4A28-BBEB-2F353BD543FE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{AEB2ABD0-5045-4A28-BBEB-2F353BD543FE}.DebugTailRec|Any CPU.ActiveCfg = DebugTailRec|Any CPU
 		{AEB2ABD0-5045-4A28-BBEB-2F353BD543FE}.DebugTailRec|Any CPU.Build.0 = DebugTailRec|Any CPU
+		{9455C456-51A6-4CA3-B33A-4F168CBADADA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9455C456-51A6-4CA3-B33A-4F168CBADADA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9455C456-51A6-4CA3-B33A-4F168CBADADA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9455C456-51A6-4CA3-B33A-4F168CBADADA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9455C456-51A6-4CA3-B33A-4F168CBADADA}.DebugTailRec|Any CPU.ActiveCfg = Debug|Any CPU
+		{9455C456-51A6-4CA3-B33A-4F168CBADADA}.DebugTailRec|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
- splited VSharp.SILI on VSharp.SILI (only interpreter and cilState operations) and VSharp.SVM (searchers, and others)
- VSharp.InternalCalls project depends on VSharp.SILI and uses cilState for exception handling
- fixed unsafe operations
- fixed error reporter
- fixed '.constrained', 'ldobj' and 'localloc' instructions
- style fixes